### PR TITLE
Fix typo on the modals page

### DIFF
--- a/docs/components/modals.html
+++ b/docs/components/modals.html
@@ -141,7 +141,7 @@ description: Modals focus the user’s attention exclusively on one task or piec
             <button class="d-btn" type="button">…</button>
         </footer>
     </div>
-    <a href="#" class="d-modal__close d-btn--cirlce" aria-label="Close"><IconClose \></a>
+    <a href="#" class="d-modal__close d-btn--circle" aria-label="Close"><IconClose \></a>
 </aside>
 {% endhighlight %}
             </div>
@@ -178,7 +178,7 @@ description: Modals focus the user’s attention exclusively on one task or piec
             <button class="d-btn--danger" type="button">…</button>
         </footer>
     </div>
-    <a href="#" class="d-modal__close d-btn--cirlce" aria-label="Close"><IconClose \></a>
+    <a href="#" class="d-modal__close d-btn--circle" aria-label="Close"><IconClose \></a>
 </aside>
 {% endhighlight %}
             </div>
@@ -217,7 +217,7 @@ description: Modals focus the user’s attention exclusively on one task or piec
             <button class="d-btn" type="button">…</button>
         </footer>
     </div>
-    <a href="#" class="d-modal__close d-btn--cirlce" aria-label="Close"><IconClose \></a>
+    <a href="#" class="d-modal__close d-btn--circle" aria-label="Close"><IconClose \></a>
 </aside>
 {% endhighlight %}
             </div>


### PR DESCRIPTION
I misspelled the word `circle` in the code examples, this pull request fixes that typo.