### PR TITLE
feat(input): support different icon sizes

### DIFF
--- a/docs/components/input.html
+++ b/docs/components/input.html
@@ -422,7 +422,7 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-input--default
                 </div>
                 <div class="d-input__wrapper">
                   <span class="d-input-icon d-input-icon--left d-input--sm d-input-icon--lg">{% iconSystem "send" %}</span>
-                  <input class="d-input d-input-icon--left d-input--sm" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+                  <input class="d-input d-input-icon--left d-input--sm" id="Dialtone--InputExample--IconLeft-sm-lg" type="text" placeholder="Placeholder" />
                 </div>
               </div>
               <div class="d-w100p">
@@ -431,7 +431,7 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-input--default
                 </div>
                 <div class="d-input__wrapper">
                   <span class="d-input-icon d-input-icon--left d-input-icon--xl">{% iconSystem "send" %}</span>
-                  <input class="d-input d-input-icon--left" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+                  <input class="d-input d-input-icon--left" id="Dialtone--InputExample--IconLeft-md-xl" type="text" placeholder="Placeholder" />
                 </div>
               </div>
               <div class="d-w100p">
@@ -440,7 +440,7 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-input--default
                 </div>
                 <div class="d-input__wrapper">
                   <span class="d-input-icon d-input-icon--left d-input--xl">{% iconSystem "send" %}</span>
-                  <input class="d-input d-input-icon--left d-input--xl" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+                  <input class="d-input d-input-icon--left d-input--xl" id="Dialtone--InputExample--IconLeft-xl-md" type="text" placeholder="Placeholder" />
                 </div>
               </div>
               <div class="d-w100p">
@@ -449,7 +449,7 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-input--default
                 </div>
                 <div class="d-input__wrapper">
                   <span class="d-input-icon d-input-icon--left d-input--lg">{% iconSystem "send" %}</span>
-                  <textarea class="d-textarea d-input-icon--left d-textarea--lg" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder"></textarea>
+                  <textarea class="d-textarea d-input-icon--left d-textarea--lg" id="Dialtone--TextareaExample--IconLeft-lg-md" type="text" placeholder="Placeholder"></textarea>
                 </div>
               </div>
             </div>
@@ -460,22 +460,22 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-input--default
 <div class="d-input__wrapper">
   <!-- note you must put the d-input--sm class on the icon element as well as the input -->
   <span class="d-input-icon d-input-icon--left d-input--sm d-input-icon--lg">{% iconSystem "send" %}</span>
-  <input class="d-input d-input-icon--left d-input--sm" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+  <input class="d-input d-input-icon--left d-input--sm" id="Dialtone--InputExample--IconLeft-sm-lg" type="text" placeholder="Placeholder" />
 </div>
 <label class="d-label" for="Dialtone--InputExample--IconLeft">Input:md(default), Icon:xl</label>
 <div class="d-input__wrapper">
   <span class="d-input-icon d-input-icon--left d-input-icon--xl">{% iconSystem "send" %}</span>
-  <input class="d-input d-input-icon--left" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+  <input class="d-input d-input-icon--left" id="Dialtone--InputExample--IconLeft-md-xl" type="text" placeholder="Placeholder" />
 </div>
 <label class="d-label" for="Dialtone--InputExample--IconLeft">Input:xl Icon:md(default)</label>
 <div class="d-input__wrapper">
   <span class="d-input-icon d-input-icon--left d-input--xl">{% iconSystem "send" %}</span>
-  <input class="d-input d-input-icon--left d-input--xl" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+  <input class="d-input d-input-icon--left d-input--xl" id="Dialtone--InputExample--IconLeft-xl-md" type="text" placeholder="Placeholder" />
 </div>
 <label class="d-label" for="Dialtone--InputExample--IconLeft">Textarea:lg Icon:md(default)</label>
 <div class="d-input__wrapper">
   <span class="d-input-icon d-input-icon--left d-input--lg">{% iconSystem "send" %}</span>
-  <textarea class="d-textarea d-input-icon--left d-textarea--lg" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder"></textarea>
+  <textarea class="d-textarea d-input-icon--left d-textarea--lg" id="Dialtone--TextareaExample--IconLeft-lg-md" type="text" placeholder="Placeholder"></textarea>
 </div>
             {% endhighlight %}
           {% endcodeWellFooter %}

--- a/docs/components/input.html
+++ b/docs/components/input.html
@@ -304,7 +304,7 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-input--default
       </div>
     </div>
     <div class="d-stack8">
-      {% header "h3", "Sizes" %}
+      {% header "h3", "Input Sizes" %}
       {% paragraph %}We offer different sizes for instances in which the interface requires a smaller or larger input. In general, though, use the base (medium) size input as much as possible, especially in forms.{% endparagraph %}
       <div class="d-stack16">
         {% codeWell %}
@@ -409,6 +409,77 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-input--default
         {% endcodeWell %}
       </div>
     </div>
+    <div class="d-stack8">
+      {% header "h3", "Icon Sizes" %}
+      {% paragraph %}You may use different icon sizes in different sized inputs{% endparagraph %}
+      <div class="d-stack16">
+        {% codeWell %}
+          {% codeWellHeader %}
+            <div class="d-stack24 d-w100p">
+              <div class="d-w100p">
+                <div>
+                  <label class="d-label" for="Dialtone--InputExample--IconLeft">Input:sm Icon:lg</label>
+                </div>
+                <div class="d-input__wrapper">
+                  <span class="d-input-icon d-input-icon--left d-input--sm d-input-icon--lg">{% iconSystem "send" %}</span>
+                  <input class="d-input d-input-icon--left d-input--sm" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+                </div>
+              </div>
+              <div class="d-w100p">
+                <div>
+                  <label class="d-label" for="Dialtone--InputExample--IconLeft">Input:md(default), Icon:xl</label>
+                </div>
+                <div class="d-input__wrapper">
+                  <span class="d-input-icon d-input-icon--left d-input-icon--xl">{% iconSystem "send" %}</span>
+                  <input class="d-input d-input-icon--left" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+                </div>
+              </div>
+              <div class="d-w100p">
+                <div>
+                  <label class="d-label" for="Dialtone--InputExample--IconLeft">Input:xl Icon:md(default)</label>
+                </div>
+                <div class="d-input__wrapper">
+                  <span class="d-input-icon d-input-icon--left d-input--xl">{% iconSystem "send" %}</span>
+                  <input class="d-input d-input-icon--left d-input--xl" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+                </div>
+              </div>
+              <div class="d-w100p">
+                <div>
+                  <label class="d-label" for="Dialtone--InputExample--IconLeft">Textarea:lg Icon:md(default)</label>
+                </div>
+                <div class="d-input__wrapper">
+                  <span class="d-input-icon d-input-icon--left d-input--lg">{% iconSystem "send" %}</span>
+                  <textarea class="d-textarea d-input-icon--left d-textarea--lg" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder"></textarea>
+                </div>
+              </div>
+            </div>
+          {% endcodeWellHeader %}
+          {% codeWellFooter %}
+            {% highlight html linenos %}
+<label class="d-label" for="Dialtone--InputExample--IconLeft">Input:sm Icon:lg</label>
+<div class="d-input__wrapper">
+  <!-- note you must put the d-input--sm class on the icon element as well as the input -->
+  <span class="d-input-icon d-input-icon--left d-input--sm d-input-icon--lg">{% iconSystem "send" %}</span>
+  <input class="d-input d-input-icon--left d-input--sm" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+</div>
+<label class="d-label" for="Dialtone--InputExample--IconLeft">Input:md(default), Icon:xl</label>
+<div class="d-input__wrapper">
+  <span class="d-input-icon d-input-icon--left d-input-icon--xl">{% iconSystem "send" %}</span>
+  <input class="d-input d-input-icon--left" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+</div>
+<label class="d-label" for="Dialtone--InputExample--IconLeft">Input:xl Icon:md(default)</label>
+<div class="d-input__wrapper">
+  <span class="d-input-icon d-input-icon--left d-input--xl">{% iconSystem "send" %}</span>
+  <input class="d-input d-input-icon--left d-input--xl" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder" />
+</div>
+<label class="d-label" for="Dialtone--InputExample--IconLeft">Textarea:lg Icon:md(default)</label>
+<div class="d-input__wrapper">
+  <span class="d-input-icon d-input-icon--left d-input--lg">{% iconSystem "send" %}</span>
+  <textarea class="d-textarea d-input-icon--left d-textarea--lg" id="Dialtone--InputExample--IconLeft" type="text" placeholder="Placeholder"></textarea>
+</div>
+            {% endhighlight %}
+          {% endcodeWellFooter %}
+        {% endcodeWell %}
   </div>
 </section>
 <section class="d-stack16">

--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -112,7 +112,7 @@
 
 //  $$  SIZES
 //  ----------------------------------------------------------------------------
-.d-input--xs {
+.d-input.d-input--xs {
     .input-button-xs();
 
     &.d-input-icon--right {
@@ -124,7 +124,7 @@
     }
 }
 
-.d-input--sm {
+.d-input.d-input--sm {
     .input-button-sm();
 
     &.d-input-icon--right {
@@ -136,7 +136,7 @@
     }
 }
 
-.d-input--lg {
+.d-input.d-input--lg {
     .input-button-lg();
 
     &.d-input-icon--right {
@@ -148,7 +148,7 @@
     }
 }
 
-.d-input--xl {
+.d-input.d-input--xl {
     .input-button-xl();
 
     &.d-input-icon--right {
@@ -268,14 +268,11 @@
     --input-icon-size: @icon16;
 
     position: absolute;
-    top: 0;
     z-index: var(--zi-base1);
     display: inline-flex;
     align-items: center;
-    width: var(--input-icon-size);
-    height: var(--input-icon-size);
+    height: 3.6rem;
     margin: 0;
-    margin-top: 1rem;
     line-height: 0;
 
     svg {
@@ -285,38 +282,33 @@
 
     &.d-input-icon--left {
         left: var(--su8);
+        // Update padding for d-input if d-input-icon--left is present
+        & ~ .d-input,
+        & ~ .d-textarea {
+            padding-left: @inputs-icon-spacing;
+        }
     }
 
     &.d-input-icon--right {
         right: var(--su8);
+
+        // Update padding for d-input if d-input-icon--right is present
+        & ~ .d-input {
+            padding-right: @inputs-icon-spacing;
+        }
     }
 }
 
-// For backwards compatibility purposes only.
-// be used instead of this.
-.d-input-icon--left {
-    // Update padding for d-input if d-input-icon--right is present
-    & ~ .d-input,
-    & ~ .d-textarea {
-        padding-left: @inputs-icon-spacing;
-    }
-}
 
-// For backwards compatibility purposes only.
-// be used instead of this.
-.d-input-icon--right {
-    // Update padding for d-input if d-input-icon--right is present
-    & ~ .d-input {
-        padding-right: @inputs-icon-spacing;
-    }
-}
 
 //  $$ SIZES
 //  ----------------------------------------------------------------------------
+.d-input-icon.d-input--xs {
+    height: 2.8rem;
+}
+
 .d-input-icon--xs {
     --input-icon-size: @icon12;
-
-    margin-top: 0.8rem;
 
     // For backwards compatibility purposes only.
     // Update padding for d-input, d-textarea if d-input-icon--left is present
@@ -332,10 +324,12 @@
     }
 }
 
+.d-input-icon.d-input--sm {
+    height: 3.2rem;
+}
+
 .d-input-icon--sm {
     --input-icon-size: @icon14;
-
-    margin-top: 0.9rem;
 
     // For backwards compatibility purposes only.
     // Update padding for d-input, d-textarea if d-input-icon--left is present
@@ -351,10 +345,12 @@
     }
 }
 
+.d-input-icon.d-input--lg {
+    height: 4.8rem;
+}
+
 .d-input-icon--lg {
     --input-icon-size: @icon20;
-
-    margin-top: 1.4rem;
 
     // For backwards compatibility purposes only.
     // Update padding for d-input, d-textarea if d-input-icon--left is present
@@ -370,10 +366,12 @@
     }
 }
 
+.d-input-icon.d-input--xl {
+    height: 5.6rem;
+}
+
 .d-input-icon--xl {
     --input-icon-size: @icon24;
-
-    margin-top: 1.6rem;
 
     // For backwards compatibility purposes only.
     // Update padding for d-input, d-textarea if d-input-icon--left is present


### PR DESCRIPTION
## Description
https://dialpad.atlassian.net/browse/DT-359

Prior to this change setting an input icon size to anything other than the default would cause strange behaviour with alignment and centering. Updated to properly center using flexbox rather than fixed padding values. We still have to set the icon height to the height of the input for a couple reasons:

1. There's no such thing as a previous sibling selector, so we have no way of dynamically matching the icon height to the input.
2. When it's a textarea we must set the height to the height of one row, rather than the height of the entire input.

The input size class will now need to be put on the icon element in addition to the input itself (if anything other than default)

Added some new documentation examples to the input page to show how to use different sized icons.

This will require a small update to dialtone-vue as well.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.