### PR TITLE
fix: allow highlighting within code wells on doc site

### DIFF
--- a/docs/assets/less/dialtone-syntax.less
+++ b/docs/assets/less/dialtone-syntax.less
@@ -31,18 +31,6 @@ pre[class*="language-"] {
 	hyphens: none;
 }
 
-pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
-code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
-	text-shadow: none;
-	background: inherit;
-}
-
-pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
-code[class*="language-"]::selection, code[class*="language-"] ::selection {
-	text-shadow: none;
-	background: inherit;
-}
-
 @media print {
 	code[class*="language-"],
 	pre[class*="language-"] {

--- a/docs/assets/less/dialtone-syntax.less
+++ b/docs/assets/less/dialtone-syntax.less
@@ -46,7 +46,7 @@ pre[class*="language-"] {
 
 :not(pre) > code[class*="language-"],
 pre[class*="language-"] {
-	background: inherir;
+	background: inherit;
 }
 
 /* Inline code */


### PR DESCRIPTION
## Description

Code wells were not allowing highlighting which made copying code from them rather annoying. Removed the code that did this. Not sure why this was in there in the first place, doesn't make much sense.