### PR TITLE
fix: badge alignment (min-width and vertical alignment)

### DIFF
--- a/lib/build/less/components/badge.less
+++ b/lib/build/less/components/badge.less
@@ -19,11 +19,13 @@
   --badge--bgc: var(--black-050);
 
   display: inline-block;
-  padding: var(--su2) var(--su6) var(--su1);
+  min-width: calc(var(--su6) + var(--su1));
+  padding: calc(var(--su6) / 4) var(--su6);
   color: var(--badge--fc);
   font-weight: bold;
   font-size: var(--fs10);
   line-height: var(--lh6);
+  text-align: center;
   text-transform: uppercase;
   background-color: var(--badge--bgc);
   border-radius: var(--su4);


### PR DESCRIPTION
## Description
Set a min width so single-digit badges have the same width (19px). Also fixed the vertical alignment to have the same spacing in top and bottom as defined in the figma spec.

<img width="1583" alt="CleanShot 2022-04-05 at 19 38 11@2x" src="https://user-images.githubusercontent.com/83774467/161864078-51fb5de3-906c-4f22-8b7b-e27b7b957018.png">
Single-digit badges should be now square (19x19)

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://i.giphy.com/media/llJVg4Ri0VrUBzNOgG/giphy.webp)
