### PR TITLE
fix(Chip): add Preview and reorder docs

### DIFF
--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -1,18 +1,22 @@
 ---
 title: Chip
-desc: A chip is a compact UI element that provides brief, descriptive information about an element. It is terse, ideally one word.
+desc: A Chip is a compact UI element that provides brief, descriptive information about an element. It is terse, ideally one word.
+storybook_url: https://vue.dialpad.design/?path=/story/components-chip--default
 ---
 
-## Classes
-<component-class-table component-name="chip" />
+<code-well-header>
+  <example-chip label="Chip" with-avatar/>
+</code-well-header>
 
+[//]: # (## Usage)
+[//]: # (Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi massa ante, tempus vitae lacus id, luctus tristique lorem. Mauris feugiat massa ex, id aliquet mi tempor non. Curabitur non tristique lectus. Fusce ut nisl non diam dignissim viverra. In posuere dui arcu, sed eleifend massa faucibus sed. Phasellus quis leo vitae erat pellentesque venenatis id vitae lectus. Suspendisse convallis, metus a congue tincidunt, velit sem tincidunt dui, eget auctor ipsum ipsum in ex. Nullam lobortis, mauris vel vestibulum rutrum, lorem elit vehicula est, nec viverra ante erat nec dolor. Proin at placerat tortor. Nam ullamcorper metus et eros porta, at lacinia leo scelerisque. Curabitur finibus sollicitudin odio tempor finibus. Donec lobortis metus vitae mollis gravida.)
 
-## Examples
-  
+## Variants and Examples
+
 ### Base
 The base chip should be the go-to chip for most of your needs.
 <code-well-header>
-  <example-chip label="Chip"/>  
+  <example-chip label="Chip"/>
 </code-well-header>
 
 ```html
@@ -32,7 +36,7 @@ The base chip should be the go-to chip for most of your needs.
 ```
 
 ### With icon
-<code-well-header> 
+<code-well-header>
   <example-chip label="Chip" with-icon hide-close-btn/>
 </code-well-header>
 
@@ -73,7 +77,7 @@ The base chip should be the go-to chip for most of your needs.
 No `.d-chip--interactive` class.
 
 <code-well-header>
-  <example-chip label="Chip" :interactive="false"/>  
+  <example-chip label="Chip" :interactive="false"/>
 </code-well-header>
 
 ```html
@@ -113,3 +117,9 @@ No `.d-chip--interactive` class.
 <script setup>
   import ExampleChip from '@exampleComponents/ExampleChip.vue';
 </script>
+
+## Classes
+<component-class-table component-name="chip" />
+
+[//]: # (## Accessibility)
+[//]: # (Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi massa ante, tempus vitae lacus id, luctus tristique lorem. Mauris feugiat massa ex, id aliquet mi tempor non. Curabitur non tristique lectus. Fusce ut nisl non diam dignissim viverra. In posuere dui arcu, sed eleifend massa faucibus sed. Phasellus quis leo vitae erat pellentesque venenatis id vitae lectus. Suspendisse convallis, metus a congue tincidunt, velit sem tincidunt dui, eget auctor ipsum ipsum in ex. Nullam lobortis, mauris vel vestibulum rutrum, lorem elit vehicula est, nec viverra ante erat nec dolor. Proin at placerat tortor. Nam ullamcorper metus et eros porta, at lacinia leo scelerisque. Curabitur finibus sollicitudin odio tempor finibus. Donec lobortis metus vitae mollis gravida.)


### PR DESCRIPTION
## Description
Previous release introduced Preview just below intro and reordered doc page sections to prioritize visual variants and examples.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![asdfasdf](https://user-images.githubusercontent.com/1165933/170611286-35041f83-cdd5-455e-a93b-3c07c4ab404d.gif)

