### PR TITLE
chore: ignore jetbrains folder from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ Thumbs.db
 ######################
 .vscode
 
+# JetBrains #
+######################
+.idea
+
 # Jekyll Site #
 ###############
 # This is compiled by Github on its servers, so no need to include it.


### PR DESCRIPTION
## Description
Ignore JetBrains config folder (`.idea`) in git. We [are ignoring this in dialtone-vue](https://github.com/dialpad/dialtone-vue/blob/staging/.gitignore#L20) but not in dialtone, so adding it to those contributors who don't use VS Code (yet?).

## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
Replaced the gif section with the news from Jetbrains, they're working on a new IDE built from scratch (and no Electron, and hopefully no RAM eater 😁)
More info here: https://www.jetbrains.com/fleet/
