### PR TITLE
fix(button): loading spinner off center

### DIFF
--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -431,8 +431,6 @@
     //  Show the loading animation
     &::before {
         position: absolute;
-        top: calc(50% - var(--su8));
-        left: calc(50% - var(--su8));
         width: var(--su16);
         height: var(--su16);
         border: var(--su2) solid currentColor;


### PR DESCRIPTION
## Description

Spinner icon is off center in button component. Should always align to vertical center regardless of size

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/3o6wNICDhLSfpqavzq/giphy.gif)
