### PR TITLE
fix: make @define-font-path scoped variable

### DIFF
--- a/lib/build/less/utilities/internals.less
+++ b/lib/build/less/utilities/internals.less
@@ -12,13 +12,8 @@
 //      Various configuration settings to generate the classes desired.
 //  ----------------------------------------------------------------------------
 #d-internal-config {
-
     //  Do we want to generate font-face CSS?
     @generate-font-face:             true;
-
-    //  What's the font-face file path?
-    @define-font-path:               '../fonts/';
-
 }
 
 //  ============================================================================
@@ -382,6 +377,9 @@
     //  ------------------------------------------------------------------------
     #font-face(@type, @name, @style: normal) {
         #d-internal-config();
+
+        //  Path of the fonts that Dialtone provides
+        @define-font-path: '../../fonts/';
 
         if((@generate-font-face = true), each(@type, {
             @font-face {

--- a/lib/build/less/utilities/internals.less
+++ b/lib/build/less/utilities/internals.less
@@ -386,7 +386,7 @@
                 font-style: @style;
                 font-weight: @key;
                 font-family: @name;
-                src: url("@{define-font-path}@{value}.woff2") format("woff2");
+                src: url("./@{define-font-path}@{value}.woff2") format("woff2");
             };
         }));
     }


### PR DESCRIPTION
## Description
Since [Dialtone provides the fonts](https://github.com/dialpad/dialtone/tree/staging/lib/build/fonts) in the library, there's no need to overwrite this variable anymore to specify the directory in the consumer [like here](https://github.com/dialpad/firespotter/blob/master/ubervoice/static/css/dialtone-globals.less#L10) where the fonts are placed. So changed it to be an internal variable.

~⚠️ Found a weird issue with the `@define-font-path` Less variable in a fresh project using Vite, it doesn't get the correct path from Dialtone. Replacing the `@define-font-path` variable with the value of it (`../../fonts/`) works properly so I'm figuring out the cause.~
✅ The issue was due to a conflict with the less variable `@define-font-path` and the alias set by default in Vite (`@`). The fix is here https://github.com/dialpad/dialtone/pull/604/commits/7d230acc1b09f0c76972c33c62b93f63fe8cb674 and now Dialtone fonts work by default also with Vite.

## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
 - [x] Request a review from Brad Paugh, David Becher, or Drew Chandler.

## Obligatory GIF (super important!)
![](https://c.tenor.com/PE3yfK4fdk0AAAAC/how-i-met-your-mother-himym.gif)
