### PR TITLE
Immutable input validation states

### DIFF
--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -80,7 +80,7 @@
     &:focus {
         --input--bc: var(--input--focus-bc);
 
-        box-shadow: var(--bs-focus-ring);
+        box-shadow: var(--bs-focus-ring)!important;
         outline: 0;
     }
     //  --  DISABLED / READ-ONLY
@@ -89,7 +89,7 @@
         --input--bc:           var(--black-500);
         --input--bgc:          var(--black-200);
 
-        box-shadow: none;
+        box-shadow: none!important;
 
         //  --  Placeholder copy
         &::placeholder {
@@ -201,7 +201,7 @@
     --input--focus-bc:  var(--warning-color);
 
     &:focus {
-        box-shadow: var(--bs-focus-ring-warning);
+        box-shadow: var(--bs-focus-ring-warning)!important;
     }
 }
 .d-input--error,
@@ -210,7 +210,7 @@
     --input--focus-bc:  var(--error-color);
 
     &:focus {
-        box-shadow: var(--bs-focus-ring-error);
+        box-shadow: var(--bs-focus-ring-error)!important;
     }
 }
 .d-input--success,
@@ -219,7 +219,7 @@
     --input--focus-bc:  var(--success-color);
 
     &:focus {
-        box-shadow: var(--bs-focus-ring-success);
+        box-shadow: var(--bs-focus-ring-success)!important;
     }
 }
 

--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -86,7 +86,7 @@
     //  --  DISABLED / READ-ONLY
     &[disabled],
     &[read-only] {
-        --input--bc:           var(--black-500);
+        --input--bc:           var(--black-500)!important;
         --input--bgc:          var(--black-200);
 
         box-shadow: none!important;

--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -89,7 +89,9 @@
         --input--bc:           var(--black-500)!important;
         --input--bgc:          var(--black-200);
 
-        box-shadow: none!important;
+        &:focus {
+            box-shadow: none!important;
+        }
 
         //  --  Placeholder copy
         &::placeholder {

--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -197,7 +197,7 @@
 //  ----------------------------------------------------------------------------
 .d-input--warning,
 .d-textarea--warning {
-    --input--bc:        var(--warning-color);
+    --input--bc:        var(--warning-color)!important;
     --input--focus-bc:  var(--warning-color);
 
     &:focus {
@@ -206,7 +206,7 @@
 }
 .d-input--error,
 .d-textarea--error {
-    --input--bc:        var(--error-color);
+    --input--bc:        var(--error-color)!important;
     --input--focus-bc:  var(--error-color);
 
     &:focus {
@@ -215,7 +215,7 @@
 }
 .d-input--success,
 .d-textarea--success {
-    --input--bc:        var(--success-color);
+    --input--bc:        var(--success-color)!important;
     --input--focus-bc:  var(--success-color);
 
     &:focus {


### PR DESCRIPTION
## Description
In DT5 we have the [border color of input validation states immutable](https://github.com/dialpad/dialtone/blob/v5.24.0/lib/build/less/components/inputs.less#L102). I'm updating to preserve it in DT6 as it will fix some use cases in Dialpad where they were overwriting input border color and the validation state border color wasn't applying because of the CSS specificity.

## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Provide a description what is being changed, extended, or removed.
 - [ ] Link to any issue(s) this request is resolving.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Joshua Hynes, Ted Goas, or David Becher.
