### PR TITLE
docs: fix checkbox selection in preview and examples sections

### DIFF
--- a/docs/.vuepress/exampleComponents/ExampleBanner.vue
+++ b/docs/.vuepress/exampleComponents/ExampleBanner.vue
@@ -19,14 +19,26 @@
             </div>
           </div>
         </div>
-        <div class="d-input-group d-d-flex d-ai-center d-fl0 d-flow6">
-          <input type="checkbox" id="style-select-important" class="d-checkbox d-mt1" v-model="important"/>
-          <label for="style-select-important" class="d-label d-fs14 d-lh2">Important?</label>
-        </div>
-        <div class="d-input-group d-d-flex d-ai-center d-fl0 d-flow6">
-          <input type="checkbox" id="style-select-pinned" class="d-checkbox d-mt1" v-model="pinned"/>
-          <label for="style-select-pinned" class="d-label d-fs14 d-lh2">Pinned?</label>
-        </div>
+        <label>
+          <div class="d-checkbox-group">
+            <div class="d-checkbox__input">
+              <input type="checkbox" class="d-checkbox" v-model="important" />
+            </div>
+            <span class="d-checkbox__copy d-checkbox__label d-mb6 d-fw-bold">
+              Important?
+            </span>
+          </div>
+        </label>
+        <label>
+          <div class="d-checkbox-group">
+            <div class="d-checkbox__input">
+              <input type="checkbox" class="d-checkbox" v-model="pinned" />
+            </div>
+            <span class="d-checkbox__copy d-checkbox__label d-mb6 d-fw-bold">
+              Pinned?
+            </span>
+          </div>
+        </label>
         <button class="d-btn d-btn--outlined d-btn--sm" role="button" @click="toggleExample">
           Toggle example
         </button>

--- a/docs/.vuepress/exampleComponents/ExampleToast.vue
+++ b/docs/.vuepress/exampleComponents/ExampleToast.vue
@@ -19,10 +19,16 @@
             </div>
           </div>
         </div>
-        <div class="d-input-group d-d-flex d-ai-center d-fl0 d-flow6">
-          <input type="checkbox" id="style-select-important" class="d-checkbox d-mt1" v-model="important"/>
-          <label for="style-select-important" class="d-label d-fs14 d-lh2">Important?</label>
-        </div>
+        <label>
+          <div class="d-checkbox-group">
+            <div class="d-checkbox__input">
+              <input type="checkbox" class="d-checkbox" v-model="important" />
+            </div>
+            <span class="d-checkbox__copy d-checkbox__label d-mb6 d-fw-bold">
+              Important?
+            </span>
+          </div>
+        </label>
         <button class="d-btn d-btn--outlined d-btn--sm" role="button" @click="toggleExample">Toggle example</button>
       </div>
     </div>


### PR DESCRIPTION
## Description
Fixes https://dialpad.atlassian.net/browse/DT-478 where the checkboxes in the "Preview" and "Variants and Examples" section were using the same id so checking one box also was checking the box in the other section.

Components affected:
- Toast
- Banner

## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [ ] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
🧩 Guess the movie
![gif](https://user-images.githubusercontent.com/83774467/171059405-dbd3fb26-af58-4676-b811-a27e07c61126.gif)

