### PR TITLE
Remove extra close icon from danger modal example

### DIFF
--- a/docs/components/modals.html
+++ b/docs/components/modals.html
@@ -163,7 +163,6 @@ description: Modals focus the user’s attention exclusively on one task or piec
                         <a href="#" class="d-modal__close d-btn--circle--danger-hover d-btn--circle--lg" aria-label="Close">
                             <span class="d-btn__label">Close</span>
                             <span class="d-btn__icon">{% icon-system "close" %}</span>
-                            <span class="d-btn__icon">{% icon-system "close" %}</span>
                         </a>
                     </div>
                 </aside>


### PR DESCRIPTION
Ooops!
<img width="705" alt="Screen Shot 2020-10-08 at 12 44 14 PM" src="https://user-images.githubusercontent.com/65190890/95489101-658c3880-0964-11eb-8cc8-fa1bb186226d.png">
