### PR TITLE
refactor: rename duplicated utility class prefix .d-bgc-unset

### DIFF
--- a/docs/utilities/backgrounds/clip.html
+++ b/docs/utilities/backgrounds/clip.html
@@ -16,7 +16,7 @@ description: Utilities for controlling whether an element's background extends u
             {% assign attachment = "unset, border-box, padding-box, content-box, text" | split: ", " %}
             {% for i in attachment %}
             <tr>
-                <th scope="row" class="d-ff-mono d-fc-purple d-fw-normal d-fs12">.d-bgc-{{ i }}</th>
+                <th scope="row" class="d-ff-mono d-fc-purple d-fw-normal d-fs12">.d-bgclip-{{ i }}</th>
                 <td class="d-ff-mono d-fc-orange d-fs12">background-clip: {{ i }} !important;</td>
             </tr>
             {% endfor %}

--- a/lib/build/less/utilities/backgrounds.less
+++ b/lib/build/less/utilities/backgrounds.less
@@ -64,7 +64,7 @@
   -webkit-background-clip: text !important;
   background-clip: text !important;
 }
-.d-bgc-unset { background-clip: unset !important; }
+.d-bgclip-unset { background-clip: unset !important; }
 
 
 //  ============================================================================


### PR DESCRIPTION
## Description

background-color and background-clip utility classes in dialtone use the same prefix `d-bgc`. This also creates a direct conflict between the two unset util classes:

.d-bgc-unset	background-clip: unset !important;. 
d-bgc-unset	background-color: unset !important;

Rename d-bgc-unset -> d-bgclip-unset

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/kfjqD4W2dajtVWkYFy/giphy.gif)
