### PR TITLE
docs: add focus-visible documentation

### DIFF
--- a/docs/getting-started/accessibility/best-practices.html
+++ b/docs/getting-started/accessibility/best-practices.html
@@ -106,7 +106,7 @@ title: Best Practices
   <h4>Source</h4>
   {% paragraph %}<a href="https://webaim.org/techniques/skipnav/" class="d-link" target="_blank">WebAim - “Skip Navigation Links”</a>{% endparagraph %}
 </section>
-<section class="d-stack16">  
+<section class="d-stack16">
   {% header "h2", "Form best practices" %}
   {% paragraph %}Forms can be difficult, high-friction points for sighted and able users, which means if not done correctly, they can be simply unusable for users reliant on keyboard navigation or assistive technology. Users should be able to fill in forms, press buttons, use range sliders, select options, and operate controls with ease. Forms that use JavaScript to manipulate form data, set focus, change form elements, or submit forms can often create interactions that only work with a mouse. Ensure your forms can be understood and operated with the keyboard alone.{% endparagraph %}
   {% paragraph %}Labeling is also important. Input labels describe the function of a form control (i.e. checkbox, radio button, etc.) and generally appear adjacent to it. While sighted users make the connection visually, users reliant on a screen reader or other assistive technology may not. The {% code %}label{% endcode %} element programmatically associates a text label to its form control, creating a connection that doesn’t rely on vision.{% endparagraph %}
@@ -114,4 +114,38 @@ title: Best Practices
   {% paragraph %}List-based inputs, such as {% code %}select{% endcode %}, comboboxes, or custom dropdown menus can be tricky for keyboard navigation. Users should be able to navigate through the options using their arrows, not their tab key.{% endparagraph %}
   <h4>Source</h4>
   {% paragraph %}<a href="https://webaim.org/techniques/forms/controls" class="d-link" target="_blank">WebAim - “Creating Accessible Forms.”</a>{% endparagraph %}
+</section>
+<section class="d-stack16">
+  {% header "h2", "Focus vs Focus-visible" %}
+  {% paragraph %}User agents can choose their own heuristics for when to match :focus-visible; however, the following (non-normative) suggestions can be used as a starting point:{% endparagraph %}
+  {% ul %}
+    <li>If a user has expressed a preference (such as via a system preference or a browser setting) to always see a visible focus indicator, the user agent should honor this by having :focus-visible always match on the active element, regardless of any other factors. (Another option may be for the user agent to show its own focus indicator regardless of author styles.)</li>
+    <li>Any element which supports keyboard input (such as an input element, or any other element which may trigger a virtual keyboard to be shown on focus if a physical keyboard is not present) should always match :focus-visible when focused.</li>
+    <li>If the user interacts with the page via the keyboard, the currently focused element should match :focus-visible (i.e. keyboard usage may change whether this pseudo-class matches even if it doesn’t affect :focus).</li>
+    <li>If the user interacts with the page via a pointing device, such that the focus is moved to a new element which does not support user input, the newly focused element should not match :focus-visible.</li>
+    <li>If the active element matches :focus-visible, and a script causes focus to move elsewhere, the newly focused element should match :focus-visible.</li>
+    <li>Conversely, if the active element does not match :focus-visible, and a script causes focus to move elsewhere, the newly focused element should not match :focus-visible.</li>
+  {% endul %}
+
+  {% paragraph %}User agents should also use :focus-visible to specify the default focus style, so that authors using :focus-visible will not also need to disable the default :focus style.{% endparagraph %}
+
+  {% paragraph %}In general, a rule of thumb is that: if an element is going to need the keyboard (ex. inputs) that element should use <span class="d-fw-bold">focus</span>, otherwise, it should use <span class="d-fw-bold">focus-visible</span>. Here is a list of elements that use focus vs focus-visible: {% endparagraph %}
+  {% paragraph %} <span class="d-fw-bold">Focus</span> {% endparagraph %}
+  {% ul %}
+    <li>Input</li>
+    <li>Select menu</li>
+  {% endul %}
+  {% paragraph %} <span class="d-fw-bold">Focus visible</span> {% endparagraph %}
+  {% ul %}
+    <li>Button</li>
+    <li>Link</li>
+    <li>Checkbox</li>
+    <li>Radio</li>
+    <li>Dropdown menu</li>
+    <li>List item</li>
+    <li>Tab</li>
+  {% endul %}
+  <h4>Source</h4>
+  {% paragraph %}<a href="https://www.w3.org/TR/selectors-4/#the-focus-visible-pseudo" class="d-link" target="_blank">The Focus-Indicated Pseudo-class: :focus-visible</a>{% endparagraph %}
+  {% paragraph %}<a href="https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html" class="d-link" target="_blank">Understanding Success Criterion 2.4.7: Focus Visible.</a>{% endparagraph %}
 </section>

--- a/docs/getting-started/usage.html
+++ b/docs/getting-started/usage.html
@@ -59,6 +59,14 @@ description: A general overview of Dialtone's utility classes, CSS components, a
   {% endol %}
 </section>
 <section class="d-stack16">
+  {% header "h2", "Polyfills" %}
+  {% paragraph %}In order to make Dialtone work accross our supported browsers you need to manually install <span class="d-fw-bold">focus-visible</span> polyfill and <span class="d-fw-bold">postcss-focus-visible</span> plugin. {% endparagraph %}
+  {% ol %}
+  <li>Focus-visible adds a listener to every element that should be keyboard-focused only and when the element is focused, it adds the .focus-visible class to it, follow the <a href="https://github.com/WICG/focus-visible#installation" target="_blank">focus-visible</a>  installation instructions</li>
+  <li>Postcss focus-visible plugin adds a .focus-visible class for every :focus-visible class found in your css, follow the <a href="https://www.npmjs.com/package/postcss-focus-visible" target="_blank">postcss-focus-visible</a> installation instructions</li>
+  {% endol %}
+</section>
+<section class="d-stack16">
   {% header "h2", "Box-Sizing" %}
   {% paragraph %}All Dialtone components are implemented with {% code %}box-sizing: border-box;{% endcode %} applied. To understand why we prefer {% code %}border-box{% endcode %} over {% code %}content-box{% endcode %}, please visit this <a target="_blank" class="d-link" href="https://stackoverflow.com/c/dialpad/questions/121">Stack Overflow Teams question</a>.{% endparagraph %}
   {% paragraph %}In {% code %}Vue{% endcode %}, we apply {% code %}border-box{% endcode %} globally at the {% code %}VueView{% endcode %} level, ensuring all child elements use this style. As such, Dialtone styles will work correctly in Vue with respect to element sizing.{% endparagraph %}

--- a/docs/getting-started/usage.html
+++ b/docs/getting-started/usage.html
@@ -62,8 +62,8 @@ description: A general overview of Dialtone's utility classes, CSS components, a
   {% header "h2", "Polyfills" %}
   {% paragraph %}In order to make Dialtone work accross our supported browsers you need to manually install <span class="d-fw-bold">focus-visible</span> polyfill and <span class="d-fw-bold">postcss-focus-visible</span> plugin. {% endparagraph %}
   {% ol %}
-  <li>Focus-visible adds a listener to every element that should be keyboard-focused only and when the element is focused, it adds the .focus-visible class to it, follow the <a href="https://github.com/WICG/focus-visible#installation" target="_blank">focus-visible</a>  installation instructions</li>
-  <li>Postcss focus-visible plugin adds a .focus-visible class for every :focus-visible class found in your css, follow the <a href="https://www.npmjs.com/package/postcss-focus-visible" target="_blank">postcss-focus-visible</a> installation instructions</li>
+  <li>Focus-visible adds a listener to every element that should be keyboard-focused only and when the element is focused, it adds the .focus-visible class to it, follow the <a href="https://github.com/WICG/focus-visible#installation" class="d-link" target="_blank">focus-visible</a> installation instructions</li>
+  <li>Postcss focus-visible plugin adds a .focus-visible class for every :focus-visible class found in your css, follow the <a href="https://www.npmjs.com/package/postcss-focus-visible" class="d-link" target="_blank">postcss-focus-visible</a> installation instructions</li>
   {% endol %}
 </section>
 <section class="d-stack16">

--- a/docs/utilities/backgrounds/color.html
+++ b/docs/utilities/backgrounds/color.html
@@ -92,7 +92,7 @@ description: Utilities for setting background colors.
 <section class="d-stack16">
     <header class="d-stack2">
         {% header "h2", "Changing opacity" %}
-        {% paragraph %}Use {% code %}d-bgo{stop}{% endcode %} to change an element's background color opacity. You can also change the background color opacity on {% code %}:hover{% endcode %}, {% code %}:focus{% endcode %}, or in dark mode by using the respective {% code %}h:d-bgo{stop}{% endcode %}, {% code %}f:d-bgo{stop}{% endcode %}, or {% code %}d:d-bgo{stop}{% endcode %} prefix.{% endparagraph %}
+        {% paragraph %}Use {% code %}d-bgo{stop}{% endcode %} to change an element's background color opacity. You can also change the background color opacity on {% code %}:hover{% endcode %}, {% code %}:focus{% endcode %}, {% code %}:focus-visible{% endcode %}, or in dark mode by using the respective {% code %}h:d-bgo{stop}{% endcode %}, {% code %}f:d-bgo{stop}{% endcode %}, {% code %}fv:d-bgo{stop}{% endcode %}, or {% code %}d:d-bgo{stop}{% endcode %} prefixes.{% endparagraph %}
     </header>
     <aside class="d-bar8 d-of-hidden">
         <header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-green-100 d-bgo50 d-w100p d-hmn102 d-stack8">
@@ -140,19 +140,36 @@ description: Utilities for setting background colors.
 <section class="d-stack16">
     <header class="d-stack2">
         {% header "h2", "Focus" %}
-        {% paragraph %}Use {% code %}f:d-fc-{color}{% endcode %} to change an element's {% code %}:focus{% endcode %} and {% code %}:focus-within{% endcode %} state background color.{% endparagraph %}
+        {% paragraph %}Use {% code %}f:d-bgc-{color}{% endcode %} to change an element's {% code %}:focus{% endcode %} and {% code %}:focus-within{% endcode %} state background color.{% endparagraph %}
     </header>
     <aside class="d-bar8 d-of-hidden">
         <header class="d-fl-center d-p24 d-bgc-black-050 d-w100p d-hmn102">
-            <button class="d-p16 d-bar4 d-fs18 d-fc-black-800 f:d-fc-red-400 d-bgc-transparent f:d-bgc-red-400 f:d-bgo25 d-ba d-bc-transparent">Click on me</button>
+            <button class="d-p16 d-bar4 d-fs18 d-fc-black-800 d-bgc-transparent f:d-fc-red-400 f:d-bgc-red-400 f:d-bgo25 d-ba d-bc-transparent">Click on me</button>
         </header>
         <footer class="d-p8 d-bgc-black-700 d-bbr8 d-fs12">
 {% highlight html linenos %}
-<button class="d-bgc-transparent f:d-bgc-red-400 f:d-bgo25">...</button>
+<button class="d-bgc-transparent f:d-fc-red-400 f:d-bgc-red-400 f:d-bgo25">...</button>
 {% endhighlight %}
         </footer>
     </aside>
 </section>
+<section class="d-stack16">
+  <header class="d-stack2">
+    {% header "h2", "Focus visible" %}
+    {% paragraph %}Use {% code %}fv:d-bgc-{color}{% endcode %} to change an element's {% code %}:focus-visible{% endcode %} state background color [only when focused by keyboard].{% endparagraph %}
+  </header>
+  <aside class="d-bar8 d-of-hidden">
+    <header class="d-fl-center d-p24 d-bgc-black-050 d-w100p d-hmn102">
+      <button class="d-p16 d-bar4 d-fs18 d-fc-black-800 d-bgc-transparent fv:d-fc-red-400 fv:d-bgc-red-400 fv:d-bgo25 d-ba d-bc-transparent">Focus on me</button>
+    </header>
+    <footer class="d-p8 d-bgc-black-700 d-bbr8 d-fs12">
+      {% highlight html linenos %}
+      <button class="d-bgc-transparent fv:d-fc-red-400 fv:d-bgc-red-400 fv:d-bgo25">...</button>
+      {% endhighlight %}
+    </footer>
+  </aside>
+</section>
+
 <!-- <section class="d-stack16">
     <header class="d-stack2">
         {% header "h2", "Dark Mode" %}

--- a/docs/utilities/backgrounds/gradients.html
+++ b/docs/utilities/backgrounds/gradients.html
@@ -121,7 +121,7 @@ description: Utilities for creating an background gradient and controlling its s
 <section class="d-stack16">
     <header class="d-stack2">
         {% header "h2", "Changing opacities" %}
-        {% paragraph %}Use {% code %}d-bgg-from-o{n}{% endcode %} or {% code %}d-bgg-to-o{n}{% endcode %} to change the opacity values of each gradient color stop. You can also change the opacity values of each gradient color stop on {% code %}:hover{% endcode %}, {% code %}:focus{% endcode %}, {% code %}:focus-visible{% endcode %}, or in dark mode by using the respective {% code %}h:d-bgg-from-o{n}{% endcode %} or {% code %}h:d-bgg-to-o{n}{% endcode %}, {% code %}f:d-bgg-from-o{n}{% endcode %} or {% code %}f:d-bgg-to-o{n}{% endcode %}, {% code %}fv:d-bgg-from-o{n}{% endcode %} or {% code %}fv:d-bgg-to-o{n}{% endcode %}, {% code %}d:d-bgg-from-o{n}{% endcode %} or {% code %}d:d-bgg-to-o{n}{% endcode %} prefixes.{% endparagraph %}
+        {% paragraph %}Use {% code %}d-bgg-(from|to)-o{n}{% endcode %} to change the opacity values of each gradient color stop. You can also change the opacity values of each gradient color stop on {% code %}:hover{% endcode %}, {% code %}:focus{% endcode %}, {% code %}:focus-visible{% endcode %}, or in dark mode by using the respective {% code %}h:d-bgg-(from|to)-o{n}{% endcode %}, {% code %}f:d-bgg-(from|to)-o{n}{% endcode %}, {% code %}fv:d-bgg-(from|to)-o{n}{% endcode %}, {% code %}d:d-bgg-(from|to)-o{n}{% endcode %} prefixes.{% endparagraph %}
     </header>
     <aside class="d-bar8 d-of-hidden">
         <header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-black-050 d-w100p d-hmn102 d-stack8">

--- a/docs/utilities/backgrounds/gradients.html
+++ b/docs/utilities/backgrounds/gradients.html
@@ -121,7 +121,7 @@ description: Utilities for creating an background gradient and controlling its s
 <section class="d-stack16">
     <header class="d-stack2">
         {% header "h2", "Changing opacities" %}
-        {% paragraph %}Use {% code %}d-bgg-from-o{n}{% endcode %} or {% code %}d-bgg-to-o{n}{% endcode %} to change the opacity values of each gradient color stop.{% endparagraph %}
+        {% paragraph %}Use {% code %}d-bgg-from-o{n}{% endcode %} or {% code %}d-bgg-to-o{n}{% endcode %} to change the opacity values of each gradient color stop. You can also change the opacity values of each gradient color stop on {% code %}:hover{% endcode %}, {% code %}:focus{% endcode %}, {% code %}:focus-visible{% endcode %}, or in dark mode by using the respective {% code %}h:d-bgg-from-o{n}{% endcode %} or {% code %}h:d-bgg-to-o{n}{% endcode %}, {% code %}f:d-bgg-from-o{n}{% endcode %} or {% code %}f:d-bgg-to-o{n}{% endcode %}, {% code %}fv:d-bgg-from-o{n}{% endcode %} or {% code %}fv:d-bgg-to-o{n}{% endcode %}, {% code %}d:d-bgg-from-o{n}{% endcode %} or {% code %}d:d-bgg-to-o{n}{% endcode %} prefixes.{% endparagraph %}
     </header>
     <aside class="d-bar8 d-of-hidden">
         <header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-black-050 d-w100p d-hmn102 d-stack8">
@@ -181,6 +181,22 @@ description: Utilities for creating an background gradient and controlling its s
 {% endhighlight %}
         </footer>
     </aside>
+</section>
+<section class="d-stack16">
+  <header class="d-stack2">
+    {% header "h2", "Focus visible" %}
+    {% paragraph %}Use {% code %}fv:d-bgg-{from|to}-{color}{% endcode %} to change an element's background gradient starting and ending stops in {% code %}:focus-visible{% endcode %} state [only when focused by keyboard].{% endparagraph %}
+  </header>
+  <aside class="d-bar8 d-of-hidden">
+    <header class="d-fl-center d-p24 d-bgc-black-050 d-w100p d-hmn102">
+      <button class="d-p16 d-bar4 d-fs18 d-fc-white d-bgg-to-r d-bgg-from-purple-300 fv:d-bgg-from-purple-300 d-bgg-to-pink-300 fv:d-bgg-to-purple-500 d-baw0">Focus on me</button>
+    </header>
+    <footer class="d-p8 d-bgc-black-700 d-bbr8 d-fs12">
+      {% highlight html linenos %}
+      <button class="d-bgg-from-purple-300 fv:d-bgg-from-purple-300 d-bgg-to-pink-300 fv:d-bgg-to-purple-500">...</button>
+      {% endhighlight %}
+    </footer>
+  </aside>
 </section>
 <!-- <section class="d-stack16">
     <header class="d-stack2">

--- a/docs/utilities/borders/color.html
+++ b/docs/utilities/borders/color.html
@@ -92,7 +92,7 @@ description: Utilities for controlling an element's border color.
 <section class="d-stack16">
     <header class="d-stack2">
         {% header "h2", "Changing opacities" %}
-        {% paragraph %}Use {% code %}d-bco{n}{% endcode %} to change a border color opacity value.{% endparagraph %}
+        {% paragraph %}Use {% code %}d-bco{n}{% endcode %} to change the border color opacity value. You can also change the border color opacity value on {% code %}:hover{% endcode %}, {% code %}:focus{% endcode %}, {% code %}:focus-visible{% endcode %}, or in dark mode by using the respective {% code %}h:d-bco{n}{% endcode %}, {% code %}f:d-bco{n}{% endcode %}, {% code %}fv:d-bco{n}{% endcode %}, or {% code %}d:d-bco{n}{% endcode %} prefixes.{% endparagraph %}
     </header>
     <aside class="d-bar8 d-of-hidden">
         <header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-orange-100 d-bgo50 d-w100p d-hmn102 d-stack8">
@@ -152,6 +152,22 @@ description: Utilities for controlling an element's border color.
 {% endhighlight %}
         </footer>
     </aside>
+</section>
+<section class="d-stack16">
+  <header class="d-stack2">
+    {% header "h2", "Focus visible" %}
+    {% paragraph %}Use {% code %}fv:d-bc-{color}{% endcode %} to change an element's border color when in {% code %}:focus-visible{% endcode %} states [only when focused by keyboard].{% endparagraph %}
+  </header>
+  <aside class="d-bar8 d-of-hidden">
+    <header class="d-fl-center d-p24 d-bgc-red-100 d-bgo50 d-w100p d-hmn102">
+      <button class="d-p16 d-bar4 d-fs18 d-fc-white d-bgc-red-400 d-ba d-baw2 d-bc-red-500 fv:d-bc-purple-400">Focus on me</button>
+    </header>
+    <footer class="d-p8 d-bgc-black-700 d-bbr8 d-fs12">
+      {% highlight html linenos %}
+      <button class="d-ba d-baw2 d-bc-red-500 fv:d-bc-purple-400">...</button>
+      {% endhighlight %}
+    </footer>
+  </aside>
 </section>
 <!-- <section class="d-stack16">
     <header class="d-stack2">

--- a/docs/utilities/borders/color.html
+++ b/docs/utilities/borders/color.html
@@ -156,7 +156,7 @@ description: Utilities for controlling an element's border color.
 <section class="d-stack16">
   <header class="d-stack2">
     {% header "h2", "Focus visible" %}
-    {% paragraph %}Use {% code %}fv:d-bc-{color}{% endcode %} to change an element's border color when in {% code %}:focus-visible{% endcode %} states [only when focused by keyboard].{% endparagraph %}
+    {% paragraph %}Use {% code %}fv:d-bc-{color}{% endcode %} to change an element's border color when in {% code %}:focus-visible{% endcode %} state [only when focused by keyboard].{% endparagraph %}
   </header>
   <aside class="d-bar8 d-of-hidden">
     <header class="d-fl-center d-p24 d-bgc-red-100 d-bgo50 d-w100p d-hmn102">

--- a/docs/utilities/effects/box-shadow.html
+++ b/docs/utilities/effects/box-shadow.html
@@ -128,3 +128,19 @@ description: Utilities for controlling an element's box shadows.
         </footer>
     </aside>
 </section>
+<section class="d-stack16">
+  <header class="d-stack2">
+    {% header "h2", "Focus visible" %}
+    {% paragraph %}Use {% code %}fv:d-bs-{n}{% endcode %} to change an element's {% code %}:focus-visible{% endcode %} state box shadow [only when focused by keyboard].{% endparagraph %}
+  </header>
+  <aside class="d-bar8 d-of-hidden">
+    <header class="d-fl-center d-p24 d-bgc-pink-100 d-bgo50 d-w100p d-hmn102">
+      <div tabindex="0" class="d-fl-center d-p16 d-bar8 d-bgc-white d-fs18 d-fw-bold d-bs-none fv:d-bs-lg">Focus on me</div>
+    </header>
+    <footer class="d-p8 d-bgc-black-700 d-bbr8 d-fs12">
+      {% highlight html linenos %}
+      <div tabindex="0" class="d-bs-none fv:d-bs-lg">Click on me</div>
+      {% endhighlight %}
+    </footer>
+  </aside>
+</section>

--- a/docs/utilities/typography/color.html
+++ b/docs/utilities/typography/color.html
@@ -178,7 +178,7 @@ description: Utilities to change an element's font-color.
 <section class="d-stack16">
     <header class="d-stack2">
         {% header "h2", "Changing opacity" %}
-        {% paragraph %}Use {% code %}d-fco{n}{% endcode %} to change an element's text color opacity. You can also change font color opacity on {% code %}:hover{% endcode %}, {% code %}:focus{% endcode %}, {% code %}:focus-visible{% endcode %}, or in dark mode by using the respective {% code %}h:d-fco{stop}{% endcode %}, {% code %}f:d-fco{stop}{% endcode %}, {% code %}fv:d-fco{stop}{% endcode %}, or {% code %}d:d-fco{stop}{% endcode %} prefixes.{% endparagraph %}
+        {% paragraph %}Use {% code %}d-fco{n}{% endcode %} to change an element's text color opacity. You can also change font color opacity on {% code %}:hover{% endcode %}, {% code %}:focus{% endcode %}, {% code %}:focus-visible{% endcode %}, or in dark mode by using the respective {% code %}h:d-fco{n}{% endcode %}, {% code %}f:d-fco{n}{% endcode %}, {% code %}fv:d-fco{n}{% endcode %}, or {% code %}d:d-fco{n}{% endcode %} prefixes.{% endparagraph %}
     </header>
     <aside class="d-bar8 d-of-hidden">
         <header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-black-050 d-w100p d-hmn102 d-stack8">
@@ -234,7 +234,7 @@ description: Utilities to change an element's font-color.
         </header>
         <footer class="d-p8 d-bgc-black-700 d-bbr8 d-fs12">
 {% highlight html linenos %}
-<button class="d-fc-pink f:d-fc-white">...</button>
+<button class="d-fc-pink f:d-fc-white d-bgc-transparent f:d-bgc-pink-600">...</button>
 {% endhighlight %}
         </footer>
     </aside>
@@ -250,7 +250,7 @@ description: Utilities to change an element's font-color.
     </header>
     <footer class="d-p8 d-bgc-black-700 d-bbr8 d-fs12">
       {% highlight html linenos %}
-      <button class="d-fc-pink fv:d-fc-white">...</button>
+      <button class="d-fc-pink fv:d-fc-white d-bgc-transparent fv:d-bgc-pink-600">...</button>
       {% endhighlight %}
     </footer>
   </aside>

--- a/docs/utilities/typography/color.html
+++ b/docs/utilities/typography/color.html
@@ -178,7 +178,7 @@ description: Utilities to change an element's font-color.
 <section class="d-stack16">
     <header class="d-stack2">
         {% header "h2", "Changing opacity" %}
-        {% paragraph %}Use {% code %}d-fco{n}{% endcode %} to change an element's text color opacity. You can also change font color opacity on {% code %}:hover{% endcode %}, {% code %}:focus{% endcode %}, or in dark mode by using the respective {% code %}h:d-fco{stop}{% endcode %}, {% code %}f:d-fco{stop}{% endcode %}, or {% code %}d:d-fco{stop}{% endcode %} prefixes.{% endparagraph %}
+        {% paragraph %}Use {% code %}d-fco{n}{% endcode %} to change an element's text color opacity. You can also change font color opacity on {% code %}:hover{% endcode %}, {% code %}:focus{% endcode %}, {% code %}:focus-visible{% endcode %}, or in dark mode by using the respective {% code %}h:d-fco{stop}{% endcode %}, {% code %}f:d-fco{stop}{% endcode %}, {% code %}fv:d-fco{stop}{% endcode %}, or {% code %}d:d-fco{stop}{% endcode %} prefixes.{% endparagraph %}
     </header>
     <aside class="d-bar8 d-of-hidden">
         <header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-black-050 d-w100p d-hmn102 d-stack8">
@@ -238,6 +238,22 @@ description: Utilities to change an element's font-color.
 {% endhighlight %}
         </footer>
     </aside>
+</section>
+<section class="d-stack16">
+  <header class="d-stack2">
+    {% header "h2", "Focus visible" %}
+    {% paragraph %}Use {% code %}fv:d-fc-{color}{% endcode %} to change an element's text color on {% code %}:focus-visible{% endcode %} state [only when focused by keyboard].{% endparagraph %}
+  </header>
+  <aside class="d-bar8 d-of-hidden">
+    <header class="d-fl-center d-p24 d-bgc-black-050 d-w100p d-hmn102">
+      <button class="d-p16 d-bar4 d-fs18 d-fc-pink fv:d-fc-white d-bgc-transparent fv:d-bgc-pink-600 d-ba d-bc-transparent">Focus on me</button>
+    </header>
+    <footer class="d-p8 d-bgc-black-700 d-bbr8 d-fs12">
+      {% highlight html linenos %}
+      <button class="d-fc-pink fv:d-fc-white">...</button>
+      {% endhighlight %}
+    </footer>
+  </aside>
 </section>
 <!-- <section class="d-stack16">
     <header class="d-stack2">

--- a/docs/utilities/typography/text-opacity.html
+++ b/docs/utilities/typography/text-opacity.html
@@ -27,7 +27,7 @@ description: Utilities for controlling an element's font-color opacity.
 <section class="d-stack16">
     <header class="d-stack2">
         {% header "h2", "Usage" %}
-        {% paragraph %}Use {% code %}d-fco{n}{% endcode %} to change a font-color's opacity.{% endparagraph %}
+        {% paragraph %}Use {% code %}d-fco{n}{% endcode %} to change a font-color's opacity. You can also change font-color's opacity on {% code %}:hover{% endcode %}, {% code %}:focus{% endcode %}, {% code %}:focus-visible{% endcode %}, or in dark mode by using the respective {% code %}h:d-fco{n}{% endcode %}, {% code %}f:d-fco{n}{% endcode %}, {% code %}fv:d-fco{n}{% endcode %}, or {% code %}d:d-fco{n}{% endcode %} prefixes.{% endparagraph %}
     </header>
     <aside class="d-bar8 d-of-hidden">
         <header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-pink-100 d-w100p d-hmn102">


### PR DESCRIPTION
## Description
As we implemented :focus-visible, we need to add the documentation, in general:

* Speak in general terms when to use focus vs. focus-visible
* Show which components use focus and which use focus-visible
* Mention and link to the polyfill needed for implementing focus-visible

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/IlJ0FkaYggwkE/giphy.gif)
