### PR TITLE
fix: percentage coordinate classes in the documentation

### DIFF
--- a/docs/_data/spacing.json
+++ b/docs/_data/spacing.json
@@ -116,91 +116,106 @@
       "coordinate": "0",
       "suffix": "px",
       "negative": "no",
-      "combo": "yes"
+      "combo": "yes",
+      "value": "0px"
     },
     {
       "coordinate": "1",
       "suffix": "px",
       "negative": "yes",
-      "combo": "yes"
+      "combo": "yes",
+      "value": "1px"
     },
     {
       "coordinate": "2",
       "suffix": "px",
       "negative": "yes",
-      "combo": "yes"
+      "combo": "yes",
+      "value": "2px"
     },
     {
       "coordinate": "4",
       "suffix": "px",
       "negative": "yes",
-      "combo": "yes"
+      "combo": "yes",
+      "value": "4px"
     },
     {
       "coordinate": "6",
       "suffix": "px",
       "negative": "yes",
-      "combo": "yes"
+      "combo": "yes",
+      "value": "6px"
     },
     {
       "coordinate": "8",
       "suffix": "px",
       "negative": "yes",
-      "combo": "yes"
+      "combo": "yes",
+      "value": "8px"
     },
     {
       "coordinate": "12",
       "suffix": "px",
       "negative": "yes",
-      "combo": "yes"
+      "combo": "yes",
+      "value": "12px"
     },
     {
       "coordinate": "16",
       "suffix": "px",
       "negative": "yes",
-      "combo": "yes"
+      "combo": "yes",
+      "value": "16px"
     },
     {
       "coordinate": "24",
       "suffix": "px",
       "negative": "yes",
-      "combo": "yes"
+      "combo": "yes",
+      "value": "24px"
     },
     {
       "coordinate": "32",
       "suffix": "px",
       "negative": "yes",
-      "combo": "yes"
+      "combo": "yes",
+      "value": "32px"
     },
     {
       "coordinate": "48",
       "suffix": "px",
       "negative": "yes",
-      "combo": "yes"
+      "combo": "yes",
+      "value": "48px"
     },
     {
       "coordinate": "64",
       "suffix": "px",
       "negative": "yes",
-      "combo": "yes"
+      "combo": "yes",
+      "value": "64px"
     },
     {
-      "coordinate": "50",
+      "coordinate": "50p",
       "suffix": "%",
       "negative": "yes",
-      "combo": "no"
+      "combo": "no",
+      "value": "50%"
     },
     {
-      "coordinate": "100",
+      "coordinate": "100p",
       "suffix": "%",
       "negative": "yes",
-      "combo": "no"
+      "combo": "no",
+      "value": "100%"
     },
     {
-      "coordinate": "100",
+      "coordinate": "100p",
       "suffix": "-calc",
       "negative": "yes",
-      "combo": "no"
+      "combo": "no",
+      "value": "100-calc"
     }
   ]
 }

--- a/docs/utilities/layout/coordinates.html
+++ b/docs/utilities/layout/coordinates.html
@@ -27,8 +27,9 @@ description: Utility classes to assign an element’s top, right, bottom, or lef
                 {% assign coordinate = c.coordinate %}
                 {% assign suffix = c.suffix %}
                 {% assign combo = c.combo %}
+                {% assign value = c.value %}
                 <tr>
-                    <th scope="row">{{ coordinate }}{{ suffix }}</th>
+                    <th scope="row">{{ value }}</th>
                     {% for i in spacing.coordinate-directions %}
                     {% assign dir = i.direction %}
                     {% assign pre = i.prefix %}
@@ -142,9 +143,10 @@ description: Utility classes to assign an element’s top, right, bottom, or lef
                 {% assign suffix = c.suffix %}
                 {% assign combo = c.combo %}
                 {% assign negative = c.negative %}
+                {% assign value = c.value %}
                 <tr>
                     {% if negative != "no" %}
-                        <th scope="row">{{ coordinate }}{{ suffix }}</th>
+                        <th scope="row">{{ value }}</th>
                         {% for i in spacing.coordinate-directions %}
                         {% assign dir = i.direction %}
                         {% assign pre = i.prefix %}


### PR DESCRIPTION
## Description
In the coordinate classes, [we're appending a `p` to the class name](https://github.com/dialpad/dialtone/blob/staging/lib/build/less/utilities/layout.less#L41-L46) to denote it's a percentage value (ex: `.d-t50p`, `.d-t100p-calc`, etc). This PR fixes the [coordinate class names in the documentation](https://dialpad.design/utilities/layout/coordinates/#classes1) that are missing this `p` in the percentage classes.

Screenshot of the changes in this branch:

<img width="951" alt="2021-11-01 at 12 48 07@2x" src="https://user-images.githubusercontent.com/83774467/139700140-d7608ccb-f10d-43fc-8c8e-3e6ea8e40bf6.png">

<img width="950" alt="2021-11-01 at 12 48 19@2x" src="https://user-images.githubusercontent.com/83774467/139700160-2d56844d-e1ab-45fc-a168-ddb38387cfee.png">

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![november](https://c.tenor.com/FXAm-FkThYYAAAAC/sherlock-holmes-robert-downey-jr.gif)
