### PR TITLE
fix(modal): focus ring being cut off in fixed header and footer

### DIFF
--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -84,7 +84,6 @@
   width: 100%;
   max-width: var(--size628);
   max-height: 100%;
-  padding: var(--su24);
   overflow-y: auto;
   color: var(--modal-dialog--fc);
   font-size: var(--fs16);
@@ -121,10 +120,14 @@
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
-  margin: var(--sun4);
+  padding: 0 var(--su24) var(--su24) var(--su24);
 
-  > * {
-    margin: var(--su4);
+  >:not(:first-child) {
+    margin-right: var(--su4);
+  }
+
+  >:not(:last-child) {
+    margin-left: var(--su4);
   }
 }
 
@@ -136,6 +139,7 @@
 //  ----------------------------------------------------------------------------
 .d-modal__header {
   margin: 0 !important;
+  padding: var(--su24) var(--su24) 0;
   color: var(--modal-header--fc);
   font-weight: var(--fw-bold);
   font-size: var(--fs24);
@@ -147,6 +151,8 @@
 .d-modal__content {
   max-width: 75ch;
   margin: 0;
+  padding-right: var(--su24);
+  padding-left: var(--su24);
 }
 
 
@@ -196,15 +202,22 @@
     flex-direction: column;
     max-width: unset;
     height: 100%;
-    padding: var(--su32);
     border-radius: 0;
     transform: unset !important;
   }
 
+  .d-modal__header {
+    padding: var(--su32) var(--su32) 0;
+  }
+
+  .d-modal__content {
+    padding-right: 0;
+    padding-left: var(--su32);
+  }
 
   .d-modal__footer {
-    margin: var(--sun16) var(--sun12);
     margin-top: auto !important;
+    padding: 0 var(--su24) var(--su32) var(--su32);
   }
 
   .d-modal__banner {
@@ -219,6 +232,7 @@
 .d-modal__dialog--scrollable {
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 
   .d-modal__content {
     overflow-y: auto;

--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -150,9 +150,8 @@
 //  ----------------------------------------------------------------------------
 .d-modal__content {
   max-width: 75ch;
-  margin: 0;
-  padding-right: var(--su24);
-  padding-left: var(--su24);
+  margin: var(--su12) 0 0 !important;
+  padding: var(--su4) var(--su24);
 }
 
 


### PR DESCRIPTION
## Description
Found an issue with the `d-modal__dialog--scrollable` class added in [this PR](https://github.com/dialpad/dialtone/pull/593) that was cutting the focus ring due to the overflow property set.

<img width="684" alt="2022-05-18 at 18 55 21@2x" src="https://user-images.githubusercontent.com/83774467/169162461-16d600f7-5bc5-4dbc-bcbc-d400756c9ccf.png">

Solved by changing the way the padding is applied going from single padding in the `d-modal__dialog` to set individual padding to each section: header, content and footer.

## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [ ] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://c.tenor.com/k-LrIqE73LAAAAAC/to-rule.gif)
