### PR TITLE
Updated CSS badge endpoint

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,8 +10,8 @@ lede: Documented styles, utility classes, and components to help you quickly des
       <h1 class="d-headline42 d-lh6 d-mb12">{{ headline }}</h1>
       <p class="d-fs20 d-lh6 d-mb8">{{ lede }}</p>
       <div class="d-mb48">
-        <a class="d-td-unset" href="https://github.com/dialpad/dialtone/tree/version6">
-          <img src="https://img.shields.io/github/package-json/v/dialpad/dialtone/version6?color=A687FF&label=CSS" alt="Dialtone CSS version number">
+        <a class="d-td-unset" href="https://github.com/dialpad/dialtone/">
+          <img src="https://img.shields.io/github/package-json/v/dialpad/dialtone?color=A687FF&label=CSS" alt="Dialtone CSS version number">
         </a>
         <a class="d-td-unset" href="https://github.com/dialpad/dialtone-vue">
           <img src="https://img.shields.io/badge/Vue-v1.0.0-A687FF" alt="Dialtone Vue version number">


### PR DESCRIPTION
## Description
Fixed url and badge endpoint so it's no longer pointer to the `version6` branch.