### PR TITLE
fix: correct icon size documentation to match implementation

### DIFF
--- a/docs/_data/icons-sizes.json
+++ b/docs/_data/icons-sizes.json
@@ -1,45 +1,47 @@
 [
   {
-    "size": "14",
+    "size": "14px",
     "variable": "@icon-size14",
     "class": "d-svg--size14"
   },
   {
-    "size": "16",
+    "size": "16px",
     "variable": "@icon-size16",
     "class": "d-svg--size16"
   },
   {
-    "size": "18",
+    "size": "18px",
     "variable": "@icon-size18",
     "class": "d-svg--size18"
   },
   {
-    "size": "20",
+    "size": "20px",
     "variable": "@icon-size20",
     "class": "d-svg--size20"
   },
   {
-    "size": "24",
+    "size": "24px",
     "variable": "@icon-size24",
     "class": "d-svg--size24"
   },
   {
-    "size": "32",
+    "size": "32px",
     "variable": "@icon-size32",
     "class": "d-svg--size32"
   },
   {
-    "size": "48",
+    "size": "48px",
     "variable": "@icon-size48",
     "class": "d-svg--size48"
   },
   {
-    "size": "64",
+    "size": "64px",
     "variable": "@icon-size64",
     "class": "d-svg--size64"
   },
   {
+    "size": "100%",
+    "variable": "N/A",
     "class": "d-svg--size100p"
   }
 ]

--- a/docs/design/icons/sizes.html
+++ b/docs/design/icons/sizes.html
@@ -1,9 +1,10 @@
 ---
 layout: page-no-toc
 title: Sizes
-description: Dialtone provides different icon sizes. By default all icons have a 100% width and an height auto to constrain aspect ratios. The size classes below can be applied <strong>either</strong> to the icon wrapper or the icon itself.
+description: Dialtone provides different icon sizes. By default all icons have a height and width of 1.5em. The size classes below can be applied <strong>either</strong> to the icon wrapper or the icon itself.
 ---
 <div class="d-stack16">
+  {% paragraph %}Note that the 100% size class sets both {% code %}width: 100%{% endcode %} and {% code %}height: auto{% endcode %} and thus has no variable.{% endparagraph %}
   <table class="d-table">
     <thead>
       <tr>
@@ -16,7 +17,7 @@ description: Dialtone provides different icon sizes. By default all icons have a
     <tbody>
       {% for size in icons-sizes %}
       <tr>
-        <th scope="row">{{ size.size }}px</th>
+        <th scope="row">{{ size.size }}</th>
         <td class="d-ff-mono d-fc-orange d-fs12">{{ size.variable }}</td>
         <td class="d-ff-mono d-fc-orange d-fs12">.{{ size.class }}</td>
         <td>


### PR DESCRIPTION
## Description
Made icon size fixes as mentioned in https://switchcomm.atlassian.net/browse/DT-197

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/3ornjZLITGcFQVRbxK/giphy.gif)
