### PR TITLE
retrieve dialtone-vue version number from vue.dialpad.design

### DIFF
--- a/docs/assets/js/version.js
+++ b/docs/assets/js/version.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
   const dialtoneVueBadge = $('#dialtone-vue-badge');
 
-  $.get('http://vue.dialpad.design/version.txt')
+  $.get('https://vue.dialpad.design/version.txt')
     .done(function(response) {
       const badgeSrc = `https://img.shields.io/badge/Vue-v${response}-A687FF`
       dialtoneVueBadge.attr("src", badgeSrc)

--- a/docs/assets/js/version.js
+++ b/docs/assets/js/version.js
@@ -1,0 +1,9 @@
+$(document).ready(function() {
+  const dialtoneVueBadge = $('#dialtone-vue-badge');
+
+  $.get('http://vue.dialpad.design/version.txt')
+    .done(function(response) {
+      const badgeSrc = `https://img.shields.io/badge/Vue-v${response}-A687FF`
+      dialtoneVueBadge.attr("src", badgeSrc)
+    })
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@ lede: Documented styles, utility classes, and components to help you quickly des
           <img src="https://img.shields.io/github/package-json/v/dialpad/dialtone?color=A687FF&label=CSS" alt="Dialtone CSS version number">
         </a>
         <a class="d-td-unset" href="https://github.com/dialpad/dialtone-vue">
-          <img src="https://img.shields.io/badge/Vue-v1.0.1-A687FF" alt="Dialtone Vue version number">
+          <img id="dialtone-vue-badge" src="https://img.shields.io/badge/Vue-v0.0.0-A687FF" alt="Dialtone Vue version number">
         </a>
       </div>
       <a class="d-btn d-btn--primary d-btn--lg" href="/getting-started/installation/">Get Started</a>
@@ -45,3 +45,5 @@ lede: Documented styles, utility classes, and components to help you quickly des
     </div>
   </div>
 </section>
+
+<script src="/{{ site.paths.js }}/version.js"></script>


### PR DESCRIPTION
version file is now hosted on vue.dialpad.design which we can retrieve via http request. This change just gets the current version and populates the badge with it.

This replaces the old solution from: https://github.com/dialpad/dialtone/pull/451
