### PR TITLE
prepublish addition. remove extra build from CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,9 +41,6 @@ jobs:
       - name: Install dependencies
         run: npm run setup:ci
 
-      - name: Build project
-        run: npm run build
-
       - name: Deploy production
         if: ${{ github.ref == 'refs/heads/production' }}
         run: npm publish

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
         run: npm config set //registry.npmjs.org/:_authToken=${{ secrets.DIALTONE_NPM_TOKEN }}
 
       - name: Install dependencies
-        run: npm run setup:ci
+        run: npm ci
 
       - name: Deploy production
         if: ${{ github.ref == 'refs/heads/production' }}

--- a/docs/getting-started/building-locally.html
+++ b/docs/getting-started/building-locally.html
@@ -65,7 +65,7 @@ cd ./path/to/dialtone
       {% codeWell %}
         {% codeWellFooter %}
           {% highlight bash linenos %}
-    npm run setup
+    npm install
           {% endhighlight %}
         {% endcodeWellFooter %}
       {% endcodeWell%}
@@ -74,7 +74,7 @@ cd ./path/to/dialtone
   <div class="d-stack16">
     {% header "h2", "Building Dialtone" %}
     <div class="d-stack16">
-      {% paragraph %}You're now ready to build Dialtone! To build: {% endparagraph %}
+      {% paragraph %}You're now ready to build Dialtone! To build and run the development server: {% endparagraph %}
       {% codeWell %}
         {% codeWellFooter %}
           {% highlight bash linenos %}

--- a/docs/getting-started/usage.html
+++ b/docs/getting-started/usage.html
@@ -27,7 +27,7 @@ description: A general overview of Dialtone's utility classes, CSS components, a
 </section>
 <section class="d-stack16">
   {% header "h2", "Components" %}
-  {% paragraph %}There are two methods to implement Dialtone components: Vue (recommended) and CSS. Vue is the preferred method as it's more robust and readily accessible out-of-the-box. <a href="https://handset.site/" class="d-link" target="_blank">Get started with Vue components.</a>{% endparagraph %}
+  {% paragraph %}There are two methods to implement Dialtone components: Vue (recommended) and CSS. Vue is the preferred method as it's more robust and readily accessible out-of-the-box. <a href="https://vue.dialpad.design/" class="d-link" target="_blank">Get started with Vue components.</a>{% endparagraph %}
   {% paragraph %}In the event Dialtone Vue doesn't suit your needs, Dialtone's CSS library offers the same set of components. These may require more work to implement and make accessible, but will work in a pinch.{% endparagraph %}
   {% codeWell %}
     {% codeWellHeader %}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -589,10 +589,18 @@ var watchFiles = function(done) {
 //  @   EXPORT TASKS
 //  ================================================================================
 //  --  BUILD OUT THE SITE BUT DON'T START THE SERVER
+exports.svg = series(
+    cleanIcons,
+    buildSystemSVGs,
+    buildBrandSVGs,
+    buildPatternSVGs
+);
+
 exports.default = series(
     cleanSite,
     cleanFonts,
     webfonts,
+    exports.svg,
     parallel(
         libStyles,
         docStyles,
@@ -605,13 +613,6 @@ exports.watch = series(
     startServer,
     watchFiles
 )
-
-exports.svg = series(
-    cleanIcons,
-    buildSystemSVGs,
-    buildBrandSVGs,
-    buildPatternSVGs
-);
 
 //  --  CONVERT WEBFONTS
 exports.fonts = series(

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [Build]
   base = "/"
   publish = "/docs/_site/"
-  command = "npm run setup:ci && npm run build"
+  command = "npm ci && npm run build"

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "unpkg": "dist/css/dialtone.min.css",
   "scripts": {
     "setup": "npm install && gulp svg",
-    "setup:ci": "npm ci && gulp svg",
+    "setup:ci": "npm ci",
     "build": "gulp",
     "start": "gulp watch",
     "svg": "gulp svg",
     "debug": "DEBUG=Elventy* npx @11ty/eleventy --serve --input=docs",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run svg && npm run build"
   },
   "license": "MIT",
   "browserslist": [

--- a/package.json
+++ b/package.json
@@ -12,13 +12,10 @@
   },
   "unpkg": "dist/css/dialtone.min.css",
   "scripts": {
-    "setup": "npm install && gulp svg",
-    "setup:ci": "npm ci",
     "build": "gulp",
     "start": "gulp watch",
-    "svg": "gulp svg",
     "debug": "DEBUG=Elventy* npx @11ty/eleventy --serve --input=docs",
-    "prepublishOnly": "npm run svg && npm run build"
+    "prepublishOnly": "npm run build"
   },
   "license": "MIT",
   "browserslist": [


### PR DESCRIPTION
no longer need npm run build in CI as we do it as part of prepublish.

added npm run svg to prepublishOnly. npm run svg does NOT run when you execute npm run build. This was probably a big point of confusion in the manual release last night.

removed svg from setup:ci since we now run it in prepublishOnly