### PR TITLE
chore: added lint rule to prevent setting properties to px values

### DIFF
--- a/lib/build/less/components/link.less
+++ b/lib/build/less/components/link.less
@@ -41,7 +41,7 @@
     }
 
     &:focus-visible {
-        border-radius: 4px;
+        border-radius: var(--br4);
         outline: none;
         box-shadow: 0 0 0 var(--su2) var(--focus-ring);
     }

--- a/lib/build/less/components/toast.less
+++ b/lib/build/less/components/toast.less
@@ -172,7 +172,7 @@
 
 .d-toast--organizer,
 .d-toast--viewing {
-  border-top: 4px solid var(--pink-500);
+  border-top: var(--su4) solid var(--pink-500);
 
   .d-notice__icon {
     color: var(--pink-500);

--- a/lib/build/less/dialtone-globals.less
+++ b/lib/build/less/dialtone-globals.less
@@ -21,6 +21,7 @@
 html,
 body {
     margin: var(--su0);
+    /* stylelint-disable-next-line meowtec/no-px */
     font-size: 10px; // [1]
 }
 

--- a/lib/build/less/variables/typography.less
+++ b/lib/build/less/variables/typography.less
@@ -1,3 +1,4 @@
+/* stylelint-disable meowtec/no-px */
 //
 //  DIALTONE
 //  TOKENS: TYPOGRAPHY

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "stylelint-config-recommended-less": "^1.0.1",
         "stylelint-config-standard": "^23.0.0",
         "stylelint-less": "^1.0.1",
+        "stylelint-no-px": "^1.0.1",
         "through2": "^4.0.2"
       }
     },
@@ -24903,6 +24904,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/stylelint-no-px": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-no-px/-/stylelint-no-px-1.0.1.tgz",
+      "integrity": "sha512-33+Gd5WFeSvEiOV8IwWMVgjzYieFg/Q4ETKeZkahSYl2V7+WMtgNT32IYYEspN402ZJv16bOciwEnG1GY2qrPA==",
+      "dev": true,
+      "dependencies": {
+        "postcss-value-parser": "^3.3.0 || ^4.0.2"
+      },
+      "peerDependencies": {
+        "stylelint": ">= 8"
+      }
+    },
     "node_modules/stylelint/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -46691,6 +46704,15 @@
           "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
           "dev": true
         }
+      }
+    },
+    "stylelint-no-px": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stylelint-no-px/-/stylelint-no-px-1.0.1.tgz",
+      "integrity": "sha512-33+Gd5WFeSvEiOV8IwWMVgjzYieFg/Q4ETKeZkahSYl2V7+WMtgNT32IYYEspN402ZJv16bOciwEnG1GY2qrPA==",
+      "dev": true,
+      "requires": {
+        "postcss-value-parser": "^3.3.0 || ^4.0.2"
       }
     },
     "sugarss": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "stylelint-config-recommended-less": "^1.0.1",
     "stylelint-config-standard": "^23.0.0",
     "stylelint-less": "^1.0.1",
+    "stylelint-no-px": "^1.0.1",
     "through2": "^4.0.2"
   },
   "dependencies": {

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -5,7 +5,8 @@ module.exports = {
     "stylelint-config-recommended-less"
   ],
   "plugins": [
-    "stylelint-less"
+    "stylelint-less",
+    "stylelint-no-px"
   ],
   "customSyntax": "postcss-less",
   "rules": {
@@ -37,6 +38,7 @@ module.exports = {
     indentation: null,
     'length-zero-no-unit': true,
     'less/color-no-invalid-hex': null,
-    'less/no-duplicate-variables': null
+    'less/no-duplicate-variables': null,
+    "meowtec/no-px": [true, {"message": "Use dialtone variables such as line-height: var(--lh6) or width: var(--su24) rather than directly setting px. See the lib/build/less/variables folder."}],
   }
 };


### PR DESCRIPTION
Prevent setting px values as we always want to use dialtone vars instead or at least rem.