### PR TITLE
fix: add important to padding

### DIFF
--- a/lib/build/less/components/selects.less
+++ b/lib/build/less/components/selects.less
@@ -100,7 +100,7 @@
 //  ----------------------------------------------------------------------------
 .d-select__input {
   height: 100%; // Fill the height of its parent
-  padding: 0.7rem 2em 0.7rem 0.8rem;
+  padding: 0.7rem 2em 0.7rem 0.8rem !important;
   color: var(--select--fc);
   background-color: var(--select--bgc);
   border-color: var(--select--bc);


### PR DESCRIPTION
## Description

The `.d-select__input` element padding was getting overwritten with de `.d-input` element padding

https://switchcomm.atlassian.net/browse/DT-323

## Pull Request Checklist

 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/K8KtAeRA1w44E/giphy.gif)
