### PR TITLE
Fixed the pinned bar position after navigating

### DIFF
--- a/docs/assets/js/banner.js
+++ b/docs/assets/js/banner.js
@@ -51,6 +51,7 @@ $(document).ready(function() {
         closeBtn.removeClass('d-btn--inverted');
         link.removeClass('d-link--inverted');
         iconTypes.addClass('d-d-none');
+        dialtone5Banner.removeClass('d-d-none');
 
         if (pinned.is(':checked')) {
             banner.addClass('d-banner--pinned');
@@ -81,7 +82,6 @@ $(document).ready(function() {
             iconStyle.removeClass('d-d-none');
         }
     });
-
 
     function closeBanner() {
       var style = selectMenu.find(':selected').data('class');

--- a/docs/assets/js/nav.js
+++ b/docs/assets/js/nav.js
@@ -37,7 +37,6 @@ $(document).ready(function() {
         }, '', window.location.href),
 
         $('#nav').on('click', 'a', function (event) {
-
             // Allow opening links in new tabs
             if (event.metaKey) {
               return
@@ -87,6 +86,8 @@ $(document).ready(function() {
 
                 //  Re-initiate ScrollSpy
                 $('.js-scrollspy').scrollSpy();
+                $('.js-navigation-header').attr('style', '');
+                $('.js-dialtone5-banner').removeClass('d-d-none');
             })
         })
 


### PR DESCRIPTION
## Description
After showing a pinned banner, navigating to a new page doesn't replace the example banner with the "Dialtone 6 is here" banner. It just remains empty space.

https://switchcomm.atlassian.net/browse/DT-171

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/EDt1m8p5hqXG8/giphy.gif)
