### PR TITLE
Removed .d-radio__description--* and .d-checkbox__description--* classes

### DIFF
--- a/lib/build/less/components/radio-checkbox.less
+++ b/lib/build/less/components/radio-checkbox.less
@@ -163,37 +163,6 @@
     }
 }
 
-.d-checkbox__description--warning,
-.d-radio__description--warning {
-    color: var(--warning-color-text);
-
-    > a[href] {
-        .d-link();
-        .d-link--warning();
-    }
-}
-
-.d-checkbox__description--error,
-.d-radio__description--error {
-    color: var(--error-color-text);
-
-    > a[href] {
-        .d-link();
-        .d-link--danger();
-    }
-}
-
-.d-checkbox__description--success,
-.d-radio__description--success {
-    color: var(--success-color-text);
-
-    > a[href] {
-        .d-link();
-        .d-link--success();
-    }
-}
-
-
 //  ============================================================================
 //  $   CHECKBOXES
 //  ----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Removed classes:
  .d-radio__description--warning
  .d-radio__description--error
  .d-radio__description--success
  .d-checkbox__description--warning
  .d-checkbox__description--error
  .d-checkbox__description--success

## Pull Request Checklist

 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Provide a description what is being changed, extended, or removed.
 - [x] Link to any issue(s) this request is resolving.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 
 https://switchcomm.atlassian.net/browse/DT-46?atlOrigin=eyJpIjoiZDhmNjg0ODY4ODBkNDZiOWEyMzA3MTM4YzVmYzQ0ZDMiLCJwIjoiaiJ9