### PR TITLE
fix: dt-436 fc-warning not mapped correctly

### DIFF
--- a/docs/_data/type.json
+++ b/docs/_data/type.json
@@ -218,7 +218,7 @@
     },
     {
       "var": "warning",
-      "output": "yellow-600"
+      "output": "fc-warning"
     },
     {
       "var": "error",

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -71,8 +71,8 @@
 #d-internals #generate-hover-focus(d-fc-green, {.d-fc-green();});
 #d-internals #generate-hover-focus(d-fc-success, {.d-fc-success();});
 
-.d-fc-yellow,
-.d-fc-warning { &:extend(.d-fc-yellow-600); }
+.d-fc-yellow { &:extend(.d-fc-yellow-600); }
+.d-fc-warning { color: var(--fc-warning) }
 #d-internals #generate-hover-focus(d-fc-yellow, {.d-fc-yellow();});
 #d-internals #generate-hover-focus(d-fc-warning, {.d-fc-warning();});
 


### PR DESCRIPTION
Utility class for `fc-warning` was mapping straight to `fc-yellow-600` when it should be `hsla(var(--yellow-500-h) var(--yellow-500-s) calc(var(--yellow-500-l) - 20%) ~' / ' var(--alpha, 100%));` based on the token. Looks like this was changed in the variable but was not updated to the utility class.
