### PR TITLE
docs: created a component to render markdown within vue components

### DIFF
--- a/docs/.vuepress/baseComponents/Markdown.vue
+++ b/docs/.vuepress/baseComponents/Markdown.vue
@@ -1,0 +1,21 @@
+<template>
+  <div v-html="renderedMarkdown" />
+</template>
+
+<script>
+import markdownIt from 'markdown-it';
+
+// Takes markdown syntax in the default slot and converts it to HTML and renders it.
+export default {
+  name: 'Markdown',
+
+  setup(props, {slots}) {
+    const slotString = slots.default()[0].children.trim();
+    let md = new markdownIt({ html: true }),
+        renderedMarkdown = md.render(slotString);
+    return {
+      renderedMarkdown
+    }
+  },
+}
+</script>

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -5,6 +5,8 @@ const sidebar = require('../_data/site-nav.json');
 const { dialtoneTheme } = require('./theme');
 const baseURL = (process.env.VUEPRESS_BASE_URL ?? "/") as `/${string}/`;
 
+const { viteBundler } = require('@vuepress/bundler-vite')
+
 const themeConfig = {
   logo: baseURL + 'assets/images/dialpad-logo.svg',
   navbar: [
@@ -35,6 +37,17 @@ export default defineUserConfig({
 
   // theme and its config
   theme: dialtoneTheme(themeConfig),
+
+  bundler: viteBundler({
+    viteOptions: {},
+    vuePluginOptions: {
+      template: {
+        compilerOptions: {
+          whitespace: 'preserve'
+        }
+      }
+    },
+  }),
 
   // Header links and meta tags
   head: [
@@ -78,6 +91,7 @@ export default defineUserConfig({
     '@svgIcons': resolve(__dirname, '../../lib/dist/vue/icons/'), // Needed to easily import svg
     '@theme': resolve(__dirname, './theme'),
     '@exampleComponents': resolve(__dirname, './exampleComponents'),
+    '@baseComponents': resolve(__dirname, './baseComponents'),
     '@dialtoneCSS': resolve(__dirname, '../assets/css/' + dialtoneCSS),
     '@dialtoneDocsCSS': resolve(__dirname, '../assets/css/' + dialtoneDocsCSS)
   },


### PR DESCRIPTION
## Description
Francis was wondering if it was possible to render markdown within a vue component. VuePress already includes a library called markdown-it to convert markdown to html. So wrote a small wrapper using this library to do the conversion.

Can be used like so

```
import Markdown from "@baseComponents/Markdown.vue";

<Markdown>
## Header

- List item 1
- List item 2
</Markdown>
```

Be careful not to indent the slot content, as white space has meaning in markdown.

Had to set a compiler option to preserve whitespace in slots as this is important for markdown.

## Pull Request Checklist

 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/du3J3cXyzhj75IOgvA/giphy.gif)
