### PR TITLE
refactor: dt-31 Modal transition refactor to use Vue transition compatible CSS classes

### DIFF
--- a/docs/_data/modal.json
+++ b/docs/_data/modal.json
@@ -39,6 +39,26 @@
       "class": "d-modal--danger",
       "applies": ".d-modal",
       "description": "Adds styling for destructive actions."
+    },
+    {
+      "class": "d-modal--animate-in",
+      "applies": ".d-modal",
+      "description": "Adds transition styles for modal appearance."
+    },
+    {
+      "class": "d-modal--animate-out",
+      "applies": ".d-modal",
+      "description": "Adds transition styles for modal exit."
+    },
+    {
+      "class": "d-modal__dialog--animate-in",
+      "applies": ".d-modal__dialog",
+      "description": "Adds transition styles for modal dialog appearance."
+    },
+    {
+      "class": "d-modal__dialog--animate-out",
+      "applies": ".d-modal__dialog",
+      "description": "Adds transition styles for modal dialog exit."
     }
   ],
   "accessible": [

--- a/docs/assets/js/modal.js
+++ b/docs/assets/js/modal.js
@@ -15,6 +15,8 @@ $(document).ready(function() {
         e.stopPropagation();
         e.preventDefault();
 
+        $.fn.removeTransitionEnterClasses();
+        $.fn.addTransitionLeaveClasses();
         $(modal).attr('aria-hidden','true');
         if ($('.js-example-modal.d-modal--danger')) {
             $(modal).removeClass('d-modal--danger');
@@ -35,12 +37,33 @@ $(document).ready(function() {
             $(btnSave).removeClass('d-btn--danger');
         }
     };
+    
+    $.fn.addTransitionEnterClasses = function() {
+        $(modal).addClass('d-modal--animate-in');
+        $(dialog).addClass('d-modal__dialog--animate-in'); 
+    }
+
+    $.fn.removeTransitionEnterClasses = function() {
+        $(modal).removeClass('d-modal--animate-in');
+        $(dialog).removeClass('d-modal__dialog--animate-in');
+    }
+
+    $.fn.addTransitionLeaveClasses = function() {
+        $(modal).addClass('d-modal--animate-out');
+        $(dialog).addClass('d-modal__dialog--animate-out');
+    }
+
+    $.fn.removeTransitionLeaveClasses = function() {
+        $(modal).removeClass('d-modal--animate-out');
+        $(dialog).removeClass('d-modal__dialog--animate-out');
+    }
 
     $(launchBtn).on('click', function(e) {
         e.stopPropagation();
         e.preventDefault();
 
-        $(modal).addClass('d-modal-enter-active')
+        $.fn.removeTransitionLeaveClasses();
+        $.fn.addTransitionEnterClasses();
         $(modal).attr('aria-hidden','false');
         $(body).addClass('d-of-hidden');
     });
@@ -49,6 +72,8 @@ $(document).ready(function() {
         e.stopPropagation();
         e.preventDefault();
 
+        $.fn.removeTransitionLeaveClasses();
+        $.fn.addTransitionEnterClasses();
         $(modal).attr('aria-hidden','false').addClass('d-modal--full');
         $(body).addClass('d-of-hidden');
     });
@@ -57,6 +82,8 @@ $(document).ready(function() {
         e.stopPropagation();
         e.preventDefault();
 
+        $.fn.removeTransitionLeaveClasses();
+        $.fn.addTransitionEnterClasses();
         $(modal).attr('aria-hidden','false').addClass('d-modal--danger');
         $(btnCancel).addClass('d-btn--danger');
         $(btnSave).addClass('d-btn--danger');

--- a/docs/assets/js/modal.js
+++ b/docs/assets/js/modal.js
@@ -40,6 +40,7 @@ $(document).ready(function() {
         e.stopPropagation();
         e.preventDefault();
 
+        $(modal).addClass('d-modal-enter-active')
         $(modal).attr('aria-hidden','false');
         $(body).addClass('d-of-hidden');
     });

--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -44,10 +44,11 @@
 
     background-color: var(--modal--bgc);
 
-  visibility: visible;
-  opacity: 1;
-  z-index: var(--zi-modal);
-  transform: translate3d(0,0,0) scale3d(1,1,1);
+    visibility: visible;
+    opacity: 1;
+    z-index: var(--zi-modal);
+    transform: translate3d(0,0,0) scale3d(1,1,1);
+    will-change: visibility, z-index, opacity;
 
     @media (prefers-reduced-motion) {
         transition: none;
@@ -77,6 +78,7 @@
   opacity: 1;
   z-index: var(--zi-modal);
   transform: translate3d(0,0,0) scale3d(1,1,1);
+  will-change: visibility, z-index, opacity, transform;
 
   .d-stack16();
 }
@@ -87,55 +89,50 @@
   visibility: hidden;
   opacity: 0;
   backface-visibility: hidden;
-  will-change: visibility, z-index, opacity;
 }
 
-.d-modal-enter, .d-modal-leave-to {
+.d-modal[aria-hidden="true"] .d-modal__dialog {
+  transform: translate3d(0,30%,0) scale3d(.75,.75,.75);
+}
+
+
+//  ============================================================================
+//  $   ANIMATION
+//  ----------------------------------------------------------------------------
+.d-modal--animate {
   z-index: var(--zi-hide);
   visibility: hidden;
   opacity: 0;
   backface-visibility: hidden;
-  will-change: visibility, z-index, opacity;
 }
 
-.d-modal-enter-active {
+.d-modal__dialog--animate {
+  .d-modal--animate();
+  transform: translate3d(0,30%,0) scale3d(.75,.75,.75);
+}
+
+.d-modal--animate-in, .d-modal__dialog--animate-in {
   transition:
-          opacity 100ms var(--ttf-in-out) 10ms,
-          z-index 0s 0s,
-          visibility 0s 0s,
-          transform 100ms var(--ttf-in-out) 10ms
+    opacity 100ms var(--ttf-in-out) 10ms,
+    z-index 0s 0s,
+    visibility 0s 0s,
+    transform 100ms var(--ttf-in-out) 10ms
 }
 
-.d-modal-leave-active {
+.d-modal--animate-out {
   transition:
-          opacity 100ms var(--ttf-in-out) 10ms,
-          z-index 0s 200ms,
-          visibility 0s 200ms,
-          transform 100ms var(--ttf-in-out) 10ms;
+    opacity 100ms var(--ttf-in-out) 10ms,
+    z-index 0s 200ms,
+    visibility 0s 200ms,
+    transform 100ms var(--ttf-in-out) 10ms;
 }
 
-.d-modal-dialog-enter, .d-modal-dialog-leave-to {
-  z-index: var(--zi-hide);
-  visibility: hidden;
-  opacity: 0;
-  backface-visibility: hidden;
-  transform: translate3d(0,30%,0) scale3d(.75,.75,.75);;
-}
-
-.d-modal-dialog-enter-active {
+.d-modal__dialog--animate-out {
   transition:
-          opacity 100ms var(--ttf-in-out) 10ms,
-          z-index 0s 0s,
-          visibility 0s 0s,
-          transform 100ms var(--ttf-in-out) 10ms;
-}
-
-.d-modal-dialog-leave-active {
-  transition:
-          opacity 200ms var(--ttf-in-out) 0s,
-          z-index 0s 200ms,
-          visibility 0s 200ms,
-          transform 100ms var(--ttf-in-out) 0s;
+    opacity 200ms var(--ttf-in-out) 0s,
+    z-index 0s 200ms,
+    visibility 0s 200ms,
+    transform 100ms var(--ttf-in-out) 0s;
 }
 
 

--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -44,17 +44,10 @@
 
     background-color: var(--modal--bgc);
 
-    z-index: var(--zi-hide);
-    visibility: hidden;
-    opacity: 0;
-    backface-visibility: hidden;
-
-    transition:
-        opacity 100ms var(--ttf-in-out) 10ms,
-        z-index 0s 200ms,
-        visibility 0s 200ms,
-        transform 100ms var(--ttf-in-out) 10ms;
-    will-change: visibility, z-index, opacity;
+  visibility: visible;
+  opacity: 1;
+  z-index: var(--zi-modal);
+  transform: translate3d(0,0,0) scale3d(1,1,1);
 
     @media (prefers-reduced-motion) {
         transition: none;
@@ -80,35 +73,69 @@
   font-size: var(--fs16);
   line-height: var(--lh8);
 
-  z-index: var(--zi-hide);
-  visibility: hidden;
-  opacity: 0;
-  backface-visibility: hidden;
-  transform: translate3d(0,30%,0) scale3d(.75,.75,.75);
-
-  transition:
-    opacity 200ms var(--ttf-in-out) 0s,
-    z-index 0s 200ms,
-    visibility 0s 200ms,
-    transform 100ms var(--ttf-in-out) 0s;
-  will-change: visibility, z-index, opacity, tranform;
-
-  .d-stack16();
-}
-
-//  $$   MAKE THEM APPEAR
-//  ----------------------------------------------------------------------------
-.d-modal[aria-hidden="false"],
-.d-modal[aria-hidden="false"] .d-modal__dialog {
   visibility: visible;
   opacity: 1;
   z-index: var(--zi-modal);
   transform: translate3d(0,0,0) scale3d(1,1,1);
+
+  .d-stack16();
+}
+
+.d-modal[aria-hidden="true"],
+.d-modal[aria-hidden="true"] .d-modal__dialog {
+  z-index: var(--zi-hide);
+  visibility: hidden;
+  opacity: 0;
+  backface-visibility: hidden;
+  will-change: visibility, z-index, opacity;
+}
+
+.d-modal-enter, .d-modal-leave-to {
+  z-index: var(--zi-hide);
+  visibility: hidden;
+  opacity: 0;
+  backface-visibility: hidden;
+  will-change: visibility, z-index, opacity;
+}
+
+.d-modal-enter-active {
   transition:
-    opacity 100ms var(--ttf-in-out) 10ms,
-    z-index 0s 0s,
-    visibility 0s 0s,
-    transform 100ms var(--ttf-in-out) 10ms;
+          opacity 100ms var(--ttf-in-out) 10ms,
+          z-index 0s 0s,
+          visibility 0s 0s,
+          transform 100ms var(--ttf-in-out) 10ms
+}
+
+.d-modal-leave-active {
+  transition:
+          opacity 100ms var(--ttf-in-out) 10ms,
+          z-index 0s 200ms,
+          visibility 0s 200ms,
+          transform 100ms var(--ttf-in-out) 10ms;
+}
+
+.d-modal-dialog-enter, .d-modal-dialog-leave-to {
+  z-index: var(--zi-hide);
+  visibility: hidden;
+  opacity: 0;
+  backface-visibility: hidden;
+  transform: translate3d(0,30%,0) scale3d(.75,.75,.75);;
+}
+
+.d-modal-dialog-enter-active {
+  transition:
+          opacity 100ms var(--ttf-in-out) 10ms,
+          z-index 0s 0s,
+          visibility 0s 0s,
+          transform 100ms var(--ttf-in-out) 10ms;
+}
+
+.d-modal-dialog-leave-active {
+  transition:
+          opacity 200ms var(--ttf-in-out) 0s,
+          z-index 0s 200ms,
+          visibility 0s 200ms,
+          transform 100ms var(--ttf-in-out) 0s;
 }
 
 

--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -50,10 +50,6 @@
     backface-visibility: hidden;
 
     will-change: visibility, z-index, opacity;
-
-    @media (prefers-reduced-motion) {
-        transition: none;
-    }
 }
 
 //  $$  MODAL DIALOG
@@ -229,6 +225,10 @@
     z-index 0s 0s,
     visibility 0s 0s,
     transform 100ms var(--ttf-in-out) 10ms;
+
+  @media (prefers-reduced-motion) {
+    transition: none!important;
+  }
 }
 
 .d-modal--animate-out {
@@ -244,6 +244,10 @@
       z-index 0s 200ms,
       visibility 0s 200ms;
   }
+
+  @media (prefers-reduced-motion) {
+    transition: none!important;
+  }
 }
 
 .d-modal__dialog--animate-out {
@@ -258,5 +262,9 @@
       opacity 200ms var(--ttf-in-out) 0s,
       z-index 0s 200ms,
       visibility 0s 200ms;
+  }
+
+  @media (prefers-reduced-motion) {
+    transition: none!important;
   }
 }

--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -44,10 +44,11 @@
 
     background-color: var(--modal--bgc);
 
-    visibility: visible;
-    opacity: 1;
-    z-index: var(--zi-modal);
-    transform: translate3d(0,0,0) scale3d(1,1,1);
+    z-index: var(--zi-hide);
+    visibility: hidden;
+    opacity: 0;
+    backface-visibility: hidden;
+
     will-change: visibility, z-index, opacity;
 
     @media (prefers-reduced-motion) {
@@ -74,65 +75,25 @@
   font-size: var(--fs16);
   line-height: var(--lh8);
 
-  visibility: visible;
-  opacity: 1;
-  z-index: var(--zi-modal);
-  transform: translate3d(0,0,0) scale3d(1,1,1);
+  z-index: var(--zi-hide);
+  visibility: hidden;
+  opacity: 0;
+  backface-visibility: hidden;
+  transform: translate3d(0,30%,0) scale3d(.75,.75,.75);
+
   will-change: visibility, z-index, opacity, transform;
 
   .d-stack16();
 }
 
-.d-modal[aria-hidden="true"],
-.d-modal[aria-hidden="true"] .d-modal__dialog {
-  z-index: var(--zi-hide);
-  visibility: hidden;
-  opacity: 0;
-  backface-visibility: hidden;
-}
-
-.d-modal[aria-hidden="true"] .d-modal__dialog {
-  transform: translate3d(0,30%,0) scale3d(.75,.75,.75);
-}
-
-
-//  ============================================================================
-//  $   ANIMATION
+//  $$   MAKE THEM APPEAR
 //  ----------------------------------------------------------------------------
-.d-modal--animate {
-  z-index: var(--zi-hide);
-  visibility: hidden;
-  opacity: 0;
-  backface-visibility: hidden;
-}
-
-.d-modal__dialog--animate {
-  .d-modal--animate();
-  transform: translate3d(0,30%,0) scale3d(.75,.75,.75);
-}
-
-.d-modal--animate-in, .d-modal__dialog--animate-in {
-  transition:
-    opacity 100ms var(--ttf-in-out) 10ms,
-    z-index 0s 0s,
-    visibility 0s 0s,
-    transform 100ms var(--ttf-in-out) 10ms
-}
-
-.d-modal--animate-out {
-  transition:
-    opacity 100ms var(--ttf-in-out) 10ms,
-    z-index 0s 200ms,
-    visibility 0s 200ms,
-    transform 100ms var(--ttf-in-out) 10ms;
-}
-
-.d-modal__dialog--animate-out {
-  transition:
-    opacity 200ms var(--ttf-in-out) 0s,
-    z-index 0s 200ms,
-    visibility 0s 200ms,
-    transform 100ms var(--ttf-in-out) 0s;
+.d-modal[aria-hidden="false"],
+.d-modal[aria-hidden="false"] .d-modal__dialog {
+  visibility: visible;
+  opacity: 1;
+  z-index: var(--zi-modal);
+  transform: translate3d(0,0,0) scale3d(1,1,1);
 }
 
 
@@ -226,13 +187,6 @@
     transform: unset !important;
   }
 
-  &,
-  .d-modal__dialog {
-    transition:
-      opacity 200ms var(--ttf-in-out) 0s,
-      z-index 0s 200ms,
-      visibility 0s 200ms;
-  }
 
   .d-modal__footer {
     margin: var(--sun16) var(--sun12);
@@ -251,4 +205,58 @@
 .d-modal--danger {
   --modal--bgc:           hsla(var(--error-color-hsl) ~" / " 95%);
   --modal-header--fc:     var(--fc-error);
+}
+
+
+//  ============================================================================
+//  $   TRANSITIONS
+//  ----------------------------------------------------------------------------
+.d-modal--animate {
+  z-index: var(--zi-hide)!important;
+  visibility: hidden!important;
+  opacity: 0!important;
+  backface-visibility: hidden!important;
+}
+
+.d-modal__dialog--animate {
+  .d-modal--animate();
+  transform: translate3d(0,30%,0) scale3d(.75,.75,.75)!important;;
+}
+
+.d-modal--animate-in, .d-modal__dialog--animate-in {
+  transition:
+    opacity 100ms var(--ttf-in-out) 10ms,
+    z-index 0s 0s,
+    visibility 0s 0s,
+    transform 100ms var(--ttf-in-out) 10ms;
+}
+
+.d-modal--animate-out {
+  transition:
+    opacity 100ms var(--ttf-in-out) 10ms,
+    z-index 0s 200ms,
+    visibility 0s 200ms,
+    transform 100ms var(--ttf-in-out) 10ms;
+
+  &.d-modal--full {
+    transition:
+      opacity 200ms var(--ttf-in-out) 0s,
+      z-index 0s 200ms,
+      visibility 0s 200ms;
+  }
+}
+
+.d-modal__dialog--animate-out {
+  transition:
+    opacity 200ms var(--ttf-in-out) 0s,
+    z-index 0s 200ms,
+    visibility 0s 200ms,
+    transform 100ms var(--ttf-in-out) 0s;
+
+  &.d-modal--full {
+    transition:
+      opacity 200ms var(--ttf-in-out) 0s,
+      z-index 0s 200ms,
+      visibility 0s 200ms;
+  }
 }


### PR DESCRIPTION
## Description
Issue: https://switchcomm.atlassian.net/browse/DT-31
This PR adds modal transition classes to apply during transition instead of relying on `aria-hidden` prop to transition.

Updated documentation modal examples in order to use these classes.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Provide a description what is being changed, extended, or removed.
 - [x] Link to any issue(s) this request is resolving.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Drew Chandler, Joshua Hynes, or Ted Goas.

## Obligatory GIF
![CleanShot 2021-08-20 at 10 59 51](https://user-images.githubusercontent.com/83774467/130245005-b74f4970-7ee7-41ee-b1cd-427c1262e09a.gif)

