### PR TITLE
Banner and toast example trigger - Implement responsive classes

### DIFF
--- a/docs/components/banner.html
+++ b/docs/components/banner.html
@@ -41,7 +41,7 @@ storybook-url: https://vue.dialpad.design/?path=/story/elements-banner--default
   {% header "h2", "Examples" %}
   <div class="dialtone-example" data-example="yes" data-code="yes">
     <div class="dialtone-example__example">
-      <div class="d-d-flex d-ai-flex-end d-p16 d-bgc-ash d-ba d-bc-black-100 d-flow16 d-mb8 d-bar4">
+      <div class="lg:d-fd-column lg:d-ai-stretch lg:d-stack8 lg:d-flow0 d-d-flex d-ai-flex-end d-p16 d-bgc-ash d-ba d-bc-black-100 d-flow16 d-mb8 d-bar4">
         <div class="d-fl-grow1">
           <div>
             <div class="d-label d-fs14">
@@ -66,10 +66,8 @@ storybook-url: https://vue.dialpad.design/?path=/story/elements-banner--default
           <input type="checkbox" id="style-select-pinned" class="d-checkbox d-mt1 js-banner-pinned" />
           <label for="style-select-pinned" class="d-label d-fs14 d-lh2">Pinned?</label>
         </div>
-        <div class="d-input-actions d-d-flex d-fl0 d-flow4">
-          <button class="d-btn d-btn--danger d-btn--sm js-style-select-remove-btn d-d-none" role="button">Remove example</button>
-          <button class="d-btn d-btn--outlined d-btn--sm js-style-select-show-btn" role="button">Show example</button>
-        </div>
+        <button class="d-btn d-btn--danger d-btn--sm js-style-select-remove-btn d-d-none" role="button">Remove example</button>
+        <button class="d-btn d-btn--outlined d-btn--sm js-style-select-show-btn" role="button">Show example</button>
       </div>
     </div>
     <div class="dialtone-example__code">

--- a/docs/components/toast.html
+++ b/docs/components/toast.html
@@ -32,7 +32,7 @@ storybook-url: https://vue.dialpad.design/?path=/story/elements-toast--default
   {% header "h2", "Examples" %}
   <div class="dialtone-example" data-example="yes" data-code="yes">
     <div class="dialtone-example__example">
-      <div class="d-d-flex d-ai-flex-end d-p16 d-bgc-ash d-ba d-bc-black-100 d-flow16 d-mb8 d-bar4">
+      <div class="lg:d-fd-column lg:d-ai-stretch lg:d-stack8 lg:d-flow0 d-d-flex d-ai-flex-end d-p16 d-bgc-ash d-ba d-bc-black-100 d-flow16 d-mb8 d-bar4">
         <div class="d-fl-grow1">
           <div>
             <div class="d-label d-fs-14">
@@ -53,10 +53,8 @@ storybook-url: https://vue.dialpad.design/?path=/story/elements-toast--default
           <input type="checkbox" id="style-select-important" class="d-checkbox d-mt1 js-toast-important" />
           <label for="style-select-important" class="d-label d-fs14 d-lh2">Important?</label>
         </div>
-        <div class="d-input-actions d-d-flex d-fl0 d-flow4">
-          <button class="d-btn d-btn--danger d-btn--sm js-style-select-remove-btn d-d-none" role="button">Remove example</button>
-          <button class="d-btn d-btn--outlined d-btn--sm js-style-select-show-btn" role="button">Show example</button>
-        </div>
+        <button class="d-btn d-btn--danger d-btn--sm js-style-select-remove-btn d-d-none" role="button">Remove example</button>
+        <button class="d-btn d-btn--outlined d-btn--sm js-style-select-show-btn" role="button">Show example</button>
       </div>
     </div>
     <div class="dialtone-example__code">


### PR DESCRIPTION
## Description
The banner and toast example trigger area has layout issues on both desktop and mobile.

https://switchcomm.atlassian.net/browse/DT-170
https://switchcomm.atlassian.net/browse/DT-160

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/3ohhwqtIYRUYP5CuZ2/giphy.gif)
