### PR TITLE
fix: responsive variations not working

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,23 @@ var settings = {
 };
 
 //  ================================================================================
+//  @@  RESPONSIVE CLASSES GENERATION
+//  ================================================================================
+//  -- BREAK POINTS
+const breakpoints = [
+  { prefix: 'sm\\:', mediaQuery: '(max-width: 480px)' },
+  { prefix: 'md\\:', mediaQuery: '(max-width: 640px)' },
+  { prefix: 'lg\\:', mediaQuery: '(max-width: 980px)' },
+  { prefix: 'xl\\:', mediaQuery: '(max-width: 1264px)' },
+];
+//  -- CLASSES
+const classes = [
+  /\.d-d-*/,
+  /\.d-mt*/,
+  /\.d-g-cols*/
+];
+
+//  ================================================================================
 //  @  PACKAGES
 //     What makes everything go
 //  ================================================================================
@@ -47,6 +64,7 @@ var gutil = settings.styles ? require('gulp-util') : null;
 var less = settings.styles ? require('gulp-less') : null;
 var sorting = settings.styles ? require('postcss-sorting') : null;
 var runSequence = settings.styles ? require('run-sequence') : null;
+var postcssResponsify = settings.styles ? require('@dialpad/postcss-responsive-variations')({breakpoints, classes}) : null;
 
 //  @@ SVGS
 var path = settings.svgs ? require('path') : null;
@@ -248,11 +266,10 @@ var libStyles = function(done) {
     return src(paths.styles.inputLib)
         //.pipe(cache('libStyles'))
         .pipe(less())
+        .pipe(postcss([ postcssResponsify ]))
         .pipe(dest(paths.styles.outputLib))
         .pipe(dest(paths.styles.outputDocs))
-        .pipe(postcss([
-            cssnano()
-        ]))
+        .pipe(postcss([ cssnano ]))
         .pipe(rename({ suffix: '.min' }))
         .pipe(dest(paths.styles.outputLib))
         .pipe(dest(paths.styles.outputDocs));
@@ -268,6 +285,7 @@ var libStylesDev = function(done) {
     return src(paths.styles.inputLib)
         // compile less to css
         .pipe(less())
+        .pipe(postcss([ postcssResponsify ]))
         // concat the css into a single file
         .pipe(concat('dialtone.css'))
         .pipe(dest(paths.styles.outputLib))

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,20 +1,3 @@
-//  ================================================================================
-//  @@  RESPONSIVE CLASSES GENERATION
-//  ================================================================================
-//  -- BREAK POINTS
-const breakpoints = [
-  { prefix: 'sm\\:', mediaQuery: '(max-width: 480px)' },
-  { prefix: 'md\\:', mediaQuery: '(max-width: 640px)' },
-  { prefix: 'lg\\:', mediaQuery: '(max-width: 980px)' },
-  { prefix: 'xl\\:', mediaQuery: '(max-width: 1264px)' },
-];
-//  -- CLASSES
-const classes = [
-  /\.d-d-*/,
-  /\.d-mt*/,
-  /\.d-g-cols*/
-];
-
 module.exports = {
     plugins: [
         //  Allows you to use Sass-like features in CSS
@@ -23,7 +6,6 @@ module.exports = {
         require('postcss-preset-env')({
             stage: 3,
         }),
-        require('@dialpad/postcss-responsive-variations')({breakpoints, classes}),
         //  Re-order the CSS declaration
         require('postcss-sorting')({
             "properties-order": [


### PR DESCRIPTION
## Description
when changing the way we created responsive classes, put the config in the wrong file I was using postscss.config.js and that file is not being used at all in dialtone

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/peaYCo9NOXQ2PcJKFC/giphy.gif)
