### PR TITLE
Fixed site title not working

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -2,7 +2,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>{% if page.title %}{{ page.title | escape }} - {% endif %}{{ site.title | escape }}</title>
+    <title>{% if title %}{{ title | escape }} - {% endif %}{{ site.title | escape }}</title>
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
     <!-- Favicons -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,5 @@
 ---
 layout: page-home
-title: Dialtone
 headline: Improve your UI's reception with Dialtone
 lede: Documented styles, utility classes, and components to help you quickly design and build unified experiences across Dialpad and Dialpad Meetings.
 ---

--- a/docs/utilities/grid/place-self.html
+++ b/docs/utilities/grid/place-self.html
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Place Items
+title: Place Self
 description: Utilities for controlling a grid item's alignment along their block and inline axis directions.
 ---
 <section class="d-stack16">


### PR DESCRIPTION
## Description
Site title doesn't update to reflect current page. While this may not be a major issue when, say, trying to identify which browser tab is open to Dialtone, it does become more of a problem when managing multiple Dialtone tabs.

https://switchcomm.atlassian.net/browse/DT-29?atlOrigin=eyJpIjoiZDA1OWUxNzhjNzc4NGNiZTgwODBkZTdmNjRjNTE1YzQiLCJwIjoiaiJ9

## Pull Request Checklist

 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Provide a description what is being changed, extended, or removed.
 - [x] Link to any issue(s) this request is resolving.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF
![Captura de Pantalla 2021-08-10 a la(s) 2 21 05 p m](https://user-images.githubusercontent.com/87546543/128921995-915b283b-697d-4ab5-90e8-ae25ba7193a4.png)

