### PR TITLE
Added Dialtone 5 cross-link, top-banner

### DIFF
--- a/docs/_includes/banner.html
+++ b/docs/_includes/banner.html
@@ -1,0 +1,14 @@
+<aside class="d-banner d-banner--info d-ps-relative js-dialtone5-banner" role="alert" aria-hidden="false">
+  <div class="d-banner__dialog" role="alertdialog" aria-labelledy="info-alert-title" aria-describedby="info-alert-desc">
+    <div class="d-notice__icon">
+      <IconInfo />
+    </div>
+    <div class="d-notice__content">
+      <h1 class="d-notice__title" id="info-alert-title">Dialtone 6.0 is here!</h1>
+      <p class="d-notice__message" id="info-alert-desc">
+        Looking for Dialtone 5 documentation?
+        <a href="//version5.dialpad.design" class="d-link" target="_blank">Find it here.</a>
+      </p>
+    </div>
+  </div>
+</aside>

--- a/docs/_includes/banner.html
+++ b/docs/_includes/banner.html
@@ -1,5 +1,5 @@
 <aside class="d-banner d-banner--info d-ps-relative js-dialtone5-banner" role="alert" aria-hidden="false">
-  <div class="d-banner__dialog" role="alertdialog" aria-labelledy="info-alert-title" aria-describedby="info-alert-desc">
+  <div class="d-banner__dialog d-w-unset" role="alertdialog" aria-labelledy="info-alert-title" aria-describedby="info-alert-desc">
     <div class="d-notice__icon">
       <IconInfo />
     </div>

--- a/docs/_includes/layouts/page-home.html
+++ b/docs/_includes/layouts/page-home.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   {% include head.html %}
+  {% include banner.html %}
   <body>
     <div class="d-ps-relative d-stack16">
       {% include header.html %}

--- a/docs/_includes/layouts/page-no-toc.html
+++ b/docs/_includes/layouts/page-no-toc.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   {% include head.html %}
+  {% include banner.html %}
   <body>
     <div class="d-ps-relative d-stack16">
       {% include header.html %}

--- a/docs/_includes/layouts/page.html
+++ b/docs/_includes/layouts/page.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   {% include head.html %}
+  {% include banner.html %}
   <body>
     <div class="d-ps-relative d-stack16">
       {% include header.html %}

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -1,5 +1,5 @@
-<nav class="d-ga-sidebar md:d-d-none" role="navigation">
-    <div class="d-of-y-scroll d-zi-navigation d-ps-fixed d-b0 d-t64 d-pt24 d-w216 d-pb48 js-navigation-sidebar">
+<nav class="d-ga-sidebar md:d-d-none d-ps-fixed" role="navigation">
+    <div class="d-of-y-scroll d-zi-navigation d-ps-fixed d-b0 d-pt24 d-w216 d-pb48 js-navigation-sidebar">
     {% if site-nav %}
         {% for section in site-nav.sections %}
             {% assign slug = page.url | replace: '/',' ' | truncatewords: 2 | remove:'...' %}
@@ -7,7 +7,7 @@
             {% if slug contains url %}
                 <!-- This is for navigation that doesn't categorize its nav items -->
                 {% if section.pages %}
-                    <ul id="nav" class="d-ls-reset d-stack4">
+                    <ul id="nav" class="d-ls-reset d-px16 d-stack4">
                       {% for item in section.pages %}
                           <li>
                               <a class="d-link d-td-none d-d-block d-px8 d-py4 d-fs14 d-lh6 d-bar4{% if page.url == item.url %} d-bgc-purple-100 d-bgo50{% endif %}" href="{{ item.url }}">{{ item.title }}</a>
@@ -17,7 +17,7 @@
                 {% endif %}
                 <!-- This is for navigation that DOES categorize its nav items -->
                 {% if section.subsections %}
-                <ul id="nav" class="d-ls-reset d-pr16 d-stack32">
+                <ul id="nav" class="d-ls-reset d-px16 d-stack32">
                     {% for subsection in section.subsections %}
                         <li>
                             <div class="d-d-block d-px8 d-py2 d-mb4 d-fs14 d-lh6 d-fc-black-600 d-fw-bold">{{ subsection.title }}</div>

--- a/docs/assets/js/banner.js
+++ b/docs/assets/js/banner.js
@@ -58,7 +58,6 @@ $(document).ready(function() {
             topNav.attr('style','height: 11.2rem !important; padding-top: 4.8rem; max-height: 11.2rem !important;');
             sideNav.attr('style','top: 6.4rem!important');
             dialtone5Banner.addClass('d-d-none');
-            console.log('here');
         }
 
         if (important.is(':checked')) {

--- a/docs/assets/js/banner.js
+++ b/docs/assets/js/banner.js
@@ -22,6 +22,7 @@ $(document).ready(function() {
     var pinned = $('.js-banner-pinned');
     var iconTypes = $('.js-banner-example-icon-base, .js-banner-example-icon-info, .js-banner-example-icon-warning, .js-banner-example-icon-error, .js-banner-example-icon-success');
     var classTypes = ("d-banner--info d-banner--warning d-banner--error d-banner--success d-banner--important d-banner--pinned");
+    var dialtone5Banner = $('.js-dialtone5-banner');
 
     launchBtn.on('click', function(e) {
         var style = selectMenu.find(':selected').data('class');
@@ -55,6 +56,9 @@ $(document).ready(function() {
             banner.addClass('d-banner--pinned');
             actions.addClass('d-d-none');
             topNav.attr('style','height: 11.2rem !important; padding-top: 4.8rem; max-height: 11.2rem !important;');
+            sideNav.attr('style','top: 6.4rem!important');
+            dialtone5Banner.addClass('d-d-none');
+            console.log('here');
         }
 
         if (important.is(':checked')) {
@@ -82,9 +86,9 @@ $(document).ready(function() {
 
     function closeBanner() {
       var style = selectMenu.find(':selected').data('class');
-      var iconStyle = "js-banner-example-icon-" + style;
+      var iconStyle = $("js-banner-example-icon-" + style);
 
-      sideNav.attr('style','');
+      sideNav.attr('style','top: 6.4rem!important');
       topNav.attr('style','');
       tableOfContents.attr('style','');
       content.attr('style','');
@@ -93,6 +97,7 @@ $(document).ready(function() {
       banner.attr('aria-hidden', 'true').removeClass(classTypes);
       icon.addClass('d-d-none');
       iconStyle.addClass('d-d-none');
+      dialtone5Banner.removeClass('d-d-none');
     }
     closeBtn.add(removeBtn).on('click', function(e) {
       e.stopPropagation();
@@ -100,4 +105,16 @@ $(document).ready(function() {
 
       closeBanner();
     });
+
+  // Position the un-pinned banner
+  $(window).scroll( () => {
+    var windowTop = $(window).scrollTop();
+
+    if (windowTop > 50) {
+      banner.attr('style', '--topbar-height: 6.4rem');
+    } else {
+      var remSize = 11.2 - windowTop/10;
+      banner.attr('style', `--topbar-height: ${remSize}rem`);
+    }
+  })
 });

--- a/docs/assets/js/nav.js
+++ b/docs/assets/js/nav.js
@@ -5,6 +5,8 @@ $(document).ready(function() {
 
     var body = $("body");
     var navHeader = $(".js-navigation-header");
+    var navigationSideBar = $(".js-navigation-sidebar");
+    var banner = $('.js-banner-example');
 
     function regenerateMenu () {
         // Hide the navigation if we've opened it
@@ -13,7 +15,17 @@ $(document).ready(function() {
         navigation.addClass("md:d-d-none");
     }
 
+    function calcSideNavPosition () {
+      const windowTop = $(window).scrollTop();
+      // const baseSideNavPosition = banner.attr('aria-hidden') === 'true' ? 0 : 4.8;
+      const baseSideNavPosition = 0;
+      const topPosition = (windowTop > 50 ? 6.4 : 11.2 - windowTop/10) + baseSideNavPosition;
+
+      navigationSideBar.attr('style',`top: ${topPosition}rem!important`);
+    }
+
     $.when($.ready).then(function() {
+        calcSideNavPosition();
         regenerateMenu();
 
         window.history.replaceState({
@@ -95,7 +107,12 @@ $(document).ready(function() {
     //  Add box shadow to the header navigation on scroll
     $(window).scroll( () => {
         var windowTop = $(window).scrollTop();
+        calcSideNavPosition();
 
-        windowTop > 64 ? navHeader.addClass('d-bs-lg d-bc-white').removeClass('d-bc-black-100') : navHeader.removeClass('d-bs-lg d-bc-white').addClass('d-bc-black-100');
+        if (windowTop > 64) {
+          navHeader.addClass('d-bs-lg d-bc-white').removeClass('d-bc-black-100');
+        } else {
+          navHeader.removeClass('d-bs-lg d-bc-white').addClass('d-bc-black-100');
+        }
     })
 });


### PR DESCRIPTION
## Description
Version 6 Documentation needs a cross-link allowing users to get to version 5 documentation.

https://switchcomm.atlassian.net/browse/DT-101?atlOrigin=eyJpIjoiNGIyOGE5NGYzOTY2NDRhYjg4OTBlMDNiYjhiNjZjMWYiLCJwIjoiaiJ9
 
## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Provide a description what is being changed, extended, or removed.
 - [x] Link to any issue(s) this request is resolving.
 - [x] Request a review from Drew Chandler, Joshua Hynes, or Ted Goas.

## Obligatory GIF
![](https://i.pinimg.com/originals/5c/99/39/5c993918849a1858176cc694ee3c354a.gif)

