### PR TITLE
Alphabetical order for avatar, badge, and link classes and examples

### DIFF
--- a/docs/_data/avatar.json
+++ b/docs/_data/avatar.json
@@ -86,14 +86,14 @@
         "description": "Applies purple-300 color."
       },
       {
-        "class": "d-avatar--purple-400",
-        "applies": "d-avatar",
-        "description": "Applies purple-400 color."
-      },
-      {
         "class": "d-avatar--purple-500",
         "applies": "d-avatar",
         "description": "Applies purple-500 color."
+      },
+      {
+        "class": "d-avatar--purple-600",
+        "applies": "d-avatar",
+        "description": "Applies purple-600 color."
       },
       {
         "class": "d-avatar--yellow-200",

--- a/docs/_data/avatar.json
+++ b/docs/_data/avatar.json
@@ -36,34 +36,9 @@
     ],
     "colors": [
       {
-        "class": "d-avatar--purple-600",
+        "class": "d-avatar--orange-200",
         "applies": "d-avatar",
-        "description": "Applies purple-600 color."
-      },
-      {
-        "class": "d-avatar--purple-500",
-        "applies": "d-avatar",
-        "description": "Applies purple-500 color."
-      },
-      {
-        "class": "d-avatar--purple-300",
-        "applies": "d-avatar",
-        "description": "Applies purple-300 color."
-      },
-      {
-        "class": "d-avatar--purple-200",
-        "applies": "d-avatar",
-        "description": "Applies purple-200 color."
-      },
-      {
-        "class": "d-avatar--orange-500",
-        "applies": "d-avatar",
-        "description": "Applies orange-500 color."
-      },
-      {
-        "class": "d-avatar--orange-400",
-        "applies": "d-avatar",
-        "description": "Applies orange-400 color."
+        "description": "Applies orange-200 color."
       },
       {
         "class": "d-avatar--orange-300",
@@ -71,24 +46,14 @@
         "description": "Applies orange-300 color."
       },
       {
-        "class": "d-avatar--orange-200",
+        "class": "d-avatar--orange-400",
         "applies": "d-avatar",
-        "description": "Applies orange-200 color."
+        "description": "Applies orange-400 color."
       },
       {
-        "class": "d-avatar--pink-600",
+        "class": "d-avatar--orange-500",
         "applies": "d-avatar",
-        "description": "Applies pink-600 color."
-      },
-      {
-        "class": "d-avatar--pink-500",
-        "applies": "d-avatar",
-        "description": "Applies pink-500 color."
-      },
-      {
-        "class": "d-avatar--pink-400",
-        "applies": "d-avatar",
-        "description": "Applies pink-400 color."
+        "description": "Applies orange-500 color."
       },
       {
         "class": "d-avatar--pink-300",
@@ -96,14 +61,44 @@
         "description": "Applies pink-300 color."
       },
       {
-        "class": "d-avatar--yellow-500",
+        "class": "d-avatar--pink-400",
         "applies": "d-avatar",
-        "description": "Applies yellow-500 color."
+        "description": "Applies pink-400 color."
       },
       {
-        "class": "d-avatar--yellow-400",
+        "class": "d-avatar--pink-500",
         "applies": "d-avatar",
-        "description": "Applies yellow-400 color."
+        "description": "Applies pink-500 color."
+      },
+      {
+        "class": "d-avatar--pink-600",
+        "applies": "d-avatar",
+        "description": "Applies pink-600 color."
+      },
+      {
+        "class": "d-avatar--purple-200",
+        "applies": "d-avatar",
+        "description": "Applies purple-200 color."
+      },
+      {
+        "class": "d-avatar--purple-300",
+        "applies": "d-avatar",
+        "description": "Applies purple-300 color."
+      },
+      {
+        "class": "d-avatar--purple-400",
+        "applies": "d-avatar",
+        "description": "Applies purple-400 color."
+      },
+      {
+        "class": "d-avatar--purple-500",
+        "applies": "d-avatar",
+        "description": "Applies purple-500 color."
+      },
+      {
+        "class": "d-avatar--yellow-200",
+        "applies": "d-avatar",
+        "description": "Applies yellow-200 color."
       },
       {
         "class": "d-avatar--yellow-300",
@@ -111,9 +106,14 @@
         "description": "Applies yellow-300 color."
       },
       {
-        "class": "d-avatar--yellow-200",
+        "class": "d-avatar--yellow-400",
         "applies": "d-avatar",
-        "description": "Applies yellow-200 color."
+        "description": "Applies yellow-400 color."
+      },
+      {
+        "class": "d-avatar--yellow-500",
+        "applies": "d-avatar",
+        "description": "Applies yellow-500 color."
       }
     ]
   }

--- a/docs/_data/badge.json
+++ b/docs/_data/badge.json
@@ -6,34 +6,14 @@
       "description": "Base badge style"
     },
     {
-      "class": "d-badge--white",
-      "applies": "d-badge",
-      "description": "Styles badge with white."
-    },
-    {
       "class": "d-badge--black-700",
       "applies": "d-badge",
       "description": "Styles badge with black-700."
     },
     {
-      "class": "d-badge--purple-100",
+      "class": "d-badge--green-400",
       "applies": "d-badge",
-      "description": "Styles badge with purple-100."
-    },
-    {
-      "class": "d-badge--purple-300",
-      "applies": "d-badge",
-      "description": "Styles badge with purple-300."
-    },
-    {
-      "class": "d-badge--purple-500",
-      "applies": "d-badge",
-      "description": "Styles badge with purple-500."
-    },
-    {
-      "class": "d-badge--purple-700",
-      "applies": "d-badge",
-      "description": "Styles badge with purple-700."
+      "description": "Styles badge with green-400."
     },
     {
       "class": "d-badge--orange-400",
@@ -61,9 +41,29 @@
       "description": "Styles badge with pink-700."
     },
     {
-      "class": "d-badge--green-400",
+      "class": "d-badge--purple-100",
       "applies": "d-badge",
-      "description": "Styles badge with green-400."
+      "description": "Styles badge with purple-100."
+    },
+    {
+      "class": "d-badge--purple-300",
+      "applies": "d-badge",
+      "description": "Styles badge with purple-300."
+    },
+    {
+      "class": "d-badge--purple-500",
+      "applies": "d-badge",
+      "description": "Styles badge with purple-500."
+    },
+    {
+      "class": "d-badge--purple-700",
+      "applies": "d-badge",
+      "description": "Styles badge with purple-700."
+    },
+    {
+      "class": "d-badge--red-500",
+      "applies": "d-badge",
+      "description": "Styles badge with red-500."
     },
     {
       "class": "d-badge--yellow-300",
@@ -71,9 +71,9 @@
       "description": "Styles badge with yellow-300."
     },
     {
-      "class": "d-badge--red-500",
+      "class": "d-badge--white",
       "applies": "d-badge",
-      "description": "Styles badge with red-500."
+      "description": "Styles badge with white."
     }
   ]
 }

--- a/docs/_data/link.json
+++ b/docs/_data/link.json
@@ -6,19 +6,14 @@
       "description": "Base link style."
     },
     {
-      "class": "d-link--warning",
-      "applies": "d-link",
-      "description": "Warning link style. Used to alert users to potential problems."
-    },
-    {
       "class": "d-link--danger",
       "applies": "d-link",
       "description": "Danger link style. Used for potentially destructive actions."
     },
     {
-      "class": "d-link--success",
+      "class": "d-link--inverted",
       "applies": "d-link",
-      "description": "Success link style. Used to alert users to successful actions."
+      "description": "Base inverted link style"
     },
     {
       "class": "d-link--muted",
@@ -26,9 +21,14 @@
       "description": "A darker, muted link style that mirrors our muted button style."
     },
     {
-      "class": "d-link--inverted",
+      "class": "d-link--success",
       "applies": "d-link",
-      "description": "Base inverted link style"
+      "description": "Success link style. Used to alert users to successful actions."
+    },
+    {
+      "class": "d-link--warning",
+      "applies": "d-link",
+      "description": "Warning link style. Used to alert users to potential problems."
     }
   ]
 }

--- a/docs/components/badge.html
+++ b/docs/components/badge.html
@@ -45,20 +45,20 @@ description: A badge is a compact UI element that provides brief, descriptive in
     {% codeWellFooter %}
       {% highlight html linenos %}
 <span class="d-badge">...</span>
-<span class="d-badge d-badge--white">...</span>
 <span class="d-badge d-badge--black-700">...</span>
-<span class="d-badge d-badge--purple-100">...</span>
-<span class="d-badge d-badge--purple-300">...</span>
-<span class="d-badge d-badge--purple-500">...</span>
-<span class="d-badge d-badge--purple-700">...</span>
+<span class="d-badge d-badge--green-400">...</span>
 <span class="d-badge d-badge--orange-400">...</span>
 <span class="d-badge d-badge--pink-300">...</span>
 <span class="d-badge d-badge--pink-500">...</span>
 <span class="d-badge d-badge--pink-600">...</span>
 <span class="d-badge d-badge--pink-700">...</span>
-<span class="d-badge d-badge--green-400">...</span>
-<span class="d-badge d-badge--yellow-300">...</span>
+<span class="d-badge d-badge--purple-100">...</span>
+<span class="d-badge d-badge--purple-300">...</span>
+<span class="d-badge d-badge--purple-500">...</span>
+<span class="d-badge d-badge--purple-700">...</span>
 <span class="d-badge d-badge--red-500">...</span>
+<span class="d-badge d-badge--yellow-300">...</span>
+<span class="d-badge d-badge--white">...</span>
       {% endhighlight %}
     {% endcodeWellFooter %}
   {% endcodeWell %}

--- a/docs/components/link.html
+++ b/docs/components/link.html
@@ -34,18 +34,18 @@ description: A link is a navigational element that can be found on its own, with
   {% codeWell %}
     {% codeWellHeader %}
       <a href="#" class="d-link">Base link</a>
-      <a href="#" class="d-link d-link--warning">Warning link</a>
       <a href="#" class="d-link d-link--danger">Danger link</a>
-      <a href="#" class="d-link d-link--success">Success link</a>
       <a href="#" class="d-link d-link--muted">Muted link</a>
+      <a href="#" class="d-link d-link--success">Success link</a>
+      <a href="#" class="d-link d-link--warning">Warning link</a>
     {% endcodeWellHeader %}
     {% codeWellFooter %}
       {% highlight html linenos %}
 <a href="#" class="d-link">...</a>
-<a href="#" class="d-link d-link--warning">...</a>
 <a href="#" class="d-link d-link--danger">...</a>
-<a href="#" class="d-link d-link--success">...</a>
 <a href="#" class="d-link d-link--muted">...</a>
+<a href="#" class="d-link d-link--success">...</a>
+<a href="#" class="d-link d-link--warning">...</a>
       {% endhighlight %}
     {% endcodeWellFooter %}
   {% endcodeWell %}


### PR DESCRIPTION
## Description
After looking at Jose's badge PR, I realized neither the classes nor examples were in alphabetical order. Looking at avatar and, I noticed the same thing, so I quickly threw this together to update the classes in the table and any examples and code snippets to be in the proper order.

## Obligatory GIF
![](https://cdn.dribbble.com/users/710392/screenshots/2986291/stt-alphabet_v2.gif)
