### PR TITLE
chore: update repository URL in order to use git URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@dialpad/dialtone",
   "description": "The design system for Dialpad and UberConference",
+  "repository": "git@github.com:dialpad/dialtone.git",
   "version": "6.16.0",
   "author": "Joshua Hynes",
   "files": [
@@ -28,10 +29,6 @@
     "last 1 version",
     "maintained node versions"
   ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/dialpad/dialtone.git"
-  },
   "devDependencies": {
     "@11ty/eleventy": "^0.12.1",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.1",


### PR DESCRIPTION
## Description
Similar changes made in dialtone-vue https://github.com/dialpad/dialtone-vue/pull/184 to be able to make a release through semantic release and not having a personal token setup but having the permissions to commit.

## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [ ] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [ ] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](path/to/gif)
