### PR TITLE
Correcting background-pattern documentation.

### DIFF
--- a/docs/utilities/backgrounds/patterns.html
+++ b/docs/utilities/backgrounds/patterns.html
@@ -19,11 +19,11 @@ description: Utilities for adding distinctive background patterns for Department
                     {% assign patterns = "blob, chevrons, crosses, crosshatch, dot-dash, dots-circles, horz-stripes, slanted-stripes, steps, stripe" | split: ", " %}
                     {% for i in patterns %}
                     <tr>
-                        <th scope="row" class="d-ff-mono d-fc-purple d-fw-normal d-fs12">.d-bgg-{{ i }}-{{ c }}</th>
+                        <th scope="row" class="d-ff-mono d-fc-purple d-fw-normal d-fs12">.d-bgg-pattern-{{ i }}-{{ c }}</th>
                         <td>
                             <div class="d-d-flex d-jc-space-between d-ai-center">
                                 <div class="d-fl-grow1 d-ff-mono d-fc-orange d-fs12">
-                                    --bgg-pattern: --bgg-{{ i }}-{{ c }};
+                                    --bgg-pattern: --bgg-pattern-{{ i }}-{{ c }};
                                 </div>
                                 <div class="d-w24 d-h24 {% if c == 'light' %}d-bgc-black-900 {% endif %}d-bgg-pattern d-bgg-pattern-{{ i }}-{{ c }} d-ba d-bc-black-900 d-bar4"></div>
                             </div>


### PR DESCRIPTION
## Description
This PR corrects inconsistent background-pattern utility class documentation, whose class table showed one naming pattern and examples showed another. We discovered this while working on the DT v6 migration guide, which threw errors showing the documented utility classes were missing. 

The naming pattern is: `.d-bgg-pattern-{pattern}-{dark|light}`

## Obligatory GIF
![](https://www.nwahomepage.com/wp-content/uploads/sites/90/2020/02/Missing-Person-GIF.gif?w=640&h=480&crop=1&resize=1280,720)
