### PR TITLE
Updates incorrect auto margin documentation

### DIFF
--- a/docs/utilities/layout/margin.html
+++ b/docs/utilities/layout/margin.html
@@ -169,7 +169,7 @@ description: Utilities to adjust an element's exterior spacing between other obj
                     {% assign dir = spacing.directions | split: ", "  %}
                     {% for i in dir %}
                     <tr>
-                        <th scope="row">.d-m{% if i != 'All' %}{{ i | slice: 0 }}{% endif %}-auto</th>
+                        <th scope="row">.d-m{% if i == 'All' %}-{% endif %}{% if i != 'All' %}{{ i | slice: 0 }}{% endif %}-auto</th>
                         <td class="d-opacity50 d-background-color--ash">.d-m{% if i != "All" %}-{{ i }}{% endif %}{{ val }}--auto</td>
                         <td>
                             {% if i == "y" %}
@@ -194,14 +194,13 @@ description: Utilities to adjust an element's exterior spacing between other obj
                     {% assign dir = spacing.directions | split: ", "  %}
                     {% for i in dir %}
                     <div class="d-fl-center d-background-color--rose-light d-height1 d-m8" style="flex-basis: calc(33.3333333% - 1.6rem);">
-                        <div class="d-fl-center d-p16 d-m{% if i != 'All' %}{{ i | slice: 0 }}{% endif %}-auto d-border d-border-color--navy-lighter d-fc-navy-text d-fs11 d-fw-bold d-ff-mono d-lh-tight d-background-color--navy-lightest {% if i == 'top' %}d-width100{% elsif i == 'bottom' %}d-width100{% elsif i == 'left' %}d-height100{% elsif i == 'right' %}d-height100{% elsif i == 'y' %}d-width100{% elsif i == 'x' %}d-height100{% endif %}">.d-m{% if i != 'All' %}{{ i | slice: 0 }}{% endif %}-auto</div>
+                        <div class="d-fl-center d-p16 d-m{% if i != 'All' %}{{ i | slice: 0 }}{% endif %}-auto d-border d-border-color--navy-lighter d-fc-navy-text d-fs11 d-fw-bold d-ff-mono d-lh-tight d-background-color--navy-lightest {% if i == 'top' %}d-width100{% elsif i == 'bottom' %}d-width100{% elsif i == 'left' %}d-height100{% elsif i == 'right' %}d-height100{% elsif i == 'y' %}d-width100{% elsif i == 'x' %}d-height100{% endif %}">.d-m{% if i == 'All' %}-{% endif %}{% if i != 'All' %}{{ i | slice: 0 }}{% endif %}-auto</div>
                     </div>
                     {% endfor %}
                 </div>
                 <div class="dialtone-example__code">
 {% highlight html linenos %}
-<div class="d-m-auto">…</div>
-<div class="d-m-auto">…</div>
+<div class="d-m--auto">…</div>
 <div class="d-mt-auto">…</div>
 <div class="d-mr-auto">…</div>
 <div class="d-mb-auto">…</div>


### PR DESCRIPTION
## Description
Updates the auto margin documentation to match the CSS class.

In `margin.less`:
```
//  New classes. Use these moving forward
.d-m--auto                      { margin: auto !important; }
```

But in the documentation:
<img width="717" alt="Screen Shot 2021-07-14 at 10 41 55 AM" src="https://user-images.githubusercontent.com/77751297/125660215-c7e89695-e5fd-44fa-b278-8b68bbf3c2f5.png">

This PR updates the documentation and resolves #365 

## Obligatory GIF
![](https://media3.giphy.com/media/G2fKgPMXJ40WA/giphy.gif?cid=790b7611ab51fae9f072bb157afd62c137d62a6ca61aa167&rid=giphy.gif&ct=g)
