### PR TITLE
feat: dt-407 support icons above and below the labels on buttons

### DIFF
--- a/docs/_data/button.json
+++ b/docs/_data/button.json
@@ -77,8 +77,13 @@
     },
     {
       "class": "d-btn__icon",
-      "applies": "N/A",
+      "applies": "Child of <span class=\"code-example--inline\">.d-btn</span>",
       "description": "Base style for including an icon with a label."
+    },
+    {
+      "class": "d-btn--vertical",
+      "applies": "d-btn",
+      "description": "To be applied when the icon will be positioned using --top or --bottom."
     },
     {
       "class": "d-btn__icon--left",
@@ -89,6 +94,16 @@
       "class": "d-btn__icon--right",
       "applies": "d-btn__icon",
       "description": "Positions the icon to the right of the text label."
+    },
+    {
+      "class": "d-btn__icon--top",
+      "applies": "d-btn__icon",
+      "description": "Positions the icon above the text label."
+    },
+    {
+      "class": "d-btn__icon--bottom",
+      "applies": "d-btn__icon",
+      "description": "Positions the icon below the text label."
     }
   ]
 }

--- a/docs/components/button.html
+++ b/docs/components/button.html
@@ -295,7 +295,7 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
     </div>
     <div class="d-stack8">
       {% header "h3", "With Icons" %}
-      {% paragraph %}Button labels can include an icon to the left or the right of text. Every button style can accept icon classes, though we only provide a few possible examples.{% endparagraph %}
+      {% paragraph %}Button labels can include an icon next to the text. Every button style can accept icon classes, though we only provide a few possible examples.{% endparagraph %}
       {% codeWell %}
         {% codeWellHeader %}
           <div class="d-stack8">
@@ -311,6 +311,18 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
                 <span class="d-btn__label">Label</span>
               </button>
             </div>
+            <div>
+              <button class="d-btn d-btn--outlined d-btn--vertical" type="button">
+                <span class="d-btn__icon d-btn__icon--top">{% iconSystem "phone", "js-svg" %}</span>
+                <span class="d-btn__label">Label</span>
+              </button>
+            </div>
+            <div>
+              <button class="d-btn d-btn--outlined d-btn--vertical" type="button">
+                <span class="d-btn__icon d-btn__icon--bottom">{% iconSystem "phone", "js-svg" %}</span>
+                <span class="d-btn__label">Label</span>
+              </button>
+            </div>
           </div>
         {% endcodeWellHeader %}
         {% codeWellFooter %}
@@ -321,6 +333,14 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
 </button>
 <button class="d-btn d-btn--outlined" type="button">
   <span class="d-btn__icon d-btn__icon--right">...</span>
+  <span class="d-btn__label">...</span>
+</button>
+<button class="d-btn d-btn--vertical d-btn--outlined" type="button">
+  <span class="d-btn__icon d-btn__icon--top">...</span>
+  <span class="d-btn__label">...</span>
+</button>
+<button class="d-btn d-btn--vertical d-btn--outlined" type="button">
+  <span class="d-btn__icon d-btn__icon--bottom">...</span>
   <span class="d-btn__label">...</span>
 </button>
           {% endhighlight %}

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -151,9 +151,16 @@
     line-height: 0;
 }
 
-:not(.d-btn--vertical) > .d-btn__icon {
+.d-btn__icon--left,
+.d-btn__icon--right {
     margin-top: var(--sun4);
     margin-bottom: var(--sun4);
+}
+
+.d-btn__icon--top,
+.d-btn__icon--bottom {
+    margin-left: var(--sun4);
+    margin-right: var(--sun4);
 }
 
 .d-btn__icon--left,
@@ -182,6 +189,16 @@
 .d-btn__icon--right ~ .d-btn__label,
 .d-btn__label ~ .d-btn__icon--left {
     margin-right: var(--su4);
+}
+
+.d-btn__icon--top ~ .d-btn__label,
+.d-btn__label ~ .d-btn__icon--bottom {
+    margin-top: var(--su4);
+}
+
+.d-btn__icon--bottom ~ .d-btn__label,
+.d-btn__label ~ .d-btn__icon--top {
+    margin-bottom: var(--su4);
 }
 
 //  ============================================================================

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -140,20 +140,29 @@
 }
 
 //  ============================================================================
-//  $   BUTTON ICON
+//  $   BUTTON WITH ICON
 //  ----------------------------------------------------------------------------
+.d-btn--vertical {
+    flex-direction: column;
+}
+
 .d-btn__icon {
     display: flex;
-    margin-top: var(--sun4);
-    margin-bottom: var(--sun4);
     line-height: 0;
 }
 
-.d-btn__icon--left {
+:not(.d-btn--vertical) > .d-btn__icon {
+    margin-top: var(--sun4);
+    margin-bottom: var(--sun4);
+}
+
+.d-btn__icon--left,
+.d-btn__icon--top {
     order: -1;
 }
 
-.d-btn__icon--right {
+.d-btn__icon--right,
+.d-btn__icon--bottom {
     order: 1;
 }
 

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -159,8 +159,8 @@
 
 .d-btn__icon--top,
 .d-btn__icon--bottom {
-    margin-left: var(--sun4);
     margin-right: var(--sun4);
+    margin-left: var(--sun4);
 }
 
 .d-btn__icon--left,


### PR DESCRIPTION
## Description
Currently, button icons are only support to go to the left or right of the label. However, for the redesigned call bar (DP-46328), we need to support icons above the labels as well. So, I’m adding the ability to position the icons on top/bottom from the labels as well.

This will include two PRs, one in dialtone and one in dialtone-vue.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![corgi-dogs](https://user-images.githubusercontent.com/70611017/159414022-5bbc27a5-07c8-4de4-8ee2-d9880529ff61.gif)



See the screenshot below for the results:
<img width="771" alt="Screen Shot 2022-03-22 at 2 20 00 AM" src="https://user-images.githubusercontent.com/70611017/159413848-b7298993-7009-4bc2-bbe8-7d48698a8646.png">
