### PR TITLE
Updated banner, notice, and toast base icon from transcript to lightb…

### DIFF
--- a/docs/components/banner.html
+++ b/docs/components/banner.html
@@ -125,7 +125,7 @@ description: A banner is a type of <a class="d-link" href="/components/notice">n
 <aside class="d-banner d-banner--info js-banner-example d-mt0" role="alert" aria-hidden="true">
   <div class="d-banner__dialog js-banner-example-dialog" role="alertdialog" aria-labelledy="info-alert-title" aria-describedby="info-alert-desc">
     <div class="d-notice__icon js-banner-example-icon">
-      {% iconSystem "transcript", "js-banner-example-icon-base d-d-none" %}
+      {% iconSystem "lightbulb", "js-banner-example-icon-base d-d-none" %}
       {% iconSystem "error", "js-banner-example-icon-error d-d-none" %}
       {% iconSystem "info", "js-banner-example-icon-info d-d-none" %}
       {% iconSystem "check-circle", "js-banner-example-icon-success d-d-none" %}

--- a/docs/components/notice.html
+++ b/docs/components/notice.html
@@ -44,7 +44,7 @@ description: A notice is an informational and assistive message that appears inl
             <aside class="d-notice d-notice--{{ i }}" role="status" aria-hidden="false">
               <div class="d-notice__icon">
                 {% if i == "base" %}
-                  {% iconSystem "transcript" %}
+                  {% iconSystem "lightbulb" %}
                 {% elsif i == "error" %}
                   {% iconSystem "error" %}
                 {% elsif i == "info" %}
@@ -106,7 +106,7 @@ description: A notice is an informational and assistive message that appears inl
             <aside class="d-notice d-notice--{{ i }} d-notice--important" role="alert" aria-hidden="false">
               <div class="d-notice__icon">
                 {% if i == "base" %}
-                  {% iconSystem "transcript" %}
+                  {% iconSystem "lightbulb" %}
                 {% elsif i == "error" %}
                   {% iconSystem "error" %}
                 {% elsif i == "info" %}

--- a/docs/components/toast.html
+++ b/docs/components/toast.html
@@ -84,7 +84,7 @@ description: A toast notice, sometimes called a snackbar, is a time-based messag
   <div class="d-toast js-toast-example-toast" role="alert" aria-hidden="true">
     <div class="d-toast__dialog js-toast-example-dialog">
       <div class="d-notice__icon js-toast-example-icon">
-        {% iconSystem "transcript", "js-toast-example-icon-base d-d-none" %}
+        {% iconSystem "lightbulb", "js-toast-example-icon-base d-d-none" %}
         {% iconSystem "info", "js-toast-example-icon-info d-d-none" %}
         {% iconSystem "warning", "js-toast-example-icon-warning d-d-none" %}
         {% iconSystem "error", "js-toast-example-icon-error d-d-none" %}


### PR DESCRIPTION
## Description
Now that DT6's icons have been updated and the lightbulb icon is available, I'm including in banner, notice, and toast components base and base important style. This replaces the transcript icon, which I originally used as a placeholder.

## Obligatory GIF
![](https://www.gadgetbytenepal.com/wp-content/uploads/2016/05/wireless-bulbs.gif)
