### PR TITLE
fix TOC scrolling bug by destroying scrollspy before re-init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ lib/build/fonts/
 ######################
 *.sublime-workspace
 
+# VS Code #
+######################
+.vscode
+
 # Jekyll Site #
 ###############
 # This is compiled by Github on its servers, so no need to include it.

--- a/docs/assets/js/nav.js
+++ b/docs/assets/js/nav.js
@@ -26,6 +26,8 @@ $(document).ready(function() {
 
         $('#nav').on('click', 'a', function (event) {
 
+            $('.js-scrollspy').destroy();
+
             // Allow opening links in new tabs
             if (event.metaKey) {
               return


### PR DESCRIPTION
## Description
Fixes scrolling bug, seems scrollspy behaves quite erratically if you initialize it twice without destroying first.
https://github.com/dialpad/dialtone/issues/179


## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Provide a description what is being changed, extended, or removed.
 - [x] Link to any issue(s) this request is resolving.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Drew Chandler, Joshua Hynes, or Ted Goas.

## Obligatory GIF
![image](https://i.imgur.com/eFAqi8d.gif)
