### PR TITLE
Adding missing d-notice__message class description

### DIFF
--- a/docs/_data/notice.json
+++ b/docs/_data/notice.json
@@ -46,6 +46,11 @@
       "description": "Contains the notice title."
     },
     {
+      "class": "d-notice__message",
+      "applies": "N/A",
+      "description": "Contains the notice message."
+    },
+    {
       "class": "d-notice__actions",
       "applies": "N/A",
       "description": "Contains the notice actions."


### PR DESCRIPTION
## Description

Added a missing description for `d-notice__message` in the notice class docs

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Provide a description what is being changed, extended, or removed.
 - [x] Link to any issue(s) this request is resolving.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Drew Chandler, Joshua Hynes, or Ted Goas.

## Obligatory GIF
![](path/to/gif)
