### PR TITLE
feat(button): add muted styles

### DIFF
--- a/docs/_data/button.json
+++ b/docs/_data/button.json
@@ -71,6 +71,11 @@
       "description": "Applies disabled style."
     },
     {
+      "class": "d-btn--muted",
+      "applies": "d-btn",
+      "description": "Applies muted style."
+    },
+    {
       "class": "d-btn__icon",
       "applies": "N/A",
       "description": "Base style for including an icon with a label."

--- a/docs/components/button.html
+++ b/docs/components/button.html
@@ -163,6 +163,28 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
       {% endcodeWell %}
     </div>
     <div class="d-stack8">
+      {% header "h3", "Muted" %}
+      {% paragraph %}The muted button style is used to communicate...{% endparagraph %}
+      {% codeWell %}
+      {% codeWellHeader %}
+      <div class="d-stack8">
+        <div>
+          <button class="d-btn d-btn--muted" type="button"><span class="d-btn__label">Place call</span></button>
+        </div>
+        <div>
+          <button class="d-btn d-btn--muted d-btn--outlined" type="button"><span class="d-btn__label">Place call</span></button>
+        </div>
+      </div>
+      {% endcodeWellHeader %}
+      {% codeWellFooter %}
+      {% highlight html linenos %}
+<button class="d-btn d-btn--muted" type="button"><span class="d-btn__label">...</span></button>
+<button class="d-btn d-btn--muted d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
+      {% endhighlight %}
+      {% endcodeWellFooter %}
+      {% endcodeWell %}
+    </div>
+    <div class="d-stack8">
       {% header "h3", "Link" %}
       {% paragraph %}Buttons can be styled as a <a href="/components/link.html">link</a> in situations for which you need the appearance of a link but behavior of a button. Using the {% code %}button{% endcode %} element provides a better accessibility experience.{% endparagraph %}
       {% codeWell %}

--- a/docs/components/button.html
+++ b/docs/components/button.html
@@ -126,7 +126,7 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
     </div>
     <div class="d-stack8">
       {% header "h3", "Muted" %}
-      {% paragraph %}The muted button style is used to communicate...{% endparagraph %}
+      {% paragraph %} The muted button style is used to communicate non-primary actions for contexts in which the base style may not work (e.g. colored backgrounds, validation components, etc). This style’s use should be rare. When in doubt, use the <a href="#base" class="d-link">base button style</a>. {% endparagraph %}
       {% codeWell %}
       {% codeWellHeader %}
       <div class="d-stack8">

--- a/docs/components/button.html
+++ b/docs/components/button.html
@@ -148,7 +148,7 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
     </div>
     <div class="d-stack8">
       {% header "h3", "Disabled" %}
-      {% paragraph %}Buttons can be disabled using either the {% code %}disabled{% endcode %} attribute or a Dialtone class. Use the attribute when a button should appear disabled and not recieve focus; use the class when a button should appear disabled but still recieve focus (i.e. a disabled button with a tooltip). Using the class also requires {% code %}aria-disabled{% endcode %} and a wrapper to disable pointer events.{% endparagraph %}
+      {% paragraph %}Buttons can be disabled using either the {% code %}disabled{% endcode %} attribute or a Dialtone class. Use the attribute when a button should appear disabled and not recieve focus; use the class when a button should appear disabled but still recieve focus (i.e. a disabled button with a tooltip). Using the class also requires {% code %}aria-disabled{% endcode %} and a wrapper to display the "not allowed" pointer. Additional javascript implementation is required to prevent the click event.{% endparagraph %}
       {% paragraph %}All button styles and variations appear the same when disabled.{% endparagraph %}
       {% codeWell %}
         {% codeWellHeader %}

--- a/docs/components/button.html
+++ b/docs/components/button.html
@@ -32,11 +32,12 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
 </section>
 <section class="d-stack16">
   {% header "h2", "Examples" %}
-  {% paragraph %}Dialtone provides three button styles: {% endparagraph %}
+  {% paragraph %}Dialtone provides four button styles: {% endparagraph %}
   {% ol %}
     <li><a href="#default" class="d-link"><strong>Base:</strong></a> Our default (purple) button colors.</li>
     <li><a href="#danger" class="d-link"><strong>Danger:</strong></a> Buttons associated with potentially destructive actions. Appears as red.</li>
     <li><a href="#inverted" class="d-link"><strong>Inverted:</strong></a> For scenarios when you want to place a button on a non-white, dark background.</li>
+    <li><a href="#muted" class="d-link"><strong>Muted:</strong></a> For non-primary actions and contexts in which the base style may not work.</li>
   {% endol %}
   {% paragraph %}Each button style offers three levels of visual important: {% endparagraph %}
   {% ol %}
@@ -124,45 +125,6 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
       {% endcodeWell %}
     </div>
     <div class="d-stack8">
-      {% header "h3", "Disabled" %}
-      {% paragraph %}Buttons can be disabled using either the {% code %}disabled{% endcode %} attribute or a Dialtone class. Use the attribute when a button should appear disabled and not recieve focus; use the class when a button should appear disabled but still recieve focus (i.e. a disabled button with a tooltip). Using the class also requires {% code %}aria-disabled{% endcode %} and additional implementation to prevent the click event.{% endparagraph %}
-      {% paragraph %}All button styles and variations appear the same when disabled.{% endparagraph %}
-      {% codeWell %}
-        {% codeWellHeader %}
-          <div class="d-stack8">
-            <div>
-              <button class="d-btn" type="button" disabled><span class="d-btn__label">Place call</span></button>
-            </div>
-            <div>
-              <button class="d-btn d-btn--disabled" type="button" aria-disabled="true"><span class="d-btn__label">Place call</span></button>
-            </div>
-          </div>
-        {% endcodeWellHeader %}
-        {% codeWellFooter %}
-          {% highlight html linenos %}
-<button class="d-btn" type="button" disabled><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--disabled" type="button" aria-disabled="true"><span class="d-btn__label">...</span></button>
-          {% endhighlight %}
-        {% endcodeWellFooter %}
-      {% endcodeWell %}
-      <h4>Cursor Styles</h4>
-      {% paragraph %}When using the {% code %}disabled{% endcode %} Dialtone button class, cursor styles must be added through a wrapper as pointer events are disabled.{% endparagraph %}
-      {% codeWell %}
-        {% codeWellHeader %}
-          <span class="d-c-not-allowed">
-            <button class="d-btn d-btn--disabled" type="button" aria-disabled="true"><span class="d-btn__label">Place call</span></button>
-          </span>
-        {% endcodeWellHeader %}
-        {% codeWellFooter %}
-          {% highlight html linenos %}
-<span class="d-c-not-allowed">
-  <button class="d-btn d-btn--disabled" type="button" aria-disabled="true"><span class="d-btn__label">...</span></button>
-</span>
-          {% endhighlight %}
-        {% endcodeWellFooter %}
-      {% endcodeWell %}
-    </div>
-    <div class="d-stack8">
       {% header "h3", "Muted" %}
       {% paragraph %}The muted button style is used to communicate...{% endparagraph %}
       {% codeWell %}
@@ -178,10 +140,37 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
       {% endcodeWellHeader %}
       {% codeWellFooter %}
       {% highlight html linenos %}
-<button class="d-btn d-btn--muted" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--muted d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
+      <button class="d-btn d-btn--muted" type="button"><span class="d-btn__label">...</span></button>
+      <button class="d-btn d-btn--muted d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
       {% endhighlight %}
       {% endcodeWellFooter %}
+      {% endcodeWell %}
+    </div>
+    <div class="d-stack8">
+      {% header "h3", "Disabled" %}
+      {% paragraph %}Buttons can be disabled using either the {% code %}disabled{% endcode %} attribute or a Dialtone class. Use the attribute when a button should appear disabled and not recieve focus; use the class when a button should appear disabled but still recieve focus (i.e. a disabled button with a tooltip). Using the class also requires {% code %}aria-disabled{% endcode %} and a wrapper to disable pointer events.{% endparagraph %}
+      {% paragraph %}All button styles and variations appear the same when disabled.{% endparagraph %}
+      {% codeWell %}
+        {% codeWellHeader %}
+          <div class="d-stack8">
+            <div>
+              <button class="d-btn" type="button" disabled><span class="d-btn__label">Place call</span></button>
+            </div>
+            <div>
+              <span class="d-c-not-allowed">
+                <button class="d-btn d-btn--disabled" type="button" aria-disabled="true"><span class="d-btn__label">Place call</span></button>
+              </span>
+            </div>
+          </div>
+        {% endcodeWellHeader %}
+        {% codeWellFooter %}
+          {% highlight html linenos %}
+<button class="d-btn" type="button" disabled><span class="d-btn__label">...</span></button>
+<span class="d-c-not-allowed">
+  <button class="d-btn d-btn--disabled" type="button" aria-disabled="true"><span class="d-btn__label">...</span></button>
+</span>
+          {% endhighlight %}
+        {% endcodeWellFooter %}
       {% endcodeWell %}
     </div>
     <div class="d-stack8">

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -260,11 +260,11 @@
 //  $$  MUTED BUTTON
 //  ----------------------------------------------------------------------------
 .d-btn--muted {
-    --button--fc: var(--black-700);
+    --button--fc: var(--muted-color);
 
     &:hover {
-      --button--fc: var(--black-800);
-      --button--bgc: hsla(var(--muted-color-hsl) ~' / ' 10%);
+      --button--fc: var(--muted-color-hover);
+      --button--bgc: hsla(var(--muted-color-hsl) ~' / ' 7.5%);
     }
 
     &:focus {

--- a/lib/build/less/variables/colors.less
+++ b/lib/build/less/variables/colors.less
@@ -92,8 +92,8 @@
     success-color-hsl:          var(--green-500-hsl);
     success-color-hover:        var(--green-600);
 
-    muted-color:                var(--black-700);
-    muted-color-hsl:            var(--black-700-hsl);
+    muted-color:                var(--black-800);
+    muted-color-hsl:            var(--black-800-hsl);
     muted-color-hover:          var(--black-800);
 
     inverted-color:             var(--black-025);
@@ -110,7 +110,7 @@
     focus-ring-success:         hsla(var(--success-color-hsl) ~' / ' 75%);
     focus-ring-warning:         hsla(var(--warning-color-hsl) ~' / ' 75%);
     focus-ring-error:           hsla(var(--error-color-hsl) ~' / ' 75%);
-    focus-ring-muted:           hsla(var(--muted-color-hsl) ~' / ' 50%);
+    focus-ring-muted:           hsla(var(--muted-color-hsl) ~' / ' 25%);
     focus-ring-inverted:        hsla(var(--inverted-color-hsl) ~' / ' 50%);
 }
 


### PR DESCRIPTION
## Description

Add muted and muted outline button styles to Dialtone. The styles already existed on Dialtone so just updated the variables and added the examples.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/VKf2GfUCYKq5GJ1VRs/giphy.gif)
