### PR TITLE
DT-103: Fix icon button margins

### DIFF
--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -167,13 +167,13 @@
     margin-right: var(--sun2);
 }
 
-.d-btn__icon--left + .d-btn__label,
-.d-btn__label + .d-btn__icon--right {
+.d-btn__icon--left ~ .d-btn__label,
+.d-btn__label ~ .d-btn__icon--right {
     margin-left: var(--su4);
 }
 
-.d-btn__icon--right + .d-btn__label,
-.d-btn__label + .d-btn__icon--left {
+.d-btn__icon--right ~ .d-btn__label,
+.d-btn__label ~ .d-btn__icon--left {
     margin-right: var(--su4);
 }
 

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -152,14 +152,29 @@
 }
 
 .d-btn__icon--left {
-    margin-left: var(--sun2);
-    margin-right: var(--su4);
+    order: -1;
 }
 
 .d-btn__icon--right {
     order: 1;
-    margin-left: var(--su4);
+}
+
+.d-btn__icon--left:not(:only-child) {
+    margin-left: var(--sun2);
+}
+
+.d-btn__icon--right:not(:only-child) {
     margin-right: var(--sun2);
+}
+
+.d-btn__icon--left + .d-btn__label,
+.d-btn__label + .d-btn__icon--right {
+    margin-left: var(--su4);
+}
+
+.d-btn__icon--right + .d-btn__label,
+.d-btn__label + .d-btn__icon--left {
+    margin-right: var(--su4);
 }
 
 //  ============================================================================


### PR DESCRIPTION
## Description
Bugfix for icon button margins:

We now only add margins if the icons are not the only child of button.
Also added fixes to order to ensure that the icons are correctly ordered no matter how they are defined in the DOM.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Provide a description what is being changed, extended, or removed.
 - [x] Link to any issue(s) this request is resolving.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Joshua Hynes, Ted Goas, or David Becher.


![Screen Shot 2021-09-20 at 11 46 16 AM](https://user-images.githubusercontent.com/73855198/134059867-a9cb95f0-282c-4fe2-8c40-d931eb2c4e4d.png)


