### PR TITLE
feat(button): add d-btn--active class

### DIFF
--- a/docs/_data/button.json
+++ b/docs/_data/button.json
@@ -71,6 +71,11 @@
       "description": "Applies disabled style."
     },
     {
+      "class": "d-btn--active",
+      "applies": "d-btn",
+      "description": "Applies active style."
+    },
+    {
       "class": "d-btn--muted",
       "applies": "d-btn",
       "description": "Applies muted style."

--- a/docs/components/button.html
+++ b/docs/components/button.html
@@ -332,129 +332,128 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
           {% endcodeWell %}
       </div>
     </div>
-      <div class="d-stack8">
-        {% header "h3", "With Icons" %}
-        {% paragraph %}Button labels can include an icon next to the text. Every button style can accept icon classes, though we only provide a few possible examples.{% endparagraph %}
-        {% codeWell %}
-          {% codeWellHeader %}
-            <div class="d-stack8">
-              <div>
-                <button class="d-btn d-btn--outlined" type="button">
-                  <span class="d-btn__icon d-btn__icon--left">{% iconSystem "phone", "js-svg" %}</span>
-                  <span class="d-btn__label">Label</span>
-                </button>
-              </div>
-              <div>
-                <button class="d-btn d-btn--outlined" type="button">
-                  <span class="d-btn__icon d-btn__icon--right">{% iconSystem "phone", "js-svg" %}</span>
-                  <span class="d-btn__label">Label</span>
-                </button>
-              </div>
-              <div>
-                <button class="d-btn d-btn--outlined d-btn--vertical" type="button">
-                  <span class="d-btn__icon d-btn__icon--top">{% iconSystem "phone", "js-svg" %}</span>
-                  <span class="d-btn__label">Label</span>
-                </button>
-              </div>
-              <div>
-                <button class="d-btn d-btn--outlined d-btn--vertical" type="button">
-                  <span class="d-btn__icon d-btn__icon--bottom">{% iconSystem "phone", "js-svg" %}</span>
-                  <span class="d-btn__label">Label</span>
-                </button>
-              </div>
-            </div>
-          {% endcodeWellHeader %}
-          {% codeWellFooter %}
-            {% highlight html linenos %}
-  <button class="d-btn d-btn--outlined" type="button">
-    <span class="d-btn__icon d-btn__icon--left">...</span>
-    <span class="d-btn__label">...</span>
-  </button>
-  <button class="d-btn d-btn--outlined" type="button">
-    <span class="d-btn__icon d-btn__icon--right">...</span>
-    <span class="d-btn__label">...</span>
-  </button>
-  <button class="d-btn d-btn--vertical d-btn--outlined" type="button">
-    <span class="d-btn__icon d-btn__icon--top">...</span>
-    <span class="d-btn__label">...</span>
-  </button>
-  <button class="d-btn d-btn--vertical d-btn--outlined" type="button">
-    <span class="d-btn__icon d-btn__icon--bottom">...</span>
-    <span class="d-btn__label">...</span>
-  </button>
-            {% endhighlight %}
-          {% endcodeWellFooter %}
-        {% endcodeWell %}
-      </div>
-      <div class="d-stack8">
-        {% header "h3", "Branded" %}
-        {% paragraph %}We provide the following branded buttons for log-in and sign-up workflows.{% endparagraph %}
-        {% codeWell %}
-          {% codeWellHeader %}
+    <div class="d-stack8">
+      {% header "h3", "With Icons" %}
+      {% paragraph %}Button labels can include an icon next to the text. Every button style can accept icon classes, though we only provide a few possible examples.{% endparagraph %}
+      {% codeWell %}
+        {% codeWellHeader %}
           <div class="d-stack8">
             <div>
-              <button class="d-btn d-btn--brand d-btn--google d-w100p" type="button"><span class="d-btn__icon">{% iconBrand "google-glyph", "js-svg" %}</span><span class="d-btn__label">Log in with Google</span></button>
+              <button class="d-btn d-btn--outlined" type="button">
+                <span class="d-btn__icon d-btn__icon--left">{% iconSystem "phone", "js-svg" %}</span>
+                <span class="d-btn__label">Label</span>
+              </button>
             </div>
             <div>
-              <button class="d-btn d-btn--brand d-btn--o365 d-w100p" type="button"><span class="d-btn__icon">{% iconBrand "office-365", "js-svg" %}</span><span class="d-btn__label">Log in with Office365</span></button>
+              <button class="d-btn d-btn--outlined" type="button">
+                <span class="d-btn__icon d-btn__icon--right">{% iconSystem "phone", "js-svg" %}</span>
+                <span class="d-btn__label">Label</span>
+              </button>
             </div>
             <div>
-              <button class="d-btn d-btn--brand d-btn--linkedin d-w100p" type="button"><span class="d-btn__icon">{% iconBrand "linkedin", "js-svg" %}</span><span class="d-btn__label">Log in with LinkedIn</span></button>
+              <button class="d-btn d-btn--outlined d-btn--vertical" type="button">
+                <span class="d-btn__icon d-btn__icon--top">{% iconSystem "phone", "js-svg" %}</span>
+                <span class="d-btn__label">Label</span>
+              </button>
+            </div>
+            <div>
+              <button class="d-btn d-btn--outlined d-btn--vertical" type="button">
+                <span class="d-btn__icon d-btn__icon--bottom">{% iconSystem "phone", "js-svg" %}</span>
+                <span class="d-btn__label">Label</span>
+              </button>
             </div>
           </div>
-          {% endcodeWellHeader %}
-          {% codeWellFooter %}
-            {% highlight html linenos %}
-  <button class="d-btn d-btn--brand d-btn--google" type="button">
-    <span class="d-btn__icon">{% iconBrand "google-glyph", "js-svg" %}</span>
-    <span class="d-btn__label">Log in with Google</span>
-  </button>
-  <button class="d-btn d-btn--brand d-btn--o365" type="button">
-    <span class="d-btn__icon">{% iconBrand "office-365", "js-svg" %}</span>
-    <span class="d-btn__label">Log in with Office365</span>
-  </button>
-  <button class="d-btn d-btn--brand d-btn--linkedin" type="button">
-    <span class="d-btn__icon">{% iconBrand "linkedin", "js-svg" %}</span>
-    <span class="d-btn__label">Log in with LinkedIn</span>
-  </button>
-            {% endhighlight %}
-          {% endcodeWellFooter %}
-        {% endcodeWell %}
-      </div>
-      <div class="d-stack8">
-        {% header "h3", "Sizes" %}
-        {% paragraph %}The base button font size is 16px and should be used in most cases. Every button style can accept size classes, though we only provide a few possible examples.{% endparagraph %}
-        {% codeWell %}
-          {% codeWellHeader %}
-          <div class="d-stack8">
-            <div>
-              <button class="d-btn d-btn--primary d-btn--xs" type="button"><span class="d-btn__label">Place call</span></button>
-            </div>
-            <div>
-              <button class="d-btn d-btn--primary d-btn--sm" type="button"><span class="d-btn__label">Place call</span></button>
-            </div>
-            <div>
-              <button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">Place call</span></button>
-            </div>
-            <div>
-              <button class="d-btn d-btn--primary d-btn--lg" type="button"><span class="d-btn__label">Place call</span></button>
-            </div>
-            <div>
-              <button class="d-btn d-btn--primary d-btn--xl" type="button"><span class="d-btn__label">Place call</span></button>
-            </div>
+        {% endcodeWellHeader %}
+        {% codeWellFooter %}
+          {% highlight html linenos %}
+<button class="d-btn d-btn--outlined" type="button">
+  <span class="d-btn__icon d-btn__icon--left">...</span>
+  <span class="d-btn__label">...</span>
+</button>
+<button class="d-btn d-btn--outlined" type="button">
+  <span class="d-btn__icon d-btn__icon--right">...</span>
+  <span class="d-btn__label">...</span>
+</button>
+<button class="d-btn d-btn--vertical d-btn--outlined" type="button">
+  <span class="d-btn__icon d-btn__icon--top">...</span>
+  <span class="d-btn__label">...</span>
+</button>
+<button class="d-btn d-btn--vertical d-btn--outlined" type="button">
+  <span class="d-btn__icon d-btn__icon--bottom">...</span>
+  <span class="d-btn__label">...</span>
+</button>
+          {% endhighlight %}
+        {% endcodeWellFooter %}
+      {% endcodeWell %}
+    </div>
+    <div class="d-stack8">
+      {% header "h3", "Branded" %}
+      {% paragraph %}We provide the following branded buttons for log-in and sign-up workflows.{% endparagraph %}
+      {% codeWell %}
+        {% codeWellHeader %}
+        <div class="d-stack8">
+          <div>
+            <button class="d-btn d-btn--brand d-btn--google d-w100p" type="button"><span class="d-btn__icon">{% iconBrand "google-glyph", "js-svg" %}</span><span class="d-btn__label">Log in with Google</span></button>
           </div>
-          {% endcodeWellHeader %}
-          {% codeWellFooter %}
-            {% highlight html linenos %}
-  <button class="d-btn d-btn--primary d-btn--xs" type="button"><span class="d-btn__label">...</span></button>
-  <button class="d-btn d-btn--primary d-btn--sm" type="button"><span class="d-btn__label">...</span></button>
-  <button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
-  <button class="d-btn d-btn--primary d-btn--lg" type="button"><span class="d-btn__label">...</span></button>
-  <button class="d-btn d-btn--primary d-btn--xl" type="button"><span class="d-btn__label">...</span></button>
-            {% endhighlight %}
-          {% endcodeWellFooter %}
-        {% endcodeWell %}
-      </div>
+          <div>
+            <button class="d-btn d-btn--brand d-btn--o365 d-w100p" type="button"><span class="d-btn__icon">{% iconBrand "office-365", "js-svg" %}</span><span class="d-btn__label">Log in with Office365</span></button>
+          </div>
+          <div>
+            <button class="d-btn d-btn--brand d-btn--linkedin d-w100p" type="button"><span class="d-btn__icon">{% iconBrand "linkedin", "js-svg" %}</span><span class="d-btn__label">Log in with LinkedIn</span></button>
+          </div>
+        </div>
+        {% endcodeWellHeader %}
+        {% codeWellFooter %}
+          {% highlight html linenos %}
+<button class="d-btn d-btn--brand d-btn--google" type="button">
+  <span class="d-btn__icon">{% iconBrand "google-glyph", "js-svg" %}</span>
+  <span class="d-btn__label">Log in with Google</span>
+</button>
+<button class="d-btn d-btn--brand d-btn--o365" type="button">
+  <span class="d-btn__icon">{% iconBrand "office-365", "js-svg" %}</span>
+  <span class="d-btn__label">Log in with Office365</span>
+</button>
+<button class="d-btn d-btn--brand d-btn--linkedin" type="button">
+  <span class="d-btn__icon">{% iconBrand "linkedin", "js-svg" %}</span>
+  <span class="d-btn__label">Log in with LinkedIn</span>
+</button>
+          {% endhighlight %}
+        {% endcodeWellFooter %}
+      {% endcodeWell %}
+    </div>
+    <div class="d-stack8">
+      {% header "h3", "Sizes" %}
+      {% paragraph %}The base button font size is 16px and should be used in most cases. Every button style can accept size classes, though we only provide a few possible examples.{% endparagraph %}
+      {% codeWell %}
+        {% codeWellHeader %}
+        <div class="d-stack8">
+          <div>
+            <button class="d-btn d-btn--primary d-btn--xs" type="button"><span class="d-btn__label">Place call</span></button>
+          </div>
+          <div>
+            <button class="d-btn d-btn--primary d-btn--sm" type="button"><span class="d-btn__label">Place call</span></button>
+          </div>
+          <div>
+            <button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">Place call</span></button>
+          </div>
+          <div>
+            <button class="d-btn d-btn--primary d-btn--lg" type="button"><span class="d-btn__label">Place call</span></button>
+          </div>
+          <div>
+            <button class="d-btn d-btn--primary d-btn--xl" type="button"><span class="d-btn__label">Place call</span></button>
+          </div>
+        </div>
+        {% endcodeWellHeader %}
+        {% codeWellFooter %}
+          {% highlight html linenos %}
+<button class="d-btn d-btn--primary d-btn--xs" type="button"><span class="d-btn__label">...</span></button>
+<button class="d-btn d-btn--primary d-btn--sm" type="button"><span class="d-btn__label">...</span></button>
+<button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
+<button class="d-btn d-btn--primary d-btn--lg" type="button"><span class="d-btn__label">...</span></button>
+<button class="d-btn d-btn--primary d-btn--xl" type="button"><span class="d-btn__label">...</span></button>
+          {% endhighlight %}
+        {% endcodeWellFooter %}
+      {% endcodeWell %}
     </div>
   </div>
 </section>

--- a/docs/components/button.html
+++ b/docs/components/button.html
@@ -174,6 +174,45 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
       {% endcodeWell %}
     </div>
     <div class="d-stack8">
+      {% header "h3", "Active" %}
+      {% paragraph %}Buttons can be set to active state using the {% code %}.d-btn--active{% endcode %} Dialtone class.{% endparagraph %}
+      {% paragraph %}Different button styles and variations appear different when active.{% endparagraph %}
+      {% codeWell %}
+      {% codeWellHeader %}
+      <div class="d-stack8">
+        <div>
+          <button class="d-btn d-btn--active" type="button">
+            <span class="d-btn__label">Place call</span>
+          </button>
+        </div>
+        <div>
+          <button class="d-btn d-btn--primary d-btn--active" type="button">
+            <span class="d-btn__label">Place call</span>
+          </button>
+        </div>
+        <div>
+          <button class="d-btn d-btn--danger d-btn--active" type="button">
+            <span class="d-btn__label">Place call</span>
+          </button>
+        </div>
+        <div>
+          <button class="d-btn d-btn--inverted d-btn--primary d-btn--active" type="button">
+            <span class="d-btn__label">Place call</span>
+          </button>
+        </div>
+      </div>
+      {% endcodeWellHeader %}
+      {% codeWellFooter %}
+      {% highlight html linenos %}
+<button class="d-btn d-btn--active" type="button"><span class="d-btn__label">...</span></button>
+<button class="d-btn d-btn--primary d-btn--active" type="button"><span class="d-btn__label">...</span></button>
+<button class="d-btn d-btn--danger d-btn--active" type="button"><span class="d-btn__label">...</span></button>
+<button class="d-btn d-btn--inverted d-btn--primary d-btn--active" type="button"><span class="d-btn__label">...</span></button>
+      {% endhighlight %}
+      {% endcodeWellFooter %}
+      {% endcodeWell %}
+    </div>
+    <div class="d-stack8">
       {% header "h3", "Link" %}
       {% paragraph %}Buttons can be styled as a <a href="components/link.html">link</a> in situations for which you need the appearance of a link but behavior of a button. Using the {% code %}button{% endcode %} element provides a better accessibility experience.{% endparagraph %}
       {% codeWell %}
@@ -293,128 +332,129 @@ storybook-url: https://vue.dialpad.design/?path=/story/components-button--defaul
           {% endcodeWell %}
       </div>
     </div>
-    <div class="d-stack8">
-      {% header "h3", "With Icons" %}
-      {% paragraph %}Button labels can include an icon next to the text. Every button style can accept icon classes, though we only provide a few possible examples.{% endparagraph %}
-      {% codeWell %}
-        {% codeWellHeader %}
+      <div class="d-stack8">
+        {% header "h3", "With Icons" %}
+        {% paragraph %}Button labels can include an icon next to the text. Every button style can accept icon classes, though we only provide a few possible examples.{% endparagraph %}
+        {% codeWell %}
+          {% codeWellHeader %}
+            <div class="d-stack8">
+              <div>
+                <button class="d-btn d-btn--outlined" type="button">
+                  <span class="d-btn__icon d-btn__icon--left">{% iconSystem "phone", "js-svg" %}</span>
+                  <span class="d-btn__label">Label</span>
+                </button>
+              </div>
+              <div>
+                <button class="d-btn d-btn--outlined" type="button">
+                  <span class="d-btn__icon d-btn__icon--right">{% iconSystem "phone", "js-svg" %}</span>
+                  <span class="d-btn__label">Label</span>
+                </button>
+              </div>
+              <div>
+                <button class="d-btn d-btn--outlined d-btn--vertical" type="button">
+                  <span class="d-btn__icon d-btn__icon--top">{% iconSystem "phone", "js-svg" %}</span>
+                  <span class="d-btn__label">Label</span>
+                </button>
+              </div>
+              <div>
+                <button class="d-btn d-btn--outlined d-btn--vertical" type="button">
+                  <span class="d-btn__icon d-btn__icon--bottom">{% iconSystem "phone", "js-svg" %}</span>
+                  <span class="d-btn__label">Label</span>
+                </button>
+              </div>
+            </div>
+          {% endcodeWellHeader %}
+          {% codeWellFooter %}
+            {% highlight html linenos %}
+  <button class="d-btn d-btn--outlined" type="button">
+    <span class="d-btn__icon d-btn__icon--left">...</span>
+    <span class="d-btn__label">...</span>
+  </button>
+  <button class="d-btn d-btn--outlined" type="button">
+    <span class="d-btn__icon d-btn__icon--right">...</span>
+    <span class="d-btn__label">...</span>
+  </button>
+  <button class="d-btn d-btn--vertical d-btn--outlined" type="button">
+    <span class="d-btn__icon d-btn__icon--top">...</span>
+    <span class="d-btn__label">...</span>
+  </button>
+  <button class="d-btn d-btn--vertical d-btn--outlined" type="button">
+    <span class="d-btn__icon d-btn__icon--bottom">...</span>
+    <span class="d-btn__label">...</span>
+  </button>
+            {% endhighlight %}
+          {% endcodeWellFooter %}
+        {% endcodeWell %}
+      </div>
+      <div class="d-stack8">
+        {% header "h3", "Branded" %}
+        {% paragraph %}We provide the following branded buttons for log-in and sign-up workflows.{% endparagraph %}
+        {% codeWell %}
+          {% codeWellHeader %}
           <div class="d-stack8">
             <div>
-              <button class="d-btn d-btn--outlined" type="button">
-                <span class="d-btn__icon d-btn__icon--left">{% iconSystem "phone", "js-svg" %}</span>
-                <span class="d-btn__label">Label</span>
-              </button>
+              <button class="d-btn d-btn--brand d-btn--google d-w100p" type="button"><span class="d-btn__icon">{% iconBrand "google-glyph", "js-svg" %}</span><span class="d-btn__label">Log in with Google</span></button>
             </div>
             <div>
-              <button class="d-btn d-btn--outlined" type="button">
-                <span class="d-btn__icon d-btn__icon--right">{% iconSystem "phone", "js-svg" %}</span>
-                <span class="d-btn__label">Label</span>
-              </button>
+              <button class="d-btn d-btn--brand d-btn--o365 d-w100p" type="button"><span class="d-btn__icon">{% iconBrand "office-365", "js-svg" %}</span><span class="d-btn__label">Log in with Office365</span></button>
             </div>
             <div>
-              <button class="d-btn d-btn--outlined d-btn--vertical" type="button">
-                <span class="d-btn__icon d-btn__icon--top">{% iconSystem "phone", "js-svg" %}</span>
-                <span class="d-btn__label">Label</span>
-              </button>
+              <button class="d-btn d-btn--brand d-btn--linkedin d-w100p" type="button"><span class="d-btn__icon">{% iconBrand "linkedin", "js-svg" %}</span><span class="d-btn__label">Log in with LinkedIn</span></button>
+            </div>
+          </div>
+          {% endcodeWellHeader %}
+          {% codeWellFooter %}
+            {% highlight html linenos %}
+  <button class="d-btn d-btn--brand d-btn--google" type="button">
+    <span class="d-btn__icon">{% iconBrand "google-glyph", "js-svg" %}</span>
+    <span class="d-btn__label">Log in with Google</span>
+  </button>
+  <button class="d-btn d-btn--brand d-btn--o365" type="button">
+    <span class="d-btn__icon">{% iconBrand "office-365", "js-svg" %}</span>
+    <span class="d-btn__label">Log in with Office365</span>
+  </button>
+  <button class="d-btn d-btn--brand d-btn--linkedin" type="button">
+    <span class="d-btn__icon">{% iconBrand "linkedin", "js-svg" %}</span>
+    <span class="d-btn__label">Log in with LinkedIn</span>
+  </button>
+            {% endhighlight %}
+          {% endcodeWellFooter %}
+        {% endcodeWell %}
+      </div>
+      <div class="d-stack8">
+        {% header "h3", "Sizes" %}
+        {% paragraph %}The base button font size is 16px and should be used in most cases. Every button style can accept size classes, though we only provide a few possible examples.{% endparagraph %}
+        {% codeWell %}
+          {% codeWellHeader %}
+          <div class="d-stack8">
+            <div>
+              <button class="d-btn d-btn--primary d-btn--xs" type="button"><span class="d-btn__label">Place call</span></button>
             </div>
             <div>
-              <button class="d-btn d-btn--outlined d-btn--vertical" type="button">
-                <span class="d-btn__icon d-btn__icon--bottom">{% iconSystem "phone", "js-svg" %}</span>
-                <span class="d-btn__label">Label</span>
-              </button>
+              <button class="d-btn d-btn--primary d-btn--sm" type="button"><span class="d-btn__label">Place call</span></button>
+            </div>
+            <div>
+              <button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">Place call</span></button>
+            </div>
+            <div>
+              <button class="d-btn d-btn--primary d-btn--lg" type="button"><span class="d-btn__label">Place call</span></button>
+            </div>
+            <div>
+              <button class="d-btn d-btn--primary d-btn--xl" type="button"><span class="d-btn__label">Place call</span></button>
             </div>
           </div>
-        {% endcodeWellHeader %}
-        {% codeWellFooter %}
-          {% highlight html linenos %}
-<button class="d-btn d-btn--outlined" type="button">
-  <span class="d-btn__icon d-btn__icon--left">...</span>
-  <span class="d-btn__label">...</span>
-</button>
-<button class="d-btn d-btn--outlined" type="button">
-  <span class="d-btn__icon d-btn__icon--right">...</span>
-  <span class="d-btn__label">...</span>
-</button>
-<button class="d-btn d-btn--vertical d-btn--outlined" type="button">
-  <span class="d-btn__icon d-btn__icon--top">...</span>
-  <span class="d-btn__label">...</span>
-</button>
-<button class="d-btn d-btn--vertical d-btn--outlined" type="button">
-  <span class="d-btn__icon d-btn__icon--bottom">...</span>
-  <span class="d-btn__label">...</span>
-</button>
-          {% endhighlight %}
-        {% endcodeWellFooter %}
-      {% endcodeWell %}
-    </div>
-    <div class="d-stack8">
-      {% header "h3", "Branded" %}
-      {% paragraph %}We provide the following branded buttons for log-in and sign-up workflows.{% endparagraph %}
-      {% codeWell %}
-        {% codeWellHeader %}
-        <div class="d-stack8">
-          <div>
-            <button class="d-btn d-btn--brand d-btn--google d-w100p" type="button"><span class="d-btn__icon">{% iconBrand "google-glyph", "js-svg" %}</span><span class="d-btn__label">Log in with Google</span></button>
-          </div>
-          <div>
-            <button class="d-btn d-btn--brand d-btn--o365 d-w100p" type="button"><span class="d-btn__icon">{% iconBrand "office-365", "js-svg" %}</span><span class="d-btn__label">Log in with Office365</span></button>
-          </div>
-          <div>
-            <button class="d-btn d-btn--brand d-btn--linkedin d-w100p" type="button"><span class="d-btn__icon">{% iconBrand "linkedin", "js-svg" %}</span><span class="d-btn__label">Log in with LinkedIn</span></button>
-          </div>
-        </div>
-        {% endcodeWellHeader %}
-        {% codeWellFooter %}
-          {% highlight html linenos %}
-<button class="d-btn d-btn--brand d-btn--google" type="button">
-  <span class="d-btn__icon">{% iconBrand "google-glyph", "js-svg" %}</span>
-  <span class="d-btn__label">Log in with Google</span>
-</button>
-<button class="d-btn d-btn--brand d-btn--o365" type="button">
-  <span class="d-btn__icon">{% iconBrand "office-365", "js-svg" %}</span>
-  <span class="d-btn__label">Log in with Office365</span>
-</button>
-<button class="d-btn d-btn--brand d-btn--linkedin" type="button">
-  <span class="d-btn__icon">{% iconBrand "linkedin", "js-svg" %}</span>
-  <span class="d-btn__label">Log in with LinkedIn</span>
-</button>
-          {% endhighlight %}
-        {% endcodeWellFooter %}
-      {% endcodeWell %}
-    </div>
-    <div class="d-stack8">
-      {% header "h3", "Sizes" %}
-      {% paragraph %}The base button font size is 16px and should be used in most cases. Every button style can accept size classes, though we only provide a few possible examples.{% endparagraph %}
-      {% codeWell %}
-        {% codeWellHeader %}
-        <div class="d-stack8">
-          <div>
-            <button class="d-btn d-btn--primary d-btn--xs" type="button"><span class="d-btn__label">Place call</span></button>
-          </div>
-          <div>
-            <button class="d-btn d-btn--primary d-btn--sm" type="button"><span class="d-btn__label">Place call</span></button>
-          </div>
-          <div>
-            <button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">Place call</span></button>
-          </div>
-          <div>
-            <button class="d-btn d-btn--primary d-btn--lg" type="button"><span class="d-btn__label">Place call</span></button>
-          </div>
-          <div>
-            <button class="d-btn d-btn--primary d-btn--xl" type="button"><span class="d-btn__label">Place call</span></button>
-          </div>
-        </div>
-        {% endcodeWellHeader %}
-        {% codeWellFooter %}
-          {% highlight html linenos %}
-<button class="d-btn d-btn--primary d-btn--xs" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--primary d-btn--sm" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--primary d-btn--lg" type="button"><span class="d-btn__label">...</span></button>
-<button class="d-btn d-btn--primary d-btn--xl" type="button"><span class="d-btn__label">...</span></button>
-          {% endhighlight %}
-        {% endcodeWellFooter %}
-      {% endcodeWell %}
+          {% endcodeWellHeader %}
+          {% codeWellFooter %}
+            {% highlight html linenos %}
+  <button class="d-btn d-btn--primary d-btn--xs" type="button"><span class="d-btn__label">...</span></button>
+  <button class="d-btn d-btn--primary d-btn--sm" type="button"><span class="d-btn__label">...</span></button>
+  <button class="d-btn d-btn--primary" type="button"><span class="d-btn__label">...</span></button>
+  <button class="d-btn d-btn--primary d-btn--lg" type="button"><span class="d-btn__label">...</span></button>
+  <button class="d-btn d-btn--primary d-btn--xl" type="button"><span class="d-btn__label">...</span></button>
+            {% endhighlight %}
+          {% endcodeWellFooter %}
+        {% endcodeWell %}
+      </div>
     </div>
   </div>
 </section>

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -52,12 +52,15 @@
     //  --  STATES
     //  ------------------------------------------------------------------------
     &:hover,
-    &:active {
+    &.d-btn--active:hover {
         --button--fc: var(--primary-color-hover);
         --button--bgc: hsla(var(--primary-color-hsl) ~' / ' 3%);
     }
 
-    &:active {
+    &:active,
+    &.d-btn--active,
+    &.d-btn--active:active {
+        --button--fc: var(--primary-color-hover);
         --button--bgc: hsla(var(--primary-color-hsl) ~' / ' 9%);
     }
 
@@ -272,12 +275,15 @@
     --button--bgc: var(--primary-color);
 
     &:hover,
-    &:active {
+    &.d-btn--active:hover {
       --button--fc: var(--white);
       --button--bgc: hsl(var(--primary-color-h), var(--primary-color-s), 65%);
     }
 
-    &:active {
+    &:active,
+    &.d-btn--active,
+    &.d-btn--active:active {
+      --button--fc: var(--white);
       --button--bgc: hsl(var(--primary-color-h), var(--primary-color-s), 42%);
     }
 }
@@ -312,12 +318,15 @@
     --button--fc: var(--error-color);
 
     &:hover,
-    &:active {
+    &.d-btn--active:hover {
         --button--fc: var(--error-color-hover);
         --button--bgc: hsla(var(--error-color-hsl) ~' / ' 6%);
     }
 
-    &:active {
+    &:active,
+    &.d-btn--active,
+    &.d-btn--active:active {
+        --button--fc: var(--error-color-hover);
         --button--bgc: hsla(var(--error-color-hsl) ~' / ' 20%);
     }
 
@@ -334,12 +343,14 @@
         --button--bgc: var(--error-color);
 
         &:hover,
-        &:active {
-            --button--fc: var(--white);
+        &.d-btn--active:hover {
             --button--bgc: hsl(var(--red-500-h), var(--red-500-s), 40%);
         }
 
-        &:active {
+        &:active,
+        &.d-btn--active,
+        &.d-btn--active:active {
+            --button--fc: var(--white);
             --button--bgc: hsl(var(--red-500-h), var(--red-500-s), 27%);
         }
     }
@@ -353,12 +364,15 @@
     --button--bgc: transparent;
 
     &:hover,
-    &:active {
+    &.d-btn--active:hover {
         --button--fc: var(--white);
         --button--bgc: hsla(var(--white-hsl) ~' / ' 15%);
     }
 
-    &:active {
+    &:active,
+    &.d-btn--active,
+    &.d-btn--active:active {
+        --button--fc: var(--white);
         --button--bgc: hsla(var(--white-hsl) ~' / ' 30%);
     }
 
@@ -376,12 +390,15 @@
         --button--fc: var(--primary-color);
         --button--bgc: hsl(var(--purple-100-h), var(--purple-100-s), 100%);
 
-        &:hover {
+        &:hover,
+        &.d-btn--active:hover {
             --button--fc: var(--primary-color-hover);
             --button--bgc: hsl(var(--purple-100-h), var(--purple-100-s), 94%);
         }
 
-        &:active {
+        &:active,
+        &.d-btn--active,
+        &.d-btn--active:active {
             --button--fc: var(--primary-color-hover);
             --button--bgc: hsl(var(--purple-100-h), var(--purple-100-s), 91%);
         }

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -51,8 +51,7 @@
 
     //  --  STATES
     //  ------------------------------------------------------------------------
-    &:hover,
-    &.d-btn--active:hover {
+    &:hover {
         --button--fc: var(--primary-color-hover);
         --button--bgc: hsla(var(--primary-color-hsl) ~' / ' 3%);
     }
@@ -274,8 +273,7 @@
     --button--fc: var(--white);
     --button--bgc: var(--primary-color);
 
-    &:hover,
-    &.d-btn--active:hover {
+    &:hover {
       --button--fc: var(--white);
       --button--bgc: hsl(var(--primary-color-h), var(--primary-color-s), 65%);
     }
@@ -317,8 +315,7 @@
 .d-btn--danger {
     --button--fc: var(--error-color);
 
-    &:hover,
-    &.d-btn--active:hover {
+    &:hover {
         --button--fc: var(--error-color-hover);
         --button--bgc: hsla(var(--error-color-hsl) ~' / ' 6%);
     }
@@ -342,8 +339,7 @@
         --button--fc: var(--white);
         --button--bgc: var(--error-color);
 
-        &:hover,
-        &.d-btn--active:hover {
+        &:hover {
             --button--bgc: hsl(var(--red-500-h), var(--red-500-s), 40%);
         }
 
@@ -363,8 +359,7 @@
     --button--fc: var(--white);
     --button--bgc: transparent;
 
-    &:hover,
-    &.d-btn--active:hover {
+    &:hover {
         --button--fc: var(--white);
         --button--bgc: hsla(var(--white-hsl) ~' / ' 15%);
     }
@@ -390,8 +385,7 @@
         --button--fc: var(--primary-color);
         --button--bgc: hsl(var(--purple-100-h), var(--purple-100-s), 100%);
 
-        &:hover,
-        &.d-btn--active:hover {
+        &:hover {
             --button--fc: var(--primary-color-hover);
             --button--bgc: hsl(var(--purple-100-h), var(--purple-100-s), 94%);
         }


### PR DESCRIPTION
## Description

Added `.d-btn--active` class so we can hold state on Dialtone-vue.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/tsX3YMWYzDPjAARfeg/giphy.gif)
