### PR TITLE
docs(button): fix indentation in muted button code snippet

### DIFF
--- a/docs/components/button.html
+++ b/docs/components/button.html
@@ -140,8 +140,8 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
       {% endcodeWellHeader %}
       {% codeWellFooter %}
       {% highlight html linenos %}
-      <button class="d-btn d-btn--muted" type="button"><span class="d-btn__label">...</span></button>
-      <button class="d-btn d-btn--muted d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
+<button class="d-btn d-btn--muted" type="button"><span class="d-btn__label">...</span></button>
+<button class="d-btn d-btn--muted d-btn--outlined" type="button"><span class="d-btn__label">...</span></button>
       {% endhighlight %}
       {% endcodeWellFooter %}
       {% endcodeWell %}


### PR DESCRIPTION
## Description

The indentation in muted button code snippet were wrong

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/B1uajA01vvL91Urtsp/giphy.gif)
