### PR TITLE
feat: dp-46817 add thread reply icon

### DIFF
--- a/docs/_data/svg-system.json
+++ b/docs/_data/svg-system.json
@@ -1106,6 +1106,12 @@
     "desc": "Communicates the ability to takeover a call."
   },
   {
+    "name": "Thread Reply",
+    "file": "thread-reply",
+    "vue": "IconThreadReply",
+    "desc": "Communicates the ability to reply in a thread."
+  },
+  {
     "name": "Thumbtack",
     "file": "thumbtack",
     "vue": "IconThumbtack",

--- a/lib/build/svg/system/thread-reply.svg
+++ b/lib/build/svg/system/thread-reply.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M2 5C2 3.89543 2.89543 3 4 3H20C21.1046 3 22 3.89543 22 5V12H20V5H4V17H16.5856L14.2928 14.7072L15.707 13.293L20.4141 18.0001L15.707 22.7072L14.2928 21.293L16.5858 19H4C2.89543 19 2 18.1046 2 17V5Z" fill="black"/>
+<path d="M6 9H18V7H6V9Z" fill="black"/>
+<path d="M14.5 12H6V10H14.5V12Z" fill="black"/>
+<path d="M6 15H11V13H6V15Z" fill="black"/>
+</svg>


### PR DESCRIPTION
# DP-46817: add thread reply icon

## :hammer_and_wrench: Type Of Change
- [x] Feature

## :bulb: Context
For the new thread functionality in the Dialpad app, we need a new icon that the design team worked on.

## :pencil: Changes
Update by:
- Add thread icon to the Dialtone system iconography


## 📷  Demo
https://user-images.githubusercontent.com/5950950/167447582-d6e6cbcf-04c1-4c23-9b2a-e7b187bdf97a.mov


