### PR TITLE
Updated Breakpoints documentation text to match the responsive utilities changes

### DIFF
--- a/docs/utilities/responsive/breakpoints.html
+++ b/docs/utilities/responsive/breakpoints.html
@@ -52,11 +52,11 @@ description: All utility classes have responsive variations. Using specific brea
     {% endcodeWellHeader %}
     {% codeWellFooter %}
 {% highlight html linenos %}
-<div>This is visible on all screens</div>
-<div class="d-d-none xl:d-d-block">This is visible on extra large screens</div>
-<div class="d-d-none lg:d-d-block">This is visible on large screens</div>
-<div class="d-d-none md:d-d-block">This is visible on medium screens</div>
-<div class="d-d-none sm:d-d-block">This is visible on small screens</div>
+<div>...</div>
+<div class="d-d-none xl:d-d-block">...</div>
+<div class="d-d-none lg:d-d-block">...</div>
+<div class="d-d-none md:d-d-block">...</div>
+<div class="d-d-none sm:d-d-block">...</div>
 {% endhighlight %}
     {% endcodeWellFooter %}
   {% endcodeWell %}

--- a/docs/utilities/responsive/breakpoints.html
+++ b/docs/utilities/responsive/breakpoints.html
@@ -1,11 +1,11 @@
 ---
 layout: page
 title: Breakpoints
-description: Most utility and component classes will have responsive classes. Using specific breakpoint constants, we create max-width media queries represented in conditional prefixes. These prefixed classes allow you to apply a style or property within a specific breakpoint.
+description: All utility classes have responsive variations. Using specific breakpoint constants, we create max-width media queries represented in conditional prefixes. These prefixed classes allow you to apply a style or property within a specific breakpoint.
 ---
 <section class="d-stack16">
   {% header "h2", "Classes" %}
-  {% paragraph %}To help keep prefixes concise, we use abbreviations. This syntax is used consistently across all responsive classes. As the viewport size grows, you can change an elements properties. For example, you can set an element to display normally, but be hidden at smaller sizes: {% code %}.d-block .sm:d-none{% endcode %}.{% endparagraph %}
+  {% paragraph %}To help keep prefixes concise, we use abbreviations. This syntax is used consistently across all responsive classes. As the viewport size grows, you can change an elements properties. For example, you can set an element to display normally, but be hidden at smaller sizes: {% code %}.d-d-block .sm:d-d-none{% endcode %}.{% endparagraph %}
 
   <table class="d-table">
     <thead>
@@ -52,11 +52,11 @@ description: Most utility and component classes will have responsive classes. Us
     {% endcodeWellHeader %}
     {% codeWellFooter %}
 {% highlight html linenos %}
-<div>...</div>
-<div class="d-d-none xl:d-d-block">...</div>
-<div class="d-d-none lg:d-d-block">...</div>
-<div class="d-d-none md:d-d-block">...</div>
-<div class="d-d-none sm:d-d-block">...</div>
+<div>This is visible on all screens</div>
+<div class="d-d-none xl:d-d-block">This is visible on extra large screens</div>
+<div class="d-d-none lg:d-d-block">This is visible on large screens</div>
+<div class="d-d-none md:d-d-block">This is visible on medium screens</div>
+<div class="d-d-none sm:d-d-block">This is visible on small screens</div>
 {% endhighlight %}
     {% endcodeWellFooter %}
   {% endcodeWell %}


### PR DESCRIPTION
## Description
Needed to add more details to the Dialtone responsive util class page to clarify that all classes are offered in responsive versions
https://switchcomm.atlassian.net/browse/DT-186

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/l0HlHRbXw6rnj6UlG/giphy.gif)
