### PR TITLE
feat(modal): add dialog scrollable class

### DIFF
--- a/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -30,11 +30,12 @@
     >
       <h2 class="d-modal__header">Example title</h2>
       <div class="d-modal__content">
-        <p id="modal-description">Sed at orci quis nunc finibus gravida eget vitae est. Praesent
-          ac laoreet mi. Cras porttitor mauris ex. Integer convallis tellus a ex egestas, id laoreet elit mollis. Mauris
-          ut elementum velit. Nam vel consectetur turpis. Aenean consequat purus non nunc tincidunt rutrum. In semper
-          pretium dui vel tempus. Proin et mi id mi egestas iaculis. Sed lacinia libero non molestie consequat. Sed
-          efficitur purus eget lacus viverra volutpat. Nam luctus ac eros eu iaculis. Fusce non condimentum lorem.</p>
+        <p id="modal-description">
+          {{ this.modalDescription }}
+          <template v-if="isFixed">
+            {{ this.modalDescription.repeat(3) }}
+          </template>
+        </p>
         <p class="d-mt16">
           <a href="#" class="d-link" @click.prevent="openModalBanner">Show me a modal banner</a>
         </p>
@@ -94,6 +95,11 @@ export default {
       showModalBanner: false,
       animateIn: false,
       animateOut: false,
+      modalDescription: `Sed at orci quis nunc finibus gravida eget vitae est. Praesent
+          ac laoreet mi. Cras porttitor mauris ex. Integer convallis tellus a ex egestas, id laoreet elit mollis. Mauris
+          ut elementum velit. Nam vel consectetur turpis. Aenean consequat purus non nunc tincidunt rutrum. In semper
+          pretium dui vel tempus. Proin et mi id mi egestas iaculis. Sed lacinia libero non molestie consequat. Sed
+          efficitur purus eget lacus viverra volutpat. Nam luctus ac eros eu iaculis. Fusce non condimentum lorem.`,
     }
   },
   computed: {

--- a/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -31,9 +31,9 @@
       <h2 class="d-modal__header">Example title</h2>
       <div class="d-modal__content">
         <p id="modal-description">
-          {{ this.modalDescription }}
+          {{ modalDescription }}
           <template v-if="isFixed">
-            {{ this.modalDescription.repeat(3) }}
+            {{ modalDescription.repeat(3) }}
           </template>
         </p>
         <p class="d-mt16">

--- a/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -24,7 +24,7 @@
       :class="{
         'd-modal__dialog--animate-in': animateIn,
         'd-modal__dialog--animate-out': animateOut,
-        'd-modal__dialog--scrollable': isFixed
+        'd-modal__dialog--scrollable d-hmx764': isFixed
       }"
       role="document"
     >
@@ -110,7 +110,7 @@ export default {
       return this.kind === 'danger';
     },
     isFixed() {
-      return this.kind === 'fixed'
+      return this.kind === 'fixed';
     }
   },
   methods: {

--- a/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -23,19 +23,22 @@
       class="d-modal__dialog"
       :class="{
         'd-modal__dialog--animate-in': animateIn,
-        'd-modal__dialog--animate-out': animateOut
+        'd-modal__dialog--animate-out': animateOut,
+        'd-modal__dialog--scrollable': isFixed
       }"
       role="document"
     >
       <h2 class="d-modal__header">Example title</h2>
-      <p class="d-modal__content" id="modal-description">Sed at orci quis nunc finibus gravida eget vitae est. Praesent
-        ac laoreet mi. Cras porttitor mauris ex. Integer convallis tellus a ex egestas, id laoreet elit mollis. Mauris
-        ut elementum velit. Nam vel consectetur turpis. Aenean consequat purus non nunc tincidunt rutrum. In semper
-        pretium dui vel tempus. Proin et mi id mi egestas iaculis. Sed lacinia libero non molestie consequat. Sed
-        efficitur purus eget lacus viverra volutpat. Nam luctus ac eros eu iaculis. Fusce non condimentum lorem.</p>
-      <p class="d-modal__content">
-        <a href="#" class="d-link" @click.prevent="openModalBanner">Show me a modal banner</a>
-      </p>
+      <div class="d-modal__content">
+        <p id="modal-description">Sed at orci quis nunc finibus gravida eget vitae est. Praesent
+          ac laoreet mi. Cras porttitor mauris ex. Integer convallis tellus a ex egestas, id laoreet elit mollis. Mauris
+          ut elementum velit. Nam vel consectetur turpis. Aenean consequat purus non nunc tincidunt rutrum. In semper
+          pretium dui vel tempus. Proin et mi id mi egestas iaculis. Sed lacinia libero non molestie consequat. Sed
+          efficitur purus eget lacus viverra volutpat. Nam luctus ac eros eu iaculis. Fusce non condimentum lorem.</p>
+        <p class="d-mt16">
+          <a href="#" class="d-link" @click.prevent="openModalBanner">Show me a modal banner</a>
+        </p>
+      </div>
       <footer class="d-modal__footer">
         <button
           class="d-btn d-btn--primary"
@@ -68,7 +71,7 @@
 </template>
 
 <script>
-const MODAL_KINDS = ['full-screen', 'danger', 'base'];
+const MODAL_KINDS = ['full-screen', 'danger', 'fixed', 'base'];
 import IconClose from '@svgIcons/IconClose.vue';
 
 export default {
@@ -99,6 +102,9 @@ export default {
     },
     isDanger() {
       return this.kind === 'danger';
+    },
+    isFixed() {
+      return this.kind === 'fixed'
     }
   },
   methods: {

--- a/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -119,6 +119,8 @@ export default {
       this.animateIn = true;
 
       this.showModal = true;
+
+      document.body.classList.add('d-of-hidden');
     },
     openModalBanner() {
       this.showModalBanner = true;
@@ -129,6 +131,8 @@ export default {
 
       this.showModal = false;
       this.showModalBanner = false;
+
+      document.body.classList.remove('d-of-hidden');
     }
   }
 }

--- a/docs/_data/modal.json
+++ b/docs/_data/modal.json
@@ -31,6 +31,11 @@
       "description": "Adds proper styling for the modal's dismiss button."
     },
     {
+      "class": "d-modal__dialog--scrollable",
+      "applies": ".d-modal__dialog",
+      "description": "Adds vertical scroll to the modal content keeping fixed the header and footer."
+    },
+    {
       "class": "d-modal--full",
       "applies": ".d-modal",
       "description": "Makes <span class=\"code-example--inline\">.d-modal__dialog</span> take up as much of the screen as possible."

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -72,6 +72,25 @@ At minimum, modals contain a title and one button. They could also contain body 
 </aside>
 ```
 
+### Fixed header and footer
+<code-well-header>
+  <example-modal kind="fixed" />
+</code-well-header>
+
+```html
+<aside class="d-modal" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
+  <div class="d-modal__dialog d-modal__dialog--scrollable" role="document">
+    <h2 class="d-modal__header" id="modal-title">…</h2>
+    <p class="d-modal__content" id="modal-description">…</p>
+    <footer class="d-modal__footer">
+      <button class="d-btn" type="button">…</button>
+      <button class="d-btn d-btn--primary" type="button">…</button>
+    </footer>
+    <button href="#" class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close"><IconClose /></button>
+  </div>
+</aside>
+```
+
 ### Danger
 <code-well-header>
   <example-modal kind="danger" />

--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -214,6 +214,17 @@
   }
 }
 
+// $$   SCROLLABLE
+//  ----------------------------------------------------------------------------
+.d-modal__dialog--scrollable {
+  display: flex;
+  flex-direction: column;
+
+  .d-modal__content {
+    overflow-y: auto;
+  }
+}
+
 //  $$  DANGER
 //  ----------------------------------------------------------------------------
 .d-modal--danger {


### PR DESCRIPTION
## Description
Added `d-modal__dialog--scrollable` class to make the modal main content scrollable but the header and footer fixed.

In the modal documentation, added the ["fixed header and footer" example](https://dialpad.design/deploy-previews/pr-593/components/modal.html#fixed-header-and-footer)

cc @francisrupert for visual review.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
💡 Guess the movie
![tumblr_01988e49eb36075fb9e2dacdcfa6fb3b_78469d7e_540](https://user-images.githubusercontent.com/83774467/168386807-fe9e2d58-c92b-4ef0-988a-d8df8092a348.gif)

