### PR TITLE
feat(interactivity): add resize property

### DIFF
--- a/docs/_data/interactivity.json
+++ b/docs/_data/interactivity.json
@@ -112,5 +112,23 @@
       "class": "d-us-none",
       "output": "user-select: none !important;"
     }
+  ],
+  "resize": [
+    {
+      "class": "d-r-both",
+      "output": "resize: both !important;"
+    },
+    {
+      "class": "d-r-horizontal",
+      "output": "resize: horizontal!important;"
+    },
+    {
+      "class": "d-r-vertical",
+      "output": "resize: vertical!important;"
+    },
+    {
+      "class": "d-r-none",
+      "output": "resize: none!important;"
+    }
   ]
 }

--- a/docs/_data/interactivity.json
+++ b/docs/_data/interactivity.json
@@ -120,15 +120,15 @@
     },
     {
       "class": "d-r-horizontal",
-      "output": "resize: horizontal!important;"
+      "output": "resize: horizontal !important;"
     },
     {
       "class": "d-r-vertical",
-      "output": "resize: vertical!important;"
+      "output": "resize: vertical !important;"
     },
     {
       "class": "d-r-none",
-      "output": "resize: none!important;"
+      "output": "resize: none !important;"
     }
   ]
 }

--- a/docs/_data/site-nav.js
+++ b/docs/_data/site-nav.js
@@ -341,6 +341,10 @@ module.exports = {
               title: "Pointer Events",
               url: `${Site.baseurl}utilities/interactivity/pointer-events/`,
             },
+            {
+              title: "Resize",
+              url: `${Site.baseurl}utilities/interactivity/resize/`,
+            },
           ],
         },
         {

--- a/docs/_data/site-nav.json
+++ b/docs/_data/site-nav.json
@@ -288,7 +288,11 @@
         {
           "text": "Pointer Events",
           "link": "/utilities/interactivity/pointer-events.html"
-        }
+        },
+        {
+          "text": "Resize",
+          "link": "/utilities/interactivity/resize.html"
+      }
       ]
     },
     {

--- a/docs/utilities/interactivity/pointer-events.md
+++ b/docs/utilities/interactivity/pointer-events.md
@@ -1,9 +1,6 @@
 ---
 title: Pointer Events
 desc: Utilities for controlling how an element responds to mouse/touch events.
-next:
-  text: Box Sizing
-  link: /utilities/layout/box-sizing
 ---
 ## Classes
 <utility-class-table>

--- a/docs/utilities/interactivity/resize.md
+++ b/docs/utilities/interactivity/resize.md
@@ -1,0 +1,37 @@
+---
+title: Resize
+desc: Utilities for controlling the resize of an element.
+next:
+  text: Box Sizing
+  link: /utilities/layout/box-sizing
+---
+## Classes
+<utility-class-table>
+  <template #content>
+    <tbody>
+      <tr v-for="{ class: className, output } in resize">
+        <th scope="row" class="d-ff-mono d-fc-purple d-fs12">.{{ className }}</th>
+        <td class="d-ff-mono d-fc-orange d-fs12">{{ output }}</td>
+      </tr>
+    </tbody>
+  </template>
+</utility-class-table>
+
+## Usage
+
+<code-well-header class="d-p32 d-bgc-purple-100 d-bgo50 d-w100p d-hmn102" custom>
+  <div v-for="{ class: className } in resize.slice(0, 4)" :class="className" class="d-of-auto d-mb8 d-py8 d-px16 d-bar8 d-ba d-bc-purple-400 d-bgc-white d-bgo50 d-fc-black-700 d-fs18">
+    .{{ className }}
+  </div>
+</code-well-header>
+
+```html
+<div class="d-r-both">...</div>
+<div class="d-r-horizontal">...</div>
+<div class="d-r-vertical">...</div>
+<div class="d-r-none">...</div>
+```
+
+<script setup>
+  import { resize } from '@data/interactivity.json';
+</script>

--- a/lib/build/less/utilities/interactivity.less
+++ b/lib/build/less/utilities/interactivity.less
@@ -63,7 +63,7 @@
 //      The resize CSS property sets whether an element is resizable,
 //      and if so, in which directions.
 //  ----------------------------------------------------------------------------
-.d-r-both { resize: both!important; }
-.d-r-horizontal { resize: horizontal!important; }
-.d-r-vertical { resize: vertical!important; }
-.d-r-none { resize: none!important; }
+.d-r-both { resize: both !important; }
+.d-r-horizontal { resize: horizontal !important; }
+.d-r-vertical { resize: vertical !important; }
+.d-r-none { resize: none !important; }

--- a/lib/build/less/utilities/interactivity.less
+++ b/lib/build/less/utilities/interactivity.less
@@ -57,3 +57,13 @@
 
 .d-us-auto { user-select: auto !important; }
 .d-us-none { user-select: none !important; }
+
+//============================================================================
+//  $   RESIZE
+//      The resize CSS property sets whether an element is resizable,
+//      and if so, in which directions.
+//  ----------------------------------------------------------------------------
+.d-r-both { resize: both!important; }
+.d-r-horizontal { resize: horizontal!important; }
+.d-r-vertical { resize: vertical!important; }
+.d-r-none { resize: none!important; }


### PR DESCRIPTION
## Description
Add resize property to allow the interaction with some of the elements, like the `dt-input` when using textarea, or if a resizable div is needed.

## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![image](https://media.giphy.com/media/BpGWitbFZflfSUYuZ9/giphy.gif)
