### PR TITLE
fix: remove generated classes from playstore SVG

### DIFF
--- a/lib/build/svg/brand/play-store-badge.svg
+++ b/lib/build/svg/brand/play-store-badge.svg
@@ -1,1 +1,63 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 135 40"><defs><style>.cls-1{fill:#a6a6a6;}.cls-10,.cls-2,.cls-3{fill:#fff;}.cls-2{stroke:#fff;stroke-miterlimit:10;stroke-width:0.2px;}.cls-4{fill:url(#linear-gradient);}.cls-5{fill:url(#linear-gradient-2);}.cls-6{fill:url(#linear-gradient-3);}.cls-7{fill:url(#linear-gradient-4);}.cls-8{opacity:0.2;}.cls-10,.cls-8,.cls-9{isolation:isolate;}.cls-9{opacity:0.12;}.cls-10{opacity:0.25;}</style><linearGradient id="linear-gradient" x1="21.8" y1="366.71" x2="5.02" y2="383.49" gradientTransform="translate(0 -358)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#00a0ff"/><stop offset="0.01" stop-color="#00a1ff"/><stop offset="0.26" stop-color="#00beff"/><stop offset="0.51" stop-color="#00d2ff"/><stop offset="0.76" stop-color="#00dfff"/><stop offset="1" stop-color="#00e3ff"/></linearGradient><linearGradient id="linear-gradient-2" x1="33.83" y1="378" x2="9.64" y2="378" gradientTransform="translate(0 -358)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#ffe000"/><stop offset="0.41" stop-color="#ffbd00"/><stop offset="0.78" stop-color="orange"/><stop offset="1" stop-color="#ff9c00"/></linearGradient><linearGradient id="linear-gradient-3" x1="24.83" y1="380.3" x2="2.07" y2="403.05" gradientTransform="translate(0 -358)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#ff3a44"/><stop offset="1" stop-color="#c31162"/></linearGradient><linearGradient id="linear-gradient-4" x1="7.3" y1="358.18" x2="17.46" y2="368.34" gradientTransform="translate(0 -358)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#32a071"/><stop offset="0.07" stop-color="#2da771"/><stop offset="0.48" stop-color="#15cf74"/><stop offset="0.8" stop-color="#06e775"/><stop offset="1" stop-color="#00f076"/></linearGradient></defs><title>Asset 14</title><g id="Layer_2" data-name="Layer 2"><g id="artwork"><rect width="135" height="40" rx="5" ry="5"/><path class="cls-1" d="M130,.8A4.2,4.2,0,0,1,134.2,5V35a4.2,4.2,0,0,1-4.2,4.2H5A4.2,4.2,0,0,1,.8,35h0V5A4.2,4.2,0,0,1,5,.8H130m0-.8H5A5,5,0,0,0,0,5V35a5,5,0,0,0,5,5H130a5,5,0,0,0,5-5V5A5,5,0,0,0,130,0Z"/><path class="cls-2" d="M47.42,10.24a2.71,2.71,0,0,1-.75,2,2.91,2.91,0,0,1-2.2.89,3.15,3.15,0,0,1-2.21-5.37,3,3,0,0,1,2.21-.9,3.1,3.1,0,0,1,1.23.25,2.47,2.47,0,0,1,.94.67l-.53.53a2,2,0,0,0-1.64-.71,2.32,2.32,0,0,0-2.33,2.31s0,.06,0,.09a2.36,2.36,0,0,0,4,1.73,1.89,1.89,0,0,0,.5-1.22H44.47V9.79h2.91A2.54,2.54,0,0,1,47.42,10.24Z"/><path class="cls-2" d="M52,7.74H49.3v1.9h2.46v.72H49.3v1.9H52V13H48.5V7H52Z"/><path class="cls-2" d="M55.28,13h-.77V7.74H52.83V7H57v.74H55.28Z"/><path class="cls-2" d="M59.94,13V7h.77v6Z"/><path class="cls-2" d="M64.13,13h-.77V7.74H61.68V7H65.8v.74H64.13Z"/><path class="cls-2" d="M73.61,12.22a3.12,3.12,0,0,1-4.4,0,3.24,3.24,0,0,1,0-4.45,3.1,3.1,0,0,1,4.38,0l0,0A3.23,3.23,0,0,1,73.61,12.22Zm-3.83-.5a2.31,2.31,0,0,0,3.26,0,2.56,2.56,0,0,0,0-3.44,2.31,2.31,0,0,0-3.26,0A2.56,2.56,0,0,0,69.78,11.72Z"/><path class="cls-2" d="M75.58,13V7h.94l2.92,4.67h0V7h.77v6h-.8L76.36,8.11h0V13Z"/><path class="cls-3" d="M68.14,21.75A4.25,4.25,0,1,0,72.41,26a4.19,4.19,0,0,0-4.13-4.25Zm0,6.83a2.58,2.58,0,1,1,2.39-2.75q0,.09,0,.17a2.46,2.46,0,0,1-2.34,2.58Zm-9.31-6.83A4.25,4.25,0,1,0,63.09,26,4.19,4.19,0,0,0,59,21.75h-.13Zm0,6.83a2.58,2.58,0,1,1,2.38-2.76q0,.09,0,.18a2.46,2.46,0,0,1-2.34,2.58h-.05ZM47.74,23.06v1.8h4.32a3.77,3.77,0,0,1-1,2.27,4.42,4.42,0,0,1-3.33,1.32,4.8,4.8,0,0,1,0-9.6A4.6,4.6,0,0,1,51,20.14l1.27-1.27A6.29,6.29,0,0,0,47.74,17a6.61,6.61,0,1,0-.51,13.21h.51a5.84,5.84,0,0,0,6.17-6.07,5.87,5.87,0,0,0-.1-1.13Zm45.31,1.4a3.92,3.92,0,0,0-7.65,1.28q0,.13,0,.26a4.16,4.16,0,0,0,4.07,4.25h.15a4.23,4.23,0,0,0,3.54-1.88l-1.45-1a2.43,2.43,0,0,1-2.09,1.18,2.16,2.16,0,0,1-2.06-1.29l5.69-2.35Zm-5.8,1.42a2.33,2.33,0,0,1,2.17-2.48h0a1.65,1.65,0,0,1,1.58.9ZM82.63,30H84.5V17.5H82.63Zm-3.06-7.3H79.5a3,3,0,0,0-2.24-1,4.26,4.26,0,0,0,0,8.51,2.9,2.9,0,0,0,2.24-1h.06v.61c0,1.63-.87,2.5-2.27,2.5a2.35,2.35,0,0,1-2.14-1.51l-1.63.68A4.05,4.05,0,0,0,77.29,34c2.19,0,4-1.29,4-4.43V22H79.57Zm-2.14,5.88a2.59,2.59,0,0,1,0-5.16,2.4,2.4,0,0,1,2.27,2.52V26a2.38,2.38,0,0,1-2.17,2.57h-.1ZM101.81,17.5H97.34V30h1.87V25.26h2.61a3.89,3.89,0,1,0,0-7.76Zm0,6H99.2V19.24h2.65a2.14,2.14,0,0,1,0,4.29Zm11.53-1.8A3.5,3.5,0,0,0,110,23.61l1.66.69a1.77,1.77,0,0,1,1.7-.92,1.8,1.8,0,0,1,2,1.58v.16a4.13,4.13,0,0,0-1.95-.48c-1.79,0-3.6,1-3.6,2.81a2.89,2.89,0,0,0,3,2.75h.08a2.63,2.63,0,0,0,2.4-1.2h.06v1h1.8V25.19c0-2.19-1.66-3.46-3.79-3.46Zm-.23,6.85c-.61,0-1.46-.31-1.46-1.06,0-1,1.06-1.33,2-1.33a3.32,3.32,0,0,1,1.7.42,2.26,2.26,0,0,1-2.19,2ZM123.74,22l-2.14,5.42h-.06L119.32,22h-2l3.33,7.58-1.9,4.21h1.95L125.82,22Zm-16.81,8h1.87V17.5h-1.87Z"/><path class="cls-4" d="M10.44,7.54A2,2,0,0,0,10,8.94V31.06a2,2,0,0,0,.46,1.4l.07.07L22.9,20.15v-.29L10.51,7.47Z"/><path class="cls-5" d="M27,24.28l-4.1-4.13v-.29L27,15.72l.09,0L32,18.56c1.4.79,1.4,2.09,0,2.89l-4.89,2.78Z"/><path class="cls-6" d="M27.12,24.22,22.9,20,10.44,32.46a1.63,1.63,0,0,0,2.08.06l14.61-8.3"/><path class="cls-7" d="M27.12,15.78,12.51,7.48a1.63,1.63,0,0,0-2.08.06L22.9,20Z"/><path class="cls-8" d="M27,24.13,12.51,32.38a1.67,1.67,0,0,1-2,0h0l-.07.07h0l.07.07h0a1.66,1.66,0,0,0,2,0l14.61-8.3Z"/><path class="cls-9" d="M10.44,32.32a2,2,0,0,1-.46-1.4v.15a2,2,0,0,0,.46,1.4l.07-.07Z"/><path class="cls-9" d="M32,21.3l-5,2.83.09.09L32,21.44A1.75,1.75,0,0,0,33,20h0A1.86,1.86,0,0,1,32,21.3Z"/><path class="cls-10" d="M12.51,7.62,32,18.7A1.86,1.86,0,0,1,33,20h0a1.75,1.75,0,0,0-1-1.44L12.51,7.48C11.11,6.69,10,7.35,10,8.95V9.1C10,7.49,11.12,6.83,12.51,7.62Z"/></g></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 135 40">
+  <defs>
+    <linearGradient id="linear-gradient" x1="21.8" y1="366.71" x2="5.02" y2="383.49"
+      gradientTransform="translate(0 -358)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#00a0ff" />
+      <stop offset="0.01" stop-color="#00a1ff" />
+      <stop offset="0.26" stop-color="#00beff" />
+      <stop offset="0.51" stop-color="#00d2ff" />
+      <stop offset="0.76" stop-color="#00dfff" />
+      <stop offset="1" stop-color="#00e3ff" />
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="33.83" y1="378" x2="9.64" y2="378" gradientTransform="translate(0 -358)"
+      gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ffe000" />
+      <stop offset="0.41" stop-color="#ffbd00" />
+      <stop offset="0.78" stop-color="orange" />
+      <stop offset="1" stop-color="#ff9c00" />
+    </linearGradient>
+    <linearGradient id="linear-gradient-3" x1="24.83" y1="380.3" x2="2.07" y2="403.05"
+      gradientTransform="translate(0 -358)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#ff3a44" />
+      <stop offset="1" stop-color="#c31162" />
+    </linearGradient>
+    <linearGradient id="linear-gradient-4" x1="7.3" y1="358.18" x2="17.46" y2="368.34"
+      gradientTransform="translate(0 -358)" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#32a071" />
+      <stop offset="0.07" stop-color="#2da771" />
+      <stop offset="0.48" stop-color="#15cf74" />
+      <stop offset="0.8" stop-color="#06e775" />
+      <stop offset="1" stop-color="#00f076" />
+    </linearGradient>
+  </defs>
+  <title>Asset 14</title>
+  <g id="Layer_2" data-name="Layer 2">
+    <g id="artwork">
+      <rect width="135" height="40" rx="5" ry="5" />
+      <path fill="#A6A6A6"
+        d="M130,.8A4.2,4.2,0,0,1,134.2,5V35a4.2,4.2,0,0,1-4.2,4.2H5A4.2,4.2,0,0,1,.8,35h0V5A4.2,4.2,0,0,1,5,.8H130m0-.8H5A5,5,0,0,0,0,5V35a5,5,0,0,0,5,5H130a5,5,0,0,0,5-5V5A5,5,0,0,0,130,0Z" />
+      <path fill="#FFF" stroke="#FFF" stroke-miterlimit="10" stroke-width="0.2px"
+        d="M47.42,10.24a2.71,2.71,0,0,1-.75,2,2.91,2.91,0,0,1-2.2.89,3.15,3.15,0,0,1-2.21-5.37,3,3,0,0,1,2.21-.9,3.1,3.1,0,0,1,1.23.25,2.47,2.47,0,0,1,.94.67l-.53.53a2,2,0,0,0-1.64-.71,2.32,2.32,0,0,0-2.33,2.31s0,.06,0,.09a2.36,2.36,0,0,0,4,1.73,1.89,1.89,0,0,0,.5-1.22H44.47V9.79h2.91A2.54,2.54,0,0,1,47.42,10.24Z" />
+      <path fill="#FFF" stroke="#FFF" stroke-miterlimit="10" stroke-width="0.2px" d="M52,7.74H49.3v1.9h2.46v.72H49.3v1.9H52V13H48.5V7H52Z" />
+      <path fill="#FFF" stroke="#FFF" stroke-miterlimit="10" stroke-width="0.2px" d="M55.28,13h-.77V7.74H52.83V7H57v.74H55.28Z" />
+      <path fill="#FFF" stroke="#FFF" stroke-miterlimit="10" stroke-width="0.2px" d="M59.94,13V7h.77v6Z" />
+      <path fill="#FFF" stroke="#FFF" stroke-miterlimit="10" stroke-width="0.2px" d="M64.13,13h-.77V7.74H61.68V7H65.8v.74H64.13Z" />
+      <path fill="#FFF" stroke="#FFF" stroke-miterlimit="10" stroke-width="0.2px"
+        d="M73.61,12.22a3.12,3.12,0,0,1-4.4,0,3.24,3.24,0,0,1,0-4.45,3.1,3.1,0,0,1,4.38,0l0,0A3.23,3.23,0,0,1,73.61,12.22Zm-3.83-.5a2.31,2.31,0,0,0,3.26,0,2.56,2.56,0,0,0,0-3.44,2.31,2.31,0,0,0-3.26,0A2.56,2.56,0,0,0,69.78,11.72Z" />
+      <path fill="#FFF" stroke="#FFF" stroke-miterlimit="10" stroke-width="0.2px" d="M75.58,13V7h.94l2.92,4.67h0V7h.77v6h-.8L76.36,8.11h0V13Z" />
+      <path fill="#FFF"
+        d="M68.14,21.75A4.25,4.25,0,1,0,72.41,26a4.19,4.19,0,0,0-4.13-4.25Zm0,6.83a2.58,2.58,0,1,1,2.39-2.75q0,.09,0,.17a2.46,2.46,0,0,1-2.34,2.58Zm-9.31-6.83A4.25,4.25,0,1,0,63.09,26,4.19,4.19,0,0,0,59,21.75h-.13Zm0,6.83a2.58,2.58,0,1,1,2.38-2.76q0,.09,0,.18a2.46,2.46,0,0,1-2.34,2.58h-.05ZM47.74,23.06v1.8h4.32a3.77,3.77,0,0,1-1,2.27,4.42,4.42,0,0,1-3.33,1.32,4.8,4.8,0,0,1,0-9.6A4.6,4.6,0,0,1,51,20.14l1.27-1.27A6.29,6.29,0,0,0,47.74,17a6.61,6.61,0,1,0-.51,13.21h.51a5.84,5.84,0,0,0,6.17-6.07,5.87,5.87,0,0,0-.1-1.13Zm45.31,1.4a3.92,3.92,0,0,0-7.65,1.28q0,.13,0,.26a4.16,4.16,0,0,0,4.07,4.25h.15a4.23,4.23,0,0,0,3.54-1.88l-1.45-1a2.43,2.43,0,0,1-2.09,1.18,2.16,2.16,0,0,1-2.06-1.29l5.69-2.35Zm-5.8,1.42a2.33,2.33,0,0,1,2.17-2.48h0a1.65,1.65,0,0,1,1.58.9ZM82.63,30H84.5V17.5H82.63Zm-3.06-7.3H79.5a3,3,0,0,0-2.24-1,4.26,4.26,0,0,0,0,8.51,2.9,2.9,0,0,0,2.24-1h.06v.61c0,1.63-.87,2.5-2.27,2.5a2.35,2.35,0,0,1-2.14-1.51l-1.63.68A4.05,4.05,0,0,0,77.29,34c2.19,0,4-1.29,4-4.43V22H79.57Zm-2.14,5.88a2.59,2.59,0,0,1,0-5.16,2.4,2.4,0,0,1,2.27,2.52V26a2.38,2.38,0,0,1-2.17,2.57h-.1ZM101.81,17.5H97.34V30h1.87V25.26h2.61a3.89,3.89,0,1,0,0-7.76Zm0,6H99.2V19.24h2.65a2.14,2.14,0,0,1,0,4.29Zm11.53-1.8A3.5,3.5,0,0,0,110,23.61l1.66.69a1.77,1.77,0,0,1,1.7-.92,1.8,1.8,0,0,1,2,1.58v.16a4.13,4.13,0,0,0-1.95-.48c-1.79,0-3.6,1-3.6,2.81a2.89,2.89,0,0,0,3,2.75h.08a2.63,2.63,0,0,0,2.4-1.2h.06v1h1.8V25.19c0-2.19-1.66-3.46-3.79-3.46Zm-.23,6.85c-.61,0-1.46-.31-1.46-1.06,0-1,1.06-1.33,2-1.33a3.32,3.32,0,0,1,1.7.42,2.26,2.26,0,0,1-2.19,2ZM123.74,22l-2.14,5.42h-.06L119.32,22h-2l3.33,7.58-1.9,4.21h1.95L125.82,22Zm-16.81,8h1.87V17.5h-1.87Z" />
+      <path fill="url(#linear-gradient)"
+        d="M10.44,7.54A2,2,0,0,0,10,8.94V31.06a2,2,0,0,0,.46,1.4l.07.07L22.9,20.15v-.29L10.51,7.47Z" />
+      <path fill="url(#linear-gradient-2)" d="M27,24.28l-4.1-4.13v-.29L27,15.72l.09,0L32,18.56c1.4.79,1.4,2.09,0,2.89l-4.89,2.78Z" />
+      <path fill="url(#linear-gradient-3)" d="M27.12,24.22,22.9,20,10.44,32.46a1.63,1.63,0,0,0,2.08.06l14.61-8.3" />
+      <path fill="url(#linear-gradient-4)" d="M27.12,15.78,12.51,7.48a1.63,1.63,0,0,0-2.08.06L22.9,20Z" />
+      <path opacity="0.2"
+        d="M27,24.13,12.51,32.38a1.67,1.67,0,0,1-2,0h0l-.07.07h0l.07.07h0a1.66,1.66,0,0,0,2,0l14.61-8.3Z" />
+      <path style="isolation: isolate" d="M10.44,32.32a2,2,0,0,1-.46-1.4v.15a2,2,0,0,0,.46,1.4l.07-.07Z" />
+      <path opacity="0.12" style="isolation: isolate" d="M32,21.3l-5,2.83.09.09L32,21.44A1.75,1.75,0,0,0,33,20h0A1.86,1.86,0,0,1,32,21.3Z" />
+      <path opacity="0.25" style="isolation: isolate"
+        d="M12.51,7.62,32,18.7A1.86,1.86,0,0,1,33,20h0a1.75,1.75,0,0,0-1-1.44L12.51,7.48C11.11,6.69,10,7.35,10,8.95V9.1C10,7.49,11.12,6.83,12.51,7.62Z" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Description
We should not allow generated css classes in svgs with generic names due to high chance for conflict. Removed and inlined the properties.