### PR TITLE
Update select menu documentation

### DIFF
--- a/docs/components/select.html
+++ b/docs/components/select.html
@@ -71,6 +71,7 @@ description: Select menus are menus used to provide choices to users.
     <select id="Dialtone--SelectExample2">
         <option>…</option>
     </select>
+    <span class="d-input-message has-warning">…</span>
 </div>
 {% endhighlight %}
             </div>
@@ -101,10 +102,11 @@ description: Select menus are menus used to provide choices to users.
             <div class="dialtone-example__code">
 {% highlight html linenos %}
 <label class="d-label" for="Dialtone--SelectExample3">…</label>
-<div class="d-select has-success">
+<div class="d-select has-error">
     <select id="Dialtone--SelectExample3">
         <option>…</option>
     </select>
+    <span class="d-input-message has-error">…</span>
 </div>
 {% endhighlight %}
             </div>
@@ -121,15 +123,15 @@ description: Select menus are menus used to provide choices to users.
                     <label class="d-label" for="Dialtone--SelectExample4">Travel Method</label>
                     <div class="d-select has-success">
                         <select id="Dialtone--SelectExample4">
-                            <option value="" selected>Please select one</option>
+                            <option value="">Please select one</option>
                             <option value="train">Train</option>
                             <option value="plane">Plane</option>
                             <option value="boat">Boat</option>
-                            <option value="car">Automobile</option>
+                            <option value="car" selected>Automobile</option>
                             <option value="walking">Walking</option>
                         </select>
                     </div>
-                    <span class="d-input-message has-success">You must select an option.</span>
+                    <span class="d-input-message has-success">Your selection has been saved.</span>
                 </div>
             </div>
             <div class="dialtone-example__code">
@@ -139,6 +141,7 @@ description: Select menus are menus used to provide choices to users.
     <select id="Dialtone--SelectExample4">
         <option>…</option>
     </select>
+    <span class="d-input-message has-success">…</span>
 </div>
 {% endhighlight %}
             </div>


### PR DESCRIPTION
Corrects error in select menu error code example where the select menu had a `.has-success` class on it instead of a `.has-error`.