### PR TITLE
docs: upgrade docsearch to version 3. prevent subdir overlap

### DIFF
--- a/docs/_data/site.js
+++ b/docs/_data/site.js
@@ -4,7 +4,6 @@ module.exports = {
   localurl: "http://localhost:4000/",
   url: "https://dialpad.design",
   baseurl: process.env.ELEVENTY_BASE_URL !== '/' ? `/${process.env.ELEVENTY_BASE_URL}/` : '/',
-  branch: process.env.ELEVENTY_BASE_URL !== '/' ? process.env.ELEVENTY_BASE_URL : 'staging',
   paths: {
     css: `assets/css`,
     img: `assets/images`,

--- a/docs/_data/site.js
+++ b/docs/_data/site.js
@@ -4,6 +4,7 @@ module.exports = {
   localurl: "http://localhost:4000/",
   url: "https://dialpad.design",
   baseurl: process.env.ELEVENTY_BASE_URL !== '/' ? `/${process.env.ELEVENTY_BASE_URL}/` : '/',
+  branch: process.env.ELEVENTY_BASE_URL !== '/' ? process.env.ELEVENTY_BASE_URL : 'staging',
   paths: {
     css: `assets/css`,
     img: `assets/images`,

--- a/docs/_includes/docsearch-js.html
+++ b/docs/_includes/docsearch-js.html
@@ -4,7 +4,6 @@ appId: 'Y5HG9UX6KM',
 apiKey: '6436ebddb959748daeec411eb388a99d',
 indexName: 'dialpad',
 container: '.js-dialtone-search',
-facetFilters: ['version:{{ site.branch }}'],
 debug: false // Set debug to true if you want to inspect the dropdown
 });
 </script>

--- a/docs/_includes/docsearch-js.html
+++ b/docs/_includes/docsearch-js.html
@@ -1,8 +1,10 @@
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@docsearch/js@3"></script>
 <script type="text/javascript"> docsearch({
-apiKey: '0aa544f93796200d13e78d4d48546ba7',
+appId: 'Y5HG9UX6KM',
+apiKey: '6436ebddb959748daeec411eb388a99d',
 indexName: 'dialpad',
-inputSelector: '.js-dialtone-search',
+container: '.js-dialtone-search',
+facetFilters: ['version:{{ site.branch }}'],
 debug: false // Set debug to true if you want to inspect the dropdown
 });
 </script>

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -13,6 +13,7 @@
     <link rel="mask-icon" href="{{ site.paths.ico }}/safari-pinned-tab.svg" color="#6C3DFF">
     <meta name="msapplication-TileColor" content="#6C3DFF">
     <meta name="theme-color" content="#ffffff">
+    <meta name="docsearch:version" content="{{ site.branch }}" />
 
     <!-- Social -->
     <meta property="og:type" content="website"/>
@@ -24,7 +25,7 @@
     <meta name="twitter:description" property="og:description" itemprop="description" content="Dialtone is the design system and resources for the Dialpad team." />
 
     <!-- CSS -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
     <link rel="stylesheet" type="text/css" href="{{ site.paths.css }}/{{ filenames.dialtone }}?{{ site.time | date: '%s%N' }}" />
     <link rel="stylesheet" type="text/css" href="{{ site.paths.css }}/{{ filenames.dialtoneDocs }}?{{ site.time | date: '%s%N' }}" />
 

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -13,7 +13,6 @@
     <link rel="mask-icon" href="{{ site.paths.ico }}/safari-pinned-tab.svg" color="#6C3DFF">
     <meta name="msapplication-TileColor" content="#6C3DFF">
     <meta name="theme-color" content="#ffffff">
-    <meta name="docsearch:version" content="{{ site.branch }}" />
 
     <!-- Social -->
     <meta property="og:type" content="website"/>

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -34,8 +34,7 @@
             </a> -->
         </div>
         <div class="d-ps-relative js-input-search-wrapper md:d-d-none">
-            <span class="d-input-icon d-input-icon--left">{%   iconSystem "search" %}</span>
-            <input type="search" class="d-input d-pl32 js-dialtone-search" placeholder="Search Dialtone" />
+            <div class="js-dialtone-search"></div>
             <div class="d-ps-absolute d-t6 d-l4 d-ml1 d-fc-black-600">
             </div>
         </div>

--- a/docs/assets/js/nav.js
+++ b/docs/assets/js/nav.js
@@ -5,12 +5,20 @@ $(document).ready(function() {
     var body = $("body");
     var navHeader = $(".js-navigation-header");
     var navigationSideBar = $(".js-navigation-sidebar");
+    var search = $(".js-dialtone-search")
     var banner = $('.js-banner-example');
     const dropDownNavigation = $('.js-mobile-header-drop-down-navigation')
     const navigationHeader = $('.js-navigation-header')
     const breadcrumbsWrapper = $('.js-mobile-header-breadcrumbs')
     const breadcrumbArrow = $('.js-mobile-header-breadcrumb-arrow')
 
+    convertSearchToDialtone();
+
+    // add dialtone child elements to the algolia search button (label and icon)
+    function convertSearchToDialtone () {
+      $('<span class="d-btn__label">Search Dialtone</span>').appendTo(search.find('button'))
+      $('<span class="d-btn__icon d-btn__icon--left"><svg aria-hidden="true" aria-label="Search" class="d-svg d-svg--system d-svg__search" viewBox="0 0 24 24"><path fill-rule="evenodd" clip-rule="evenodd" d="M15.732 14.318h-.741l-.263-.253a6.095 6.095 0 001.389-5.009c-.441-2.607-2.619-4.69-5.246-5.009a6.103 6.103 0 00-6.823 6.82c.319 2.626 2.402 4.802 5.011 5.243a6.103 6.103 0 005.012-1.388l.253.262v.741l3.989 3.987a.992.992 0 001.398 0 .99.99 0 000-1.398l-3.979-3.996zm-5.631 0a4.217 4.217 0 01-4.223-4.22A4.216 4.216 0 0110.1 5.876a4.216 4.216 0 014.223 4.22 4.216 4.216 0 01-4.223 4.221z"></path></svg></span>').appendTo(search.find('button'))
+    }
 
     function toggleDropDownNavigation () {
         breadcrumbArrow.toggleClass('breadcrumb-arrow--top')

--- a/docs/assets/less/dialtone-docs.less
+++ b/docs/assets/less/dialtone-docs.less
@@ -25,6 +25,7 @@
 @import (reference) '../../../lib/build/less/utilities/grid';
 @import (reference) '../../../lib/build/less/utilities/typography';
 @import (reference) '../../../lib/build/less/components/link';
+@import (reference) '../../../lib/build/less/components/button';
 @import 'dialtone-syntax';
 
 //  ============================================================================
@@ -49,9 +50,36 @@
   border-top-left-radius: var(--su4);
   border-top-right-radius: var(--su4);
 }
+
 .dialtone-color-grid__item:last-of-type {
-  border-bottom-left-radius: var(--su4);
   border-bottom-right-radius: var(--su4);
+  border-bottom-left-radius: var(--su4);
+}
+
+//  ============================================================================
+//  $   SEARCH BUTTON
+//      Override search button with dialtone styles
+//  ----------------------------------------------------------------------------
+.DocSearch-Button {
+  &:hover {
+    color: var(--muted-color-hover);
+    background-color: hsla(var(--black-800-hsl) ~' / ' 3%);
+    box-shadow: unset;
+  }
+  .d-btn();
+  .d-btn--muted();
+  .d-btn--outlined();
+
+  justify-content: left;
+  width: 22.9rem;
+}
+
+.DocSearch-Button-Container {
+  display: none;
+}
+
+.DocSearch-Button-Keys {
+  display: none;
 }
 
 //  ============================================================================
@@ -62,6 +90,7 @@
 //  ----------------------------------------------------------------------------
 .toc ol {
   .d-ls-reset();
+
   display: flex;
   flex-direction: column;
 
@@ -72,6 +101,7 @@
 .toc li > ol {
   margin-top: var(--su4);
   margin-left: var(--su16);
+
   a {
     font-size: var(--fs12);
   }
@@ -86,29 +116,29 @@
   display: flex;
   justify-content: flex-start;
   padding: var(--su2) var(--su8);
-  border-radius: var(--br4);
   font-size: var(--fs14);
   line-height: var(--lh6);
   text-decoration: none;
+  border-radius: var(--br4);
 
   &:hover {
-    background-color: var(--black-050);
     text-decoration: none;
+    background-color: var(--black-050);
   }
 
   &.active {
-    font-weight: var(--fw-bold);
     color: var(--primary-color);
+    font-weight: var(--fw-bold);
 
     &::before {
-      content: "";
       position: absolute;
       top: var(--su0);
       bottom: var(--su0);
       left: var(--sun4);
       width: var(--su4);
-      border-radius: var(--br4);
       background-color: var(--primary-color);
+      border-radius: var(--br4);
+      content: '';
     }
   }
 }
@@ -119,13 +149,15 @@
 //      appropriate to ship as part of Dialtone.
 //  ----------------------------------------------------------------------------
 .d-ga-toc { grid-area: toc !important; }
+
 .d-gl-docsite {
-  grid-template-areas: "sidebar content";
+  grid-template-areas: 'sidebar content';
   grid-template-columns: [sidebar] 21.6rem [content] minmax(32rem, 75rem);
   column-gap: 4.8rem;
 }
+
 .d-gl-docsite-toc {
-  grid-template-areas: "sidebar content toc";
+  grid-template-areas: 'sidebar content toc';
   grid-template-columns: [sidebar] 21.6rem [content] minmax(32rem, 75rem) [toc] minmax(min-content, 21.6rem);
   column-gap: 4.8rem;
 }
@@ -147,10 +179,11 @@
 
 .d-gl-docsite-icons--large {
   .d-gl-docsite-icons();
+
   --icon-card-width: 18rem;
   --icon-grid-columns: auto-fit;
-  grid-auto-rows: 18rem;
 
+  grid-auto-rows: 18rem;
 }
 
 .dialtone-icon-grid__item {
@@ -158,30 +191,30 @@
 }
 
 .dialtone-icon-card {
-  display: flex;
-  height: 100%;
   position: relative;
+  display: flex;
   width: 100%;
+  height: 100%;
 }
 
 .dialtone-icon-card__header {
-  align-items: center;
-  background-color: hsl(var(--black-050-h), var(--black-050-s), var(--black-050-l),0);
-  border-radius: var(--su8);
-  cursor: pointer;
   display: flex;
   flex-direction: column;
+  align-items: center;
   justify-content: center;
+  width: 100%;
   height: 100%;
   padding: var(--su8);
+  background-color: hsl(var(--black-050-h), var(--black-050-s), var(--black-050-l), 0);
+  border-radius: var(--su8);
+  cursor: pointer;
   transition: all 150ms var(--ttf-in-out);
-  width: 100%;
 
   &:hover {
     background-color: hsl(var(--black-050-h), var(--black-050-s), var(--black-050-l), 0.4);
   }
 
-  .dialtone-icon-card[data-selected="yes"] & {
+  .dialtone-icon-card[data-selected='yes'] & {
     background-color: hsl(var(--black-050-h), var(--black-050-s), var(--black-050-l), 0.4);
     border: 1px solid var(--black-700);
     box-shadow: var(--bs-md);
@@ -189,57 +222,58 @@
 }
 
 .dialtone-icon-card__footer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: var(--zi-popover);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: calc((var(--icon-card-width) * 2) + var(--su32));
+  min-height: var(--icon-card-width);
+  margin-right: calc(-1 * var(--su1));
+  padding: var(--su12) var(--su16);
+  color: var(--black-050);
+  font-size: var(--fs14);
   background-color: var(--black-700);
   border-radius: var(--su8);
   box-shadow: var(--bs-md);
-  color: var(--black-050);
-  display: flex;
-  flex-direction: column;
-  font-size: var(--fs14);
-  justify-content: center;
-  margin-right: calc(-1 * var(--su1));
-  min-height: var(--icon-card-width);
-  padding: var(--su12) var(--su16);
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: calc((var(--icon-card-width) * 2) + var(--su32));
-  z-index: var(--zi-popover);
 
-  .dialtone-icon-card[data-selected="yes"] & {
+  .dialtone-icon-card[data-selected='yes'] & {
     margin: calc(-1 * var(--su1));
-    opacity: 1;
     transform: translateX(calc(-1 * var(--icon-card-width)));
+    visibility: visible;
+    opacity: 1;
     transition:
       opacity 50ms var(--ttf-in-out) 0s,
       transform 50ms var(--ttf-in-out) 0s,
       visibility 0s 50ms;
-    visibility: visible;
   }
 
   //  If it's in the first two columns, show the footer on the right
-  .dialtone-icon-grid__item:nth-child(5n+1) .dialtone-icon-card[data-selected="yes"] &,
-  .dialtone-icon-grid__item:nth-child(5n+2) .dialtone-icon-card[data-selected="yes"] & {
-    margin-right: unset;
+  .dialtone-icon-grid__item:nth-child(5n+1) .dialtone-icon-card[data-selected='yes'] &,
+  .dialtone-icon-grid__item:nth-child(5n+2) .dialtone-icon-card[data-selected='yes'] & {
     right: var(--su1);
+    margin-right: unset;
     transform: translateX(100%);
   }
 
-  .dialtone-icon-card[data-selected="no"] & {
-    opacity: 0;
+  .dialtone-icon-card[data-selected='no'] & {
     transform: translateX(0);
+    visibility: hidden;
+    opacity: 0;
     transition:
       opacity 100ms var(--ttf-in-out) 0s,
       transform 100ms var(--ttf-in-out) 0s,
       visibility 0s 0s;
-    visibility: hidden;
   }
 }
 
 .dialtone-icon-card__footer-spot-illustration {
   .dialtone-icon-card__footer();
-  width: calc(var(--icon-card-width)*1.5);
-  min-height: auto
+
+  width: calc(var(--icon-card-width) *1.5);
+  min-height: auto;
 }
 
 .dialtone-icon-card__list {
@@ -257,40 +291,42 @@
 }
 
 .dialtone-icon-card__icon {
+  width: @icon48;
   height: @icon48;
   margin-bottom: var(--su4);
-  width: @icon48;
+
   svg {
-    height: auto;
     width: 100%;
+    height: auto;
   }
 }
 
 .dialtone-icon-card__icon--autosize {
   margin-bottom: var(--su4);
+
   svg {
-    height: auto;
     width: 100%;
+    height: auto;
   }
 }
 
 .dialtone-icon-card__title {
-  font-size: var(--fs16);
-  font-weight: var(--fw-bold);
-  line-height: var(--lh-tight);
-  margin-bottom: var(--su4);
   margin-top: var(--su0);
+  margin-bottom: var(--su4);
+  font-weight: var(--fw-bold);
+  font-size: var(--fs16);
+  line-height: var(--lh-tight);
 }
 
 .dialtone-icon-card__subtitle {
-  font-size: var(--fs12);
-  line-height: var(--lh-none);
+  width: 100%;
   margin-bottom: var(--su0);
   overflow: hidden;
+  font-size: var(--fs12);
+  line-height: var(--lh-none);
+  white-space: nowrap;
   text-align: center;
   text-overflow: ellipsis;
-  white-space: nowrap;
-  width: 100%;
 }
 
 .dialtone-icon-card__description {
@@ -305,19 +341,21 @@
 //  ----------------------------------------------------------------------------
 
 .hero {
-  background-color: #F5F2ED;
-  background-image: url("/assets/images/home-dp-logo.svg");
-  background-position: 80% center;
   margin-top: var(--sun16) !important;
+  background-color: #f5f2ed;
+  background-image: url('/assets/images/home-dp-logo.svg');
+  background-position: 80% center;
+
   @media (max-width: 640px) {
-    padding-left: var(--su8);
     padding-right: var(--su16);
+    padding-left: var(--su8);
   }
 }
 
 .hero--inner-wrapper {
-  padding-bottom: 12.8rem;
   padding-top: 12.8rem;
+  padding-bottom: 12.8rem;
+
   @media (max-width: 640px) {
     flex-direction: column;
   }
@@ -326,6 +364,7 @@
 .hero--content {
   align-items: flex-start;
   max-width: 40%;
+
   @media (max-width: 640px) {
     align-items: unset;
     max-width: 100%;
@@ -340,8 +379,9 @@
 }
 
 .links {
-  padding-bottom: 9.6rem;
   padding-top: 9.6rem;
+  padding-bottom: 9.6rem;
+
   @media (max-width: 640px) {
     display: block !important;
   }

--- a/docs/sitemap.html
+++ b/docs/sitemap.html
@@ -1,0 +1,14 @@
+---
+permalink: '/sitemap.xml'
+eleventyExcludeFromCollections: true
+---
+
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  {% for page in collections.all %}
+  <url>
+    <loc>{{ site.url }}{{ page.url | url }}</loc>
+    <lastmod>{{ page.date }}</lastmod>
+  </url>
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
Updated docsearch to v3 so we could use the facetFilters feature so dialpad.design does not give search results from dialpad.design/version5.

Upgrading from v2 to v3 changed the search from an input to a button. This caused a bunch of styling issues which I had to manually manipulate the dom to fix, giving it dialtone styling. Was a bit hacky but it worked.

Added facetFilters based on branch name so the page you are on only searches within that branch instead of all subdir pages on dialpad.design. Seems to work correctly, but I also know algolia only crawls data once per week or so, so not completely sure.