### PR TITLE
fix: missing css file, change port and disable contributors

### DIFF
--- a/docs/.vuepress/clientAppEnhance.js
+++ b/docs/.vuepress/clientAppEnhance.js
@@ -23,8 +23,8 @@ import IconClose from "@svgIcons/IconClose.vue";
 import IconCheckmark from "@svgIcons/IconCheckmark.vue";
 import IconPhone from "@svgIcons/IconPhone.vue";
 
-process.env.NODE_ENV === 'development' ? import ('../assets/css/dialtone.css') : import ('../assets/css/dialtone.min.css');
-process.env.NODE_ENV === 'development' ? import ('../assets/css/dialtone-docs.css') : import ('../assets/css/dialtone-docs.min.css');
+import '@dialtoneCSS';
+import '@dialtoneDocsCSS';
 
 export default defineClientAppEnhance(({app, router, siteData}) => {
     // Common views

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -31,6 +31,8 @@ export default defineUserConfig({
 
   base: baseURL,
 
+  port: 4000,
+
   // theme and its config
   theme: dialtoneTheme(themeConfig),
 

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -1,5 +1,6 @@
 import { defineUserConfig } from 'vuepress';
 import { resolve } from 'path';
+
 const sidebar = require('../_data/site-nav.json');
 const { dialtoneTheme } = require('./theme');
 const baseURL = (process.env.VUEPRESS_BASE_URL ?? "/") as `/${string}/`;
@@ -19,6 +20,10 @@ const themeConfig = {
   // contributors: false,
   // lastUpdated: false,
 };
+
+const isDevelopment = (process.env.NODE_ENV === 'development');
+const dialtoneCSS = isDevelopment ? 'dialtone.css' : 'dialtone.min.css';
+const dialtoneDocsCSS = isDevelopment ? 'dialtone-docs.css' : 'dialtone-docs.min.css';
 
 export default defineUserConfig({
   // site config
@@ -72,5 +77,7 @@ export default defineUserConfig({
     '@svgIcons': resolve(__dirname, '../../lib/dist/vue/icons/'), // Needed to easily import svg
     '@theme': resolve(__dirname, './theme'),
     '@exampleComponents': resolve(__dirname, './exampleComponents'),
+    '@dialtoneCSS': resolve(__dirname, '../assets/css/' + dialtoneCSS),
+    '@dialtoneDocsCSS': resolve(__dirname, '../assets/css/' + dialtoneDocsCSS)
   },
 })

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -17,8 +17,7 @@ const themeConfig = {
   sidebar,
   editLink: false,
   darkMode: false,
-  // contributors: false,
-  // lastUpdated: false,
+  contributors: false,
 };
 
 const isDevelopment = (process.env.NODE_ENV === 'development');


### PR DESCRIPTION
## Description

Changed the way we were importing CSS
Changed port back to 4000
Disabled contributors as the only contributor is the bot

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/7rJE4vH3ItKDu/giphy.gif)
