### PR TITLE
Align items vertically in the d-input-icon class

### DIFF
--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -239,6 +239,8 @@
     //  ------------------------------------------------------------------------
     --input-icon-size: @icon16;
 
+    display: inline-flex;
+    align-items: center;
     position: absolute;
     top: 0;
     z-index:  var(--zi-base1);


### PR DESCRIPTION
## Description
If you want to use a smaller icon than the expected dimensions in each input size like `16x16` for the default input size, it won't be vertically centered, [example here](https://codepen.io/jokerwin/pen/VwWNzRe).

So adding `align-items: center` to `d-input-icon` class:

<img width="1066" alt="2021-10-04 at 11 19 58@2x" src="https://user-images.githubusercontent.com/83774467/135868405-6a94f678-166d-40c6-8482-f32e7cf36d39.png">

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![code review required](https://c.tenor.com/WpyHlSR7DdYAAAAC/star-trek-code-review.gif)
