### PR TITLE
Fix input icon positions in safari

### DIFF
--- a/docs/components/input.html
+++ b/docs/components/input.html
@@ -236,20 +236,20 @@ storybook-url: https://vue.dialpad.design/?path=/story/forms-input--default
         {% codeWell %}
           {% codeWellHeader %}
             <div class="d-stack24 d-w100p">
-              <div class="d-w100p d-ps-relative">
+              <div class="d-w100p">
                 <div>
                   <label class="d-label" for="Dialtone--InputExample--IconLeft">Label</label>
                 </div>
-                <div>
+                <div class="d-ps-relative">
                   <span class="d-input-icon d-input-icon--left">{% iconSystem "send" %}</span>
                   <input class="d-input d-input-icon--left" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
                 </div>
               </div>
-              <div class="d-w100p d-ps-relative">
+              <div class="d-w100p">
                 <div>
                   <label class="d-label" for="Dialtone--InputExample--IconRight">Label</label>
                 </div>
-                <div>
+                <div class="d-ps-relative">
                   <span class="d-input-icon d-input-icon--right">{% iconSystem "lock" %}</span>
                   <input class="d-input d-input-icon--right" id="Dialtone--InputExample--IconRight" type="text" placeholder="Placeholder" />
                 </div>

--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -234,6 +234,7 @@
     --input-icon-size: @icon16;
 
     position: absolute;
+    top: 0;
     z-index:  var(--zi-base1);
     margin: 0;
     margin-top: 1.6rem;


### PR DESCRIPTION
## Description
Added `top: 0` to input icon class to correctly position the input icon in Safari

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Provide a description what is being changed, extended, or removed.
 - [x] Link to any issue(s) this request is resolving.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Joshua Hynes, Ted Goas, or David Becher.

## Screenshots

### Dialtone

#### Chrome

![Screen Shot 2021-09-28 at 3 46 37 PM](https://user-images.githubusercontent.com/73855198/135176030-f47cc308-6eba-4330-a81b-74e9d7521dda.png)


#### Safari

![Screen Shot 2021-09-28 at 3 46 52 PM](https://user-images.githubusercontent.com/73855198/135176038-a70ee378-c69a-46ba-b2cc-3e38db06807f.png)

### Dialtone Vue (Local)

#### Chrome
![Screen Shot 2021-09-28 at 3 53 36 PM](https://user-images.githubusercontent.com/73855198/135176490-a9cb2780-e80d-47f2-a17d-afeb71cddb30.png)


#### Safari
![Screen Shot 2021-09-28 at 3 53 18 PM](https://user-images.githubusercontent.com/73855198/135176499-37d04c5b-a820-423b-b089-28e5f736f02b.png)


