### PR TITLE
feat: implement focus visible

### DIFF
--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -59,10 +59,16 @@
     }
 
     &:focus {
-        outline: none;
+      outline: none;
+      box-shadow: var(--bs-focus-ring);
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
     }
 
     &:focus-visible {
+      outline: none;
       box-shadow: var(--bs-focus-ring);
     }
 
@@ -195,6 +201,14 @@
         --button--bgc: var(--black-100);
     }
 
+    &:focus {
+      box-shadow: var(--bs-focus-ring-circle);
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
+    }
+
     &:focus-visible {
         box-shadow: var(--bs-focus-ring-circle);
     }
@@ -270,6 +284,14 @@
       --button--bgc: hsla(var(--muted-color-hsl) ~' / ' 7.5%);
     }
 
+    &:focus {
+      box-shadow: var(--bs-focus-ring-muted);
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
+    }
+
     &:focus-visible {
         box-shadow: var(--bs-focus-ring-muted);
     }
@@ -287,6 +309,14 @@
     &:hover {
         --button--bgc: hsla(var(--error-color-hsl) ~' / ' 10%);
         --button--fc: var(--error-color-hover);
+    }
+
+    &:focus {
+      box-shadow: var(--bs-focus-ring-error);
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
     }
 
     &:focus-visible {
@@ -318,6 +348,14 @@
     &:hover {
         --button--fc: var(--white);
         --button--bgc: hsla(var(--white-hsl) ~' / ' 15%);
+    }
+
+    &:focus {
+      box-shadow: var(--bs-focus-ring-inverted);
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
     }
 
     &:focus-visible {
@@ -366,10 +404,18 @@
     background-color: hsl(var(--brand-color-h) var(--brand-color-s) var(--brand-color-l));
 
     &:hover,
-    &:focus-visible,
+    &:focus,
     &:active {
         color: hsla(var(--white-hsl) ~' / ' 90%);
         background-color: hsl(var(--brand-color-h) calc(var(--brand-color-s) + 2.5%) calc(var(--brand-color-l) - 5%));
+    }
+
+    &:focus {
+      box-shadow: 0 0 0 var(--su1) var(--white), 0 0 0 0.25em hsla(var(--brand-color-h) var(--brand-color-s) var(--brand-color-l) ~' / ' 90%);
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
     }
 
     &:focus-visible {

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -60,7 +60,10 @@
 
     &:focus {
         outline: none;
-        box-shadow: var(--bs-focus-ring);
+    }
+
+    &:focus-visible {
+      box-shadow: var(--bs-focus-ring);
     }
 
     &[disabled] {
@@ -192,7 +195,7 @@
         --button--bgc: var(--black-100);
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: var(--bs-focus-ring-circle);
     }
 
@@ -267,7 +270,7 @@
       --button--bgc: hsla(var(--muted-color-hsl) ~' / ' 7.5%);
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: var(--bs-focus-ring-muted);
     }
 
@@ -286,7 +289,7 @@
         --button--fc: var(--error-color-hover);
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: var(--bs-focus-ring-error);
     }
 
@@ -317,7 +320,7 @@
         --button--bgc: hsla(var(--white-hsl) ~' / ' 15%);
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: var(--bs-focus-ring-inverted);
     }
 
@@ -363,13 +366,13 @@
     background-color: hsl(var(--brand-color-h) var(--brand-color-s) var(--brand-color-l));
 
     &:hover,
-    &:focus,
+    &:focus-visible,
     &:active {
         color: hsla(var(--white-hsl) ~' / ' 90%);
         background-color: hsl(var(--brand-color-h) calc(var(--brand-color-s) + 2.5%) calc(var(--brand-color-l) - 5%));
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: 0 0 0 var(--su1) var(--white), 0 0 0 0.25em hsla(var(--brand-color-h) var(--brand-color-s) var(--brand-color-l) ~' / ' 90%);
     }
 

--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -82,6 +82,13 @@
         outline: 0;
         box-shadow: var(--bs-focus-ring) !important;
     }
+    //  --  FOCUS VISIBLE COMPATIBLE BROWSERS ONLY
+    &:focus:not(:focus-visible) {
+      --input--bc: var(--black-500);
+
+      outline: none;
+      box-shadow: none !important;
+    }
     //  --  DISABLED / READ-ONLY
     &[disabled],
     &[read-only] {

--- a/lib/build/less/components/link.less
+++ b/lib/build/less/components/link.less
@@ -50,7 +50,6 @@
       box-shadow: none;
     }
 
-
     &:focus-visible {
         border-radius: 4px;
         outline: none;

--- a/lib/build/less/components/link.less
+++ b/lib/build/less/components/link.less
@@ -40,7 +40,7 @@
         cursor: pointer;
     }
 
-    &:focus {
+    &:focus-visible {
         border-radius: 4px;
         outline: none;
         box-shadow: 0 0 0 var(--su2) var(--focus-ring);
@@ -60,7 +60,7 @@
         color: var(--fc-warning-hover);
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: 0 0 0 var(--su2) var(--focus-ring-warning);
     }
 }
@@ -74,7 +74,7 @@
         color: var(--error-color-hover);
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: 0 0 0 var(--su2) var(--focus-ring-error);
     }
 }
@@ -88,7 +88,7 @@
         color: var(--success-color-hover);
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: 0 0 0 var(--su2) var(--focus-ring-success);
     }
 }
@@ -102,7 +102,7 @@
         color: var(--muted-color-hover);
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: 0 0 0 var(--su2) var(--focus-ring-muted);
     }
 }
@@ -121,7 +121,7 @@
         cursor: not-allowed;
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: none;
     }
 }
@@ -135,7 +135,7 @@
         color: var(--inverted-color-hover);
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: 0 0 0 var(--su2) var(--focus-ring-inverted);
     }
 }
@@ -153,7 +153,7 @@
         cursor: not-allowed;
     }
 
-    &:focus {
+    &:focus-visible {
         box-shadow: none;
     }
 }

--- a/lib/build/less/components/link.less
+++ b/lib/build/less/components/link.less
@@ -40,6 +40,17 @@
         cursor: pointer;
     }
 
+    &:focus {
+      border-radius: 4px;
+      outline: none;
+      box-shadow: 0 0 0 var(--su2) var(--focus-ring);
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
+    }
+
+
     &:focus-visible {
         border-radius: 4px;
         outline: none;

--- a/lib/build/less/components/selects.less
+++ b/lib/build/less/components/selects.less
@@ -115,7 +115,13 @@
   --select--bc: var(--black-500);
 
   &:focus {
-    --input--bc: var(--black-500);
+    --select--bc: var(--primary-color);
+
+    box-shadow: var(--bs-focus-ring);
+  }
+
+  &:focus:not(:focus-visible) {
+    --select--bc: var(--black-500);
 
     box-shadow: none !important;
   }
@@ -123,7 +129,7 @@
   &:focus-visible {
     --select--bc: var(--primary-color);
 
-    box-shadow: var(--bs-focus-ring) !important;
+    box-shadow: var(--bs-focus-ring);
   }
 
   &:disabled {
@@ -151,6 +157,18 @@
 .d-select__input--success {
   --select--bc: var(--success-color);
 
+  &:focus {
+    --select--bc: var(--success-color);
+
+    box-shadow: var(--bs-focus-ring-success) !important;
+  }
+
+  &:focus:not(:focus-visible) {
+    --select--bc: var(--black-500);
+
+    box-shadow: none !important;
+  }
+
   &:focus-visible {
     --select--bc: var(--success-color);
 
@@ -161,6 +179,18 @@
 .d-select__input--error {
   --select--bc: var(--error-color);
 
+  &:focus {
+    --select--bc: var(--error-color);
+
+    box-shadow: var(--bs-focus-ring-error) !important;
+  }
+
+  &:focus:not(:focus-visible) {
+    --select--bc: var(--black-500);
+
+    box-shadow: none !important;
+  }
+
   &:focus-visible {
     --select--bc: var(--error-color);
 
@@ -170,6 +200,18 @@
 
 .d-select__input--warning {
   --select--bc: var(--warning-color);
+
+  &:focus {
+    --select--bc: var(--warning-color);
+
+    box-shadow: var(--bs-focus-ring-warning) !important;
+  }
+
+  &:focus:not(:focus-visible) {
+    --select--bc: var(--black-500);
+
+    box-shadow: none !important;
+  }
 
   &:focus-visible {
     --select--bc: var(--warning-color);

--- a/lib/build/less/components/selects.less
+++ b/lib/build/less/components/selects.less
@@ -106,8 +106,8 @@
   border-color: var(--select--bc);
   //  [1] Reset the appearance
   -webkit-appearance: none;
-      -moz-appearance: none;
-          appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 
   //  [2] Update the styles
   .d-input();
@@ -115,9 +115,15 @@
   --select--bc: var(--black-500);
 
   &:focus {
+    --input--bc: var(--black-500);
+
+    box-shadow: none !important;
+  }
+
+  &:focus-visible {
     --select--bc: var(--primary-color);
 
-    box-shadow: var(--bs-focus-ring);
+    box-shadow: var(--bs-focus-ring) !important;
   }
 
   &:disabled {
@@ -145,30 +151,30 @@
 .d-select__input--success {
   --select--bc: var(--success-color);
 
-  &:focus {
+  &:focus-visible {
     --select--bc: var(--success-color);
 
-    box-shadow: var(--bs-focus-ring-success);
+    box-shadow: var(--bs-focus-ring-success) !important;
   }
 }
 
 .d-select__input--error {
   --select--bc: var(--error-color);
 
-  &:focus {
+  &:focus-visible {
     --select--bc: var(--error-color);
 
-    box-shadow: var(--bs-focus-ring-error);
+    box-shadow: var(--bs-focus-ring-error) !important;
   }
 }
 
 .d-select__input--warning {
   --select--bc: var(--warning-color);
 
-  &:focus {
+  &:focus-visible {
     --select--bc: var(--warning-color);
 
-    box-shadow: var(--bs-focus-ring-warning);
+    box-shadow: var(--bs-focus-ring-warning) !important;
   }
 }
 

--- a/lib/build/less/components/selects.less
+++ b/lib/build/less/components/selects.less
@@ -120,18 +120,6 @@
     box-shadow: var(--bs-focus-ring);
   }
 
-  &:focus:not(:focus-visible) {
-    --select--bc: var(--black-500);
-
-    box-shadow: none !important;
-  }
-
-  &:focus-visible {
-    --select--bc: var(--primary-color);
-
-    box-shadow: var(--bs-focus-ring);
-  }
-
   &:disabled {
     color: var(--black-400);
     background: var(--black-075);
@@ -162,18 +150,6 @@
 
     box-shadow: var(--bs-focus-ring-success) !important;
   }
-
-  &:focus:not(:focus-visible) {
-    --select--bc: var(--black-500);
-
-    box-shadow: none !important;
-  }
-
-  &:focus-visible {
-    --select--bc: var(--success-color);
-
-    box-shadow: var(--bs-focus-ring-success) !important;
-  }
 }
 
 .d-select__input--error {
@@ -184,36 +160,12 @@
 
     box-shadow: var(--bs-focus-ring-error) !important;
   }
-
-  &:focus:not(:focus-visible) {
-    --select--bc: var(--black-500);
-
-    box-shadow: none !important;
-  }
-
-  &:focus-visible {
-    --select--bc: var(--error-color);
-
-    box-shadow: var(--bs-focus-ring-error) !important;
-  }
 }
 
 .d-select__input--warning {
   --select--bc: var(--warning-color);
 
   &:focus {
-    --select--bc: var(--warning-color);
-
-    box-shadow: var(--bs-focus-ring-warning) !important;
-  }
-
-  &:focus:not(:focus-visible) {
-    --select--bc: var(--black-500);
-
-    box-shadow: none !important;
-  }
-
-  &:focus-visible {
     --select--bc: var(--warning-color);
 
     box-shadow: var(--bs-focus-ring-warning) !important;

--- a/lib/build/less/components/tabs.less
+++ b/lib/build/less/components/tabs.less
@@ -82,7 +82,7 @@
         content: '';
     }
 
-    &:focus {
+    &:focus-visible {
         outline: none;
         box-shadow: 0 0 0 var(--su2) var(--tab--oc);
     }

--- a/lib/build/less/components/tabs.less
+++ b/lib/build/less/components/tabs.less
@@ -82,6 +82,15 @@
         content: '';
     }
 
+    &:focus {
+      outline: none;
+      box-shadow: 0 0 0 var(--su2) var(--tab--oc);
+    }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: none;
+    }
+
     &:focus-visible {
         outline: none;
         box-shadow: 0 0 0 var(--su2) var(--tab--oc);

--- a/lib/build/less/components/tooltip.less
+++ b/lib/build/less/components/tooltip.less
@@ -100,21 +100,8 @@
         &:extend(.d-tooltip--hide);
     }
 
-    &:focus,
+    &:focus-visible,
     &:hover {
-        .d-tooltip {
-            &:extend(.d-tooltip--show);
-        }
-    }
-
-    // Remove focus style from browsers compatible with focus-visible
-    &:focus:not(:focus-visible) {
-        .d-tooltip {
-            &:extend(.d-tooltip--hide);
-       }
-    }
-
-    &:focus-visible {
         .d-tooltip {
             &:extend(.d-tooltip--show);
         }

--- a/lib/build/less/components/tooltip.less
+++ b/lib/build/less/components/tooltip.less
@@ -100,8 +100,21 @@
         &:extend(.d-tooltip--hide);
     }
 
-    &:focus-visible,
+    &:focus,
     &:hover {
+        .d-tooltip {
+            &:extend(.d-tooltip--show);
+        }
+    }
+
+    // Remove focus style from browsers compatible with focus-visible
+    &:focus:not(:focus-visible) {
+        .d-tooltip {
+            &:extend(.d-tooltip--hide);
+       }
+    }
+
+    &:focus-visible {
         .d-tooltip {
             &:extend(.d-tooltip--show);
         }

--- a/lib/build/less/utilities/internals.less
+++ b/lib/build/less/utilities/internals.less
@@ -52,7 +52,7 @@
         --fco: 100%;
         color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--fco)) !important;
       }
-      .f\:d-fc-@{color-name}:focus-visible {
+      .fv\:d-fc-@{color-name}:focus-visible {
         --fco: 100%;
         color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--fco)) !important;
       }
@@ -73,7 +73,7 @@
         --bco: 100%;
         border-color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--bco)) !important;
       }
-      .f\:d-bc-@{color-name}:focus-visible {
+      .fv\:d-bc-@{color-name}:focus-visible {
         --bco: 100%;
         border-color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--bco)) !important;
       }
@@ -103,7 +103,7 @@
         --bgo: 100%;
         background-color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--bgo)) !important;
       }
-      .f\:d-bgc-@{color-name}:focus-visible {
+      .fv\:d-bgc-@{color-name}:focus-visible {
         --bgo: 100%;
         background-color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--bgo)) !important;
       }
@@ -153,7 +153,7 @@
       .f\:@{className}:focus-within {
         @mixin();
       }
-      .f\:@{className}:focus-visible {
+      .fv\:@{className}:focus-visible {
         @mixin();
       }
     }
@@ -176,7 +176,7 @@
       .f\:d-fco@{opacity}:focus-within {
         --fco: ~'@{opacity}%' !important;
       }
-      .f\:d-fco@{opacity}:focus-visible {
+      .fv\:d-fco@{opacity}:focus-visible {
         --fco: ~'@{opacity}%' !important;
       }
       #d-internals #dark-mode('.d\:d-fco@{opacity}', {
@@ -193,7 +193,7 @@
       .f\:d-bco@{opacity}:focus-within {
         --bco: ~'@{opacity}%' !important;
       }
-      .f\:d-bco@{opacity}:focus-visible {
+      .fv\:d-bco@{opacity}:focus-visible {
         --bco: ~'@{opacity}%' !important;
       }
       #d-internals #dark-mode('.d\:d-bco@{opacity}', {
@@ -217,7 +217,7 @@
       .f\:d-bgo@{opacity}:focus-within {
         --bgo: ~'@{opacity}%' !important;
       }
-      .f\:d-bgo@{opacity}:focus-visible {
+      .fv\:d-bgo@{opacity}:focus-visible {
         --bgo: ~'@{opacity}%' !important;
       }
       #d-internals #dark-mode('.d\:d-bgo@{opacity}', {
@@ -233,7 +233,7 @@
       .f\:d-bgg-from-@{opacity}:focus-within {
         --bgg-from-opacity: ~'@{opacity}%' !important;
       }
-      .f\:d-bgg-from-@{opacity}:focus-visible {
+      .fv\:d-bgg-from-@{opacity}:focus-visible {
         --bgg-from-opacity: ~'@{opacity}%' !important;
       }
       #d-internals #dark-mode('.d\:d-bgg-from-@{opacity}', {
@@ -249,7 +249,7 @@
       .f\:d-bgg-to-@{opacity}:focus-within {
         --bgg-to-opacity: ~'@{opacity}%' !important;
       }
-      .f\:d-bgg-to-@{opacity}:focus-visible {
+      .fv\:d-bgg-to-@{opacity}:focus-visible {
         --bgg-to-opacity: ~'@{opacity}%' !important;
       }
       #d-internals #dark-mode('.d\:d-bgg-to-@{opacity}', {
@@ -407,7 +407,7 @@
         --bgg-from: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " var(--bgg-from-opacity));
         --bgg-to: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " 0%);
       }
-      .f\:d-bgg-from-@{color}:focus-visible {
+      .fv\:d-bgg-from-@{color}:focus-visible {
         --bgg-from-opacity: 100%;
         --bgg-from: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " var(--bgg-from-opacity));
         --bgg-to: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " 0%);
@@ -429,7 +429,7 @@
         --bgg-to-opacity: 100%;
         --bgg-to: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " var(--bgg-to-opacity)) !important;
       }
-      .f\:d-bgg-to-@{color}:focus-visible {
+      .fv\:d-bgg-to-@{color}:focus-visible {
         --bgg-to-opacity: 100%;
         --bgg-to: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " var(--bgg-to-opacity)) !important;
       }

--- a/lib/build/less/utilities/internals.less
+++ b/lib/build/less/utilities/internals.less
@@ -52,6 +52,10 @@
         --fco: 100%;
         color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--fco)) !important;
       }
+      .f\:d-fc-@{color-name}:focus-visible {
+        --fco: 100%;
+        color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--fco)) !important;
+      }
       #d-internals #dark-mode('.d\:d-fc-@{color-name}', {
         --fco: 100%;
         color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--fco)) !important;
@@ -66,6 +70,10 @@
         border-color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--bco)) !important;
       }
       .f\:d-bc-@{color-name}:focus-within {
+        --bco: 100%;
+        border-color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--bco)) !important;
+      }
+      .f\:d-bc-@{color-name}:focus-visible {
         --bco: 100%;
         border-color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--bco)) !important;
       }
@@ -92,6 +100,10 @@
         background-color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--bgo)) !important;
       }
       .f\:d-bgc-@{color-name}:focus-within {
+        --bgo: 100%;
+        background-color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--bgo)) !important;
+      }
+      .f\:d-bgc-@{color-name}:focus-visible {
         --bgo: 100%;
         background-color: hsla(var(~'--@{color-name}-h') var(~'--@{color-name}-s') var(~'--@{color-name}-l') ~' / ' var(--bgo)) !important;
       }
@@ -141,6 +153,9 @@
       .f\:@{className}:focus-within {
         @mixin();
       }
+      .f\:@{className}:focus-visible {
+        @mixin();
+      }
     }
 
     //  ========================================================================
@@ -161,6 +176,9 @@
       .f\:d-fco@{opacity}:focus-within {
         --fco: ~'@{opacity}%' !important;
       }
+      .f\:d-fco@{opacity}:focus-visible {
+        --fco: ~'@{opacity}%' !important;
+      }
       #d-internals #dark-mode('.d\:d-fco@{opacity}', {
         --fco: ~'@{opacity}%' !important;
       });
@@ -173,6 +191,9 @@
         --bco: ~'@{opacity}%' !important;
       }
       .f\:d-bco@{opacity}:focus-within {
+        --bco: ~'@{opacity}%' !important;
+      }
+      .f\:d-bco@{opacity}:focus-visible {
         --bco: ~'@{opacity}%' !important;
       }
       #d-internals #dark-mode('.d\:d-bco@{opacity}', {
@@ -196,6 +217,9 @@
       .f\:d-bgo@{opacity}:focus-within {
         --bgo: ~'@{opacity}%' !important;
       }
+      .f\:d-bgo@{opacity}:focus-visible {
+        --bgo: ~'@{opacity}%' !important;
+      }
       #d-internals #dark-mode('.d\:d-bgo@{opacity}', {
         --bgo: ~'@{opacity}%' !important;
       });
@@ -209,6 +233,9 @@
       .f\:d-bgg-from-@{opacity}:focus-within {
         --bgg-from-opacity: ~'@{opacity}%' !important;
       }
+      .f\:d-bgg-from-@{opacity}:focus-visible {
+        --bgg-from-opacity: ~'@{opacity}%' !important;
+      }
       #d-internals #dark-mode('.d\:d-bgg-from-@{opacity}', {
         --bgg-from-opacity: ~'@{opacity}%' !important;
       });
@@ -220,6 +247,9 @@
         --bgg-to-opacity: ~'@{opacity}%' !important;
       }
       .f\:d-bgg-to-@{opacity}:focus-within {
+        --bgg-to-opacity: ~'@{opacity}%' !important;
+      }
+      .f\:d-bgg-to-@{opacity}:focus-visible {
         --bgg-to-opacity: ~'@{opacity}%' !important;
       }
       #d-internals #dark-mode('.d\:d-bgg-to-@{opacity}', {
@@ -377,6 +407,11 @@
         --bgg-from: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " var(--bgg-from-opacity));
         --bgg-to: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " 0%);
       }
+      .f\:d-bgg-from-@{color}:focus-visible {
+        --bgg-from-opacity: 100%;
+        --bgg-from: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " var(--bgg-from-opacity));
+        --bgg-to: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " 0%);
+      }
       #d-internals #dark-mode('.d\:d-bgg-from-@{color}', {
         --bgg-from-opacity: 100%;
         --bgg-from: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " var(--bgg-from-opacity));
@@ -391,6 +426,10 @@
         --bgg-to: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " var(--bgg-to-opacity)) !important;
       }
       .f\:d-bgg-to-@{color}:focus-within {
+        --bgg-to-opacity: 100%;
+        --bgg-to: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " var(--bgg-to-opacity)) !important;
+      }
+      .f\:d-bgg-to-@{color}:focus-visible {
         --bgg-to-opacity: 100%;
         --bgg-to: hsla(var(~"--@{color}-h") var(~"--@{color}-s") var(~"--@{color}-l") ~" / " var(--bgg-to-opacity)) !important;
       }


### PR DESCRIPTION
## Description
We need to use `:focus-visible` instead of `:focus`: to allow keyboard navigation to still use visible focus, but remove instances in which pointer interaction shows focus indication.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/f9GRIiXQJP8DpKDo1M/giphy.gif)
