### PR TITLE
Dt 169 banner component example triggers piled up

### DIFF
--- a/docs/components/banner.html
+++ b/docs/components/banner.html
@@ -41,17 +41,21 @@ storybook-url: https://vue.dialpad.design/?path=/story/elements-banner--default
   {% header "h2", "Examples" %}
   <div class="dialtone-example" data-example="yes" data-code="yes">
     <div class="dialtone-example__example">
-      <div class="d-d-flex d-ai-center d-p16 d-bgc-ash d-ba d-bc-black-100 d-flow16 d-mb8 d-bar4">
-        <div class="d-input-group d-d-flex d-fl-grow1 d-ai-center d-flow8">
-          <label for="style-select" class="d-label d-fs14 d-fl0">Style</label>
-          <div class="d-select d-select--sm d-fl1">
-            <select id="style-select" class="d-select__input js-banner-style-menu">
-              <option name="style-select" id="style-select-base" data-class="base" selected>Base</option>
-              <option name="style-select" id="style-select-error" data-class="error">Error</option>
-              <option name="style-select" id="style-select-info" data-class="info">Informational</option>
-              <option name="style-select" id="style-select-success" data-class="success">Success</option>
-              <option name="style-select" id="style-select-warning" data-class="warning">Warning</option>
-            </select>
+      <div class="d-d-flex d-ai-flex-end d-p16 d-bgc-ash d-ba d-bc-black-100 d-flow16 d-mb8 d-bar4">
+        <div class="d-fl-grow1">
+          <div>
+            <div class="d-label d-fs14">
+              <label for="style-select">Style</label>
+            </div>
+            <div class="d-select d-select--sm">
+              <select id="style-select" class="d-select__input js-banner-style-menu">
+                <option name="style-select" id="style-select-base" data-class="base" selected>Base</option>
+                <option name="style-select" id="style-select-error" data-class="error">Error</option>
+                <option name="style-select" id="style-select-info" data-class="info">Informational</option>
+                <option name="style-select" id="style-select-success" data-class="success">Success</option>
+                <option name="style-select" id="style-select-warning" data-class="warning">Warning</option>
+              </select>
+            </div>
           </div>
         </div>
         <div class="d-input-group d-d-flex d-ai-center d-fl0 d-flow6">

--- a/docs/components/banner.html
+++ b/docs/components/banner.html
@@ -66,7 +66,7 @@ storybook-url: https://vue.dialpad.design/?path=/story/elements-banner--default
           <input type="checkbox" id="style-select-pinned" class="d-checkbox d-mt1 js-banner-pinned" />
           <label for="style-select-pinned" class="d-label d-fs14 d-lh2">Pinned?</label>
         </div>
-        <div class="d-input-actions d-as-flex-end d-d-flex d-fl0 d-flow4">
+        <div class="d-input-actions d-d-flex d-fl0 d-flow4">
           <button class="d-btn d-btn--danger d-btn--sm js-style-select-remove-btn d-d-none" role="button">Remove example</button>
           <button class="d-btn d-btn--outlined d-btn--sm js-style-select-show-btn" role="button">Show example</button>
         </div>

--- a/docs/components/toast.html
+++ b/docs/components/toast.html
@@ -32,24 +32,28 @@ storybook-url: https://vue.dialpad.design/?path=/story/elements-toast--default
   {% header "h2", "Examples" %}
   <div class="dialtone-example" data-example="yes" data-code="yes">
     <div class="dialtone-example__example">
-      <div class="d-d-flex d-ai-center d-p16 d-bgc-ash d-ba d-bc-black-100 d-flow16 d-mb8 d-bar4">
-        <div class="d-input-group d-d-flex d-fl-grow1 d-ai-center d-flow8">
-          <label for="style-select" class="d-label d-fs14 d-fl0">Style</label>
-          <div class="d-select d-select--sm d-fl1">
-            <select id="style-select" class="d-select__input js-toast-style-menu">
-              <option name="style-select" id="style-select-base" data-class="base" selected>Base</option>
-              <option name="style-select" id="style-select-error" data-class="error">Error</option>
-              <option name="style-select" id="style-select-info" data-class="info">Informational</option>
-              <option name="style-select" id="style-select-success" data-class="success">Success</option>
-              <option name="style-select" id="style-select-warning" data-class="warning">Warning</option>
-            </select>
+      <div class="d-d-flex d-ai-flex-end d-p16 d-bgc-ash d-ba d-bc-black-100 d-flow16 d-mb8 d-bar4">
+        <div class="d-fl-grow1">
+          <div>
+            <div class="d-label d-fs-14">
+              <label for="style-select">Style</label>
+            </div>
+            <div class="d-select d-select--sm">
+              <select id="style-select" class="d-select__input js-toast-style-menu">
+                <option name="style-select" id="style-select-base" data-class="base" selected>Base</option>
+                <option name="style-select" id="style-select-error" data-class="error">Error</option>
+                <option name="style-select" id="style-select-info" data-class="info">Informational</option>
+                <option name="style-select" id="style-select-success" data-class="success">Success</option>
+                <option name="style-select" id="style-select-warning" data-class="warning">Warning</option>
+              </select>
+            </div>
           </div>
         </div>
         <div class="d-input-group d-d-flex d-ai-center d-fl0 d-flow6">
           <input type="checkbox" id="style-select-important" class="d-checkbox d-mt1 js-toast-important" />
           <label for="style-select-important" class="d-label d-fs14 d-lh2">Important?</label>
         </div>
-        <div class="d-input-actions d-as-flex-end d-d-flex d-fl0 d-flow4">
+        <div class="d-input-actions d-d-flex d-fl0 d-flow4">
           <button class="d-btn d-btn--danger d-btn--sm js-style-select-remove-btn d-d-none" role="button">Remove example</button>
           <button class="d-btn d-btn--outlined d-btn--sm js-style-select-show-btn" role="button">Show example</button>
         </div>


### PR DESCRIPTION
## Description
The Examples section in the Banner component, the triggers to the examples are piled up due to an incorrect usage of tags

https://switchcomm.atlassian.net/browse/DT-169?atlOrigin=eyJpIjoiZDk0YjM0ZmEwMmUyNDYxYmJhMDNlZmMwZThlNGEwZmMiLCJwIjoiaiJ9

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/NEvPzZ8bd1V4Y/giphy.gif)
