### PR TITLE
fix: circle button hover and active colors

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -155,6 +155,11 @@ Different button styles and variations appear different when active.
         <span class="d-btn__label">Place call</span>
       </button>
     </div>
+    <div>
+      <button class="d-btn d-btn--muted d-btn--active" type="button">
+        <span class="d-btn__label">Place call</span>
+      </button>
+    </div>
   </div>
 </code-well-header>
 

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -219,13 +219,15 @@
     padding: calc(var(--su8) + var(--su1));
     transition-duration: 150ms;
 
-    &:hover,
-    &:active {
+    &:hover {
         --button--fc: var(--muted-color-hover);
         --button--bgc: hsla(var(--black-800-hsl) ~' / ' 3%);
     }
 
-    &:active {
+    &:active,
+    &.d-btn--active,
+    &.d-btn--active:active {
+        --button--fc: var(--muted-color-hover);
         --button--bgc: hsla(var(--black-800-hsl) ~' / ' 9%);
     }
 
@@ -301,14 +303,16 @@
 .d-btn--muted {
     --button--fc: var(--muted-color);
 
-    &:hover,
-    &:active {
-      --button--fc: var(--muted-color-hover);
-      --button--bgc: hsla(var(--black-800-hsl) ~' / ' 3%);
+    &:hover {
+        --button--fc: var(--muted-color-hover);
+        --button--bgc: hsla(var(--black-800-hsl) ~' / ' 3%);
     }
 
-    &:active {
-      --button--bgc: hsla(var(--black-800-hsl) ~' / ' 9%);
+    &:active,
+    &.d-btn--active,
+    &.d-btn--active:active {
+        --button--fc: var(--muted-color-hover);
+        --button--bgc: hsla(var(--black-800-hsl) ~' / ' 9%);
     }
 
     &:focus-visible {

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -219,6 +219,16 @@
     padding: calc(var(--su8) + var(--su1));
     transition-duration: 150ms;
 
+    &:hover,
+    &:active {
+        --button--fc: var(--muted-color-hover);
+        --button--bgc: hsla(var(--black-800-hsl) ~' / ' 3%);
+    }
+
+    &:active {
+        --button--bgc: hsla(var(--black-800-hsl) ~' / ' 9%);
+    }
+
     &:focus-visible {
         box-shadow: var(--bs-focus-ring-circle);
     }


### PR DESCRIPTION
## Description

The foreground of muted circle buttons is purple on hover in dialtone. This does not match the figma design, as well as the non circle muted button.

Fixed the hover and active colors of circle and muted buttons.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/s9FnbSA9469AQ/giphy.gif)
