### PR TITLE
Improve gulp watch

### DIFF
--- a/docs/getting-started/usage.html
+++ b/docs/getting-started/usage.html
@@ -42,7 +42,7 @@ description: A general overview of Dialtone's utility classes, CSS components, a
 </section>
 <section class="d-stack16">
   {% header "h2", "Writing CSS" %}
-  {% paragraph %}In the event you need to write CSS, use <a href="http://getbem.com/" class="d-link" target="_blank">BEM (Block Element Modifier)</a>. This is a simple, common naming convention that helps make our CSS easier to read and understand. If you aren't familiar with the approach, here's a <a href="http://getbem.com/introduction/" class="d-link" target="_blank">quick synposis</a>:{% endparagraph %}
+  {% paragraph %}In the event you need to write WTF CSS, use <a href="http://getbem.com/" class="d-link" target="_blank">BEM (Block Element Modifier)</a>. This is a simple, common naming convention that helps make our CSS easier to read and understand. If you aren't familiar with the approach, here's a <a href="http://getbem.com/introduction/" class="d-link" target="_blank">quick synposis</a>:{% endparagraph %}
   {% ul %}
     <li><strong>Block:</strong> A parent entity that is meaningful on its own. For example: {% code %}.d-input{% endcode %}</li>
     <li><strong>Element:</strong> A child that is meaningful only in relation to its parent. For example: {% code %}.d-input__label{% endcode %}</li>

--- a/docs/getting-started/usage.html
+++ b/docs/getting-started/usage.html
@@ -42,7 +42,7 @@ description: A general overview of Dialtone's utility classes, CSS components, a
 </section>
 <section class="d-stack16">
   {% header "h2", "Writing CSS" %}
-  {% paragraph %}In the event you need to write WTF CSS, use <a href="http://getbem.com/" class="d-link" target="_blank">BEM (Block Element Modifier)</a>. This is a simple, common naming convention that helps make our CSS easier to read and understand. If you aren't familiar with the approach, here's a <a href="http://getbem.com/introduction/" class="d-link" target="_blank">quick synposis</a>:{% endparagraph %}
+  {% paragraph %}In the event you need to write CSS, use <a href="http://getbem.com/" class="d-link" target="_blank">BEM (Block Element Modifier)</a>. This is a simple, common naming convention that helps make our CSS easier to read and understand. If you aren't familiar with the approach, here's a <a href="http://getbem.com/introduction/" class="d-link" target="_blank">quick synposis</a>:{% endparagraph %}
   {% ul %}
     <li><strong>Block:</strong> A parent entity that is meaningful on its own. For example: {% code %}.d-input{% endcode %}</li>
     <li><strong>Element:</strong> A child that is meaningful only in relation to its parent. For example: {% code %}.d-input__label{% endcode %}</li>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,7 +137,9 @@ var paths = {
         docs: './docs/**/*',
         docsExcludeSite: '!./docs/_site/**/*',
         docsExcludeCSS: '!./docs/assets/css/**/*',
-        docsExcludeSVG: '!./docs/_includes/icons/**/*'
+        docsExcludeFonts: '!./docs/assets/fonts/**/*',
+        docsExcludeSVG: '!./docs/_includes/icons/**/*',
+        docsExcludePatterns: '!./docs/_includes/patterns/**/*'
     }
 }
 
@@ -580,7 +582,9 @@ var watchFiles = function(done) {
         paths.watch.docs,
         paths.watch.docsExcludeSite,
         paths.watch.docsExcludeCSS,
-        paths.watch.docsExcludeSVG
+        paths.watch.docsExcludeFonts,
+        paths.watch.docsExcludeSVG,
+        paths.watch.docsExcludePatterns,
     ], series(exports.default, reloadBrowser));
     done();
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4482,6 +4482,16 @@
         "gulp-help": "^1.6.1"
       }
     },
+    "gulp-cached": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gulp-cached/-/gulp-cached-1.1.1.tgz",
+      "integrity": "sha1-/nzU+H83YB5gc8/t7lwr2vi2rM4=",
+      "dev": true,
+      "requires": {
+        "lodash.defaults": "^4.2.0",
+        "through2": "^2.0.1"
+      }
+    },
     "gulp-cli": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "fs-extra": "^9.0.1",
     "gulp": "^4.0.2",
     "gulp-atoms": "^1.0.3",
+    "gulp-cached": "^1.1.1",
     "gulp-git": "^2.10.1",
     "gulp-header": "^2.0.9",
     "gulp-less": "^4.0.1",


### PR DESCRIPTION
This PR does two things:

- fixes the issue where gulp was rebuilding infinitely on change
- greatly improves watch build performance

infinite rebuild was caused by some build generated files not being excluded from the watch, so they would change on build, be detected as a new change, and it would rebuild again

greatly improved watch rebuild performance from 27 seconds to about 3-4 seconds. Did this by a number of methods:

- Implemented gulp-cached into the gulp build. Meaning it only rebuilds files that have changed rather than all of them.
- Run the eleventy --watch --incremental task to only build changed files (same kind of deal as gulp-cached but for eleventy)
- Run gulp watch and eleventy watch in parallel for improved performance.

Note that all of these improvements are on REBUILD. the initial build will still be about the same (27 sec)