### PR TITLE
fix (button): add removed font color on hover state

### DIFF
--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -340,6 +340,7 @@
         --button--bgc: var(--error-color);
 
         &:hover {
+            --button--fc: var(--white);
             --button--bgc: hsl(var(--red-500-h), var(--red-500-s), 40%);
         }
 


### PR DESCRIPTION
## Description

Recently we have removed css variable --button--fc: var(--white) for the hover state. 
Because of that all the buttons in the product which are using d-btn-danger class do not have proper styling.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/LpkLWXTp0v0qy70xPp/giphy.gif)
