### PR TITLE
fix: svg sizes showing up as NaN in svg utility class page

### DIFF
--- a/docs/_data/icons-sizes.json
+++ b/docs/_data/icons-sizes.json
@@ -1,41 +1,49 @@
 [
   {
     "size": "14px",
+    "sizeRem": "1.4rem",
     "variable": "@icon-size14",
     "class": "d-svg--size14"
   },
   {
     "size": "16px",
+    "sizeRem": "1.6rem",
     "variable": "@icon-size16",
     "class": "d-svg--size16"
   },
   {
     "size": "18px",
+    "sizeRem": "1.8rem",
     "variable": "@icon-size18",
     "class": "d-svg--size18"
   },
   {
     "size": "20px",
+    "sizeRem": "2.0rem",
     "variable": "@icon-size20",
     "class": "d-svg--size20"
   },
   {
     "size": "24px",
+    "sizeRem": "2.4rem",
     "variable": "@icon-size24",
     "class": "d-svg--size24"
   },
   {
     "size": "32px",
+    "sizeRem": "3.2rem",
     "variable": "@icon-size32",
     "class": "d-svg--size32"
   },
   {
     "size": "48px",
+    "sizeRem": "4.8rem",
     "variable": "@icon-size48",
     "class": "d-svg--size48"
   },
   {
     "size": "64px",
+    "sizeRem": "6.4rem",
     "variable": "@icon-size64",
     "class": "d-svg--size64"
   },

--- a/docs/utilities/svg/size.html
+++ b/docs/utilities/svg/size.html
@@ -19,8 +19,8 @@ description: Utilities for controlling an SVG's size.
         <tr>
           <th scope="row" class="d-ff-mono d-fc-purple d-fw-normal d-fs12">{{ size.class }}</th>
             <td class="d-ff-mono d-fc-orange d-fs12">
-              {% if size.size %}
-                width: {{ size.size | divided_by: 10 }}rem !important; height: {{ size.size | divided_by: 10 }}rem !important;
+              {% if size.sizeRem %}
+                width: {{ size.sizeRem }} !important; height: {{ size.sizeRem }} !important;
               {% elsif size.class == "d-svg--size100p" %}
                 width: 100% !important; height: auto !important;
               {% endif %}
@@ -77,5 +77,3 @@ description: Utilities for controlling an SVG's size.
     {% endcodeWellFooter %}
   {% endcodeWell %}
 </section>
-
-


### PR DESCRIPTION
Fixes bug mentioned in https://github.com/dialpad/dialtone/issues/523

When we changed icons-sizes to include px they were no longer numbers so could not be calculated. 

Just added new property for rem sizes rather than using a calculation.
