### PR TITLE
Add content-copy icon

### DIFF
--- a/docs/_data/svg-system.json
+++ b/docs/_data/svg-system.json
@@ -234,6 +234,12 @@
     "desc": "Used to communicate the contacts section."
   },
   {
+    "name": "Content Copy",
+    "file": "content-copy",
+    "vue": "IconContentCopy",
+    "desc": "Used to communicate the ability to copy content to the clipboard."
+  },
+  {
     "name": "Credit Card",
     "file": "credit-card",
     "vue": "IconCreditCard",

--- a/docs/_includes/icons/system/content-copy.svg
+++ b/docs/_includes/icons/system/content-copy.svg
@@ -1,0 +1,1 @@
+<svg aria-hidden="true" aria-label="Content Copy" class="d-svg d-svg--system d-svg__contentCopy" viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>

--- a/lib/build/svg/system/content-copy.svg
+++ b/lib/build/svg/system/content-copy.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z" fill="black"/>
+</svg>

--- a/lib/dist/svg/system/content-copy.svg
+++ b/lib/dist/svg/system/content-copy.svg
@@ -1,0 +1,1 @@
+<svg aria-hidden="true" aria-label="Content Copy" class="d-svg d-svg--system d-svg__contentCopy" viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>

--- a/lib/dist/vue/icons/IconContentCopy.vue
+++ b/lib/dist/vue/icons/IconContentCopy.vue
@@ -1,0 +1,3 @@
+<template>
+  <svg aria-hidden="true" aria-label="Content Copy" class="d-svg d-svg--system d-svg__contentCopy" viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>
+</template>


### PR DESCRIPTION
## Description
Add new content-copy icon to dialtone.

Screenshot of new content-copy icon on localhost:
![Screen Shot 2021-01-12 at 6 10 35 AM](https://user-images.githubusercontent.com/72946382/104325958-06c3e700-549e-11eb-9cfe-73dcf895acab.png)

Example of where icon would be used:
![Screen Shot 2021-01-12 at 6 22 31 AM](https://user-images.githubusercontent.com/72946382/104326448-99fd1c80-549e-11eb-8111-59c338178110.png)



## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Provide a description what is being changed, extended, or removed.
 - [x] Link to any issue(s) this request is resolving.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Joshua Hynes, Ted Goas, or David Becher.
