### PR TITLE
DT-104: Update danger modal background color

### DIFF
--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -225,6 +225,5 @@
 //  $$  DANGER
 //  ----------------------------------------------------------------------------
 .d-modal--danger {
-  --modal--bgc:           hsla(var(--error-color-hsl) ~" / " 95%);
   --modal-header--fc:     var(--fc-error);
 }


### PR DESCRIPTION
## Description
Removed red background from danger modal as it was too intense

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Provide a description what is being changed, extended, or removed.
 - [x] Link to any issue(s) this request is resolving.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Joshua Hynes, Ted Goas, or David Becher.

![Screen Shot 2021-09-21 at 10 09 38 AM](https://user-images.githubusercontent.com/73855198/134216259-6f55b75f-aa29-489c-8e61-f2416dffa9d5.png)

