### PR TITLE
fix(Chip): improvements to semantic html

### DIFF
--- a/docs/.vuepress/exampleComponents/ExampleChip.vue
+++ b/docs/.vuepress/exampleComponents/ExampleChip.vue
@@ -14,12 +14,11 @@
         <icon-phone />
       </span>
       <span :class="{'d-truncate': truncate}">{{ label }}</span>
-      <span v-if="!hideCloseBtn" class="d-chip-btn-holder"></span>
     </component>
     <button
         v-if="!hideCloseBtn"
         aria-label="close"
-        :class="['d-btn', 'd-btn--circle', 'd-chip-close-btn', {[`d-chip-close-btn--${size}`]: size}]"
+        :class="['d-chip-close-btn', {[`d-chip-close-btn--${size}`]: size}]"
     >
       <span class="d-btn__icon" ref="closeBtn"><icon-close/></span>
     </button>

--- a/docs/.vuepress/exampleComponents/ExampleChip.vue
+++ b/docs/.vuepress/exampleComponents/ExampleChip.vue
@@ -2,6 +2,7 @@
   <span class="d-chip-container">
     <component
         :is="interactive ? 'button' : 'span'"
+        :type="interactive ? 'button' : undefined"
         :class="['d-chip', {
           'd-w102': truncate,
           [`d-chip--${size}`]: size

--- a/docs/.vuepress/exampleComponents/ExampleChip.vue
+++ b/docs/.vuepress/exampleComponents/ExampleChip.vue
@@ -1,11 +1,11 @@
 <template>
-  <span class="d-chip-container">
+  <span class="d-chip">
     <component
         :is="interactive ? 'button' : 'span'"
         :type="interactive ? 'button' : undefined"
-        :class="['d-chip', {
+        :class="['d-chip__label', {
           'd-w102': truncate,
-          [`d-chip--${size}`]: size
+          [`d-chip__label--${size}`]: size
         }]"
     >
       <span v-if="withAvatar" class="d-avatar">
@@ -19,7 +19,7 @@
     <button
         v-if="!hideCloseBtn"
         aria-label="close"
-        :class="['d-chip-close-btn', {[`d-chip-close-btn--${size}`]: size}]"
+        :class="['d-chip__close', {[`d-chip__close--${size}`]: size}]"
     >
       <span class="d-btn__icon" ref="closeBtn"><icon-close/></span>
     </button>

--- a/docs/.vuepress/exampleComponents/ExampleChip.vue
+++ b/docs/.vuepress/exampleComponents/ExampleChip.vue
@@ -1,43 +1,34 @@
 <template>
-  <span
-      class="d-chip"
-      :class="{
-        'd-chip--interactive': interactive,
-        'd-w102': truncate,
-        'd-chip--active': isActive,
-        [`d-chip--${size}`]: size
-      }"
-      :tabindex="interactive ? 0 : -1"
-      @mousedown="setActive"
-      @mouseup="setActive"
-      @mouseleave="isActive = false"
-      @focusout="isActive = false"
-  >
-    <span v-if="withAvatar" class="d-avatar">
-      <img src="/assets/images/person.png" alt="" />
-    </span>
-    <span v-if="withIcon" class="d-chip__icon">
-      <icon-phone />
-    </span>
-    <span :class="{'d-truncate': truncate}">{{ label }}</span>
-    <span v-if="!hideCloseBtn" class="d-chip-btn-holder"></span>
-    <span class="d-chip-btn-container">
-      <button
-          v-if="!hideCloseBtn"
-          aria-label="close"
-          class="d-btn d-btn--circle"
-          type="button"
-      >
-        <span class="d-btn__icon" ref="closeBtn"><icon-close/></span>
-      </button>
-    </span>
+  <span class="d-chip-container">
+    <component
+        :is="interactive ? 'button' : 'span'"
+        :class="['d-chip', {
+          'd-w102': truncate,
+          [`d-chip--${size}`]: size
+        }]"
+    >
+      <span v-if="withAvatar" class="d-avatar">
+        <img src="/assets/images/person.png" alt="" />
+      </span>
+      <span v-if="withIcon" class="d-chip__icon">
+        <icon-phone />
+      </span>
+      <span :class="{'d-truncate': truncate}">{{ label }}</span>
+      <span v-if="!hideCloseBtn" class="d-chip-btn-holder"></span>
+    </component>
+    <button
+        v-if="!hideCloseBtn"
+        aria-label="close"
+        :class="['d-btn', 'd-btn--circle', 'd-chip-close-btn', {[`d-chip-close-btn--${size}`]: size}]"
+    >
+      <span class="d-btn__icon" ref="closeBtn"><icon-close/></span>
+    </button>
   </span>
 </template>
 
 <script setup>
 import {ref} from 'vue';
 
-const isActive = ref(false);
 const closeBtn = ref(null);
 
 const props = defineProps({
@@ -49,10 +40,5 @@ const props = defineProps({
   truncate: { type: Boolean, default: false },
   size: { type: String }
 })
-
-function setActive(event) {
-  if(!props.interactive || closeBtn.value.parentNode.contains(event.target)) return;
-  isActive.value = event.type === 'mousedown';
-}
 
 </script>

--- a/docs/_data/chip.json
+++ b/docs/_data/chip.json
@@ -1,14 +1,9 @@
 {
   "classes": [
     {
-      "class": "d-chip--xs",
-      "applies": "d-chip",
-      "description": "Applies extra small size."
-    },
-    {
-      "class": "d-chip--sm",
-      "applies": "d-chip",
-      "description": "Applies small size."
+      "class": "d-chip-container",
+      "applies": "N/A",
+      "description": "Container for the chip button and close button elements."
     },
     {
       "class": "d-chip",
@@ -16,9 +11,34 @@
       "description": "Default button size."
     },
     {
-      "class": "d-chip--interactive",
+      "class": "d-chip--sm",
       "applies": "d-chip",
-      "description": "Applies hover,focused,active states. (default)"
+      "description": "Applies small size."
+    },
+    {
+      "class": "d-chip--xs",
+      "applies": "d-chip",
+      "description": "Applies extra small size."
+    },
+    {
+      "class": "d-chip-close-btn",
+      "applies": "N/A",
+      "description": "Applies positioning and styling for the chip close button."
+    },
+    {
+      "class": "d-chip-close-btn--sm",
+      "applies": "N/A",
+      "description": "Small close button."
+    },
+    {
+      "class": "d-chip-close-btn--xs",
+      "applies": "N/A",
+      "description": "Extra small close button."
+    },
+    {
+      "class": "d-chip__icon",
+      "applies": "N/A",
+      "description": "Applies positioning and styling for the chip icon."
     }
   ]
 }

--- a/docs/_data/chip.json
+++ b/docs/_data/chip.json
@@ -1,37 +1,37 @@
 {
   "classes": [
     {
-      "class": "d-chip-container",
+      "class": "d-chip",
       "applies": "N/A",
       "description": "Container for the chip button and close button elements."
     },
     {
-      "class": "d-chip",
+      "class": "d-chip__label",
       "applies": "N/A",
-      "description": "Default button size."
+      "description": "Default chip styling"
     },
     {
-      "class": "d-chip--sm",
+      "class": "d-chip__label--sm",
       "applies": "d-chip",
       "description": "Applies small size."
     },
     {
-      "class": "d-chip--xs",
+      "class": "d-chip__label--xs",
       "applies": "d-chip",
       "description": "Applies extra small size."
     },
     {
-      "class": "d-chip-close-btn",
+      "class": "d-chip__close",
       "applies": "N/A",
       "description": "Applies positioning and styling for the chip close button."
     },
     {
-      "class": "d-chip-close-btn--sm",
+      "class": "d-chip__close--sm",
       "applies": "d-chip-close-btn",
       "description": "Small close button."
     },
     {
-      "class": "d-chip-close-btn--xs",
+      "class": "d-chip__close--xs",
       "applies": "d-chip-close-btn",
       "description": "Extra small close button."
     },

--- a/docs/_data/chip.json
+++ b/docs/_data/chip.json
@@ -27,12 +27,12 @@
     },
     {
       "class": "d-chip-close-btn--sm",
-      "applies": "N/A",
+      "applies": "d-chip-close-btn",
       "description": "Small close button."
     },
     {
       "class": "d-chip-close-btn--xs",
-      "applies": "N/A",
+      "applies": "d-chip-close-btn",
       "description": "Extra small close button."
     },
     {

--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -21,10 +21,10 @@ The base chip should be the go-to chip for most of your needs.
 
 ```html
 <span class="d-chip-container">
-  <button class="d-chip">
+  <button class="d-chip" type="button">
     <span>Chip</span>
   </button>
-  <button class="d-chip-close-btn" aria-label="close">...</button>
+  <button class="d-chip-close-btn" type="button" aria-label="close"/>
 </span>
 ```
 
@@ -35,7 +35,7 @@ The base chip should be the go-to chip for most of your needs.
 
 ```html
 <span class="d-chip-container">
-  <button class="d-chip">
+  <button class="d-chip" type="button">
     <span>Chip</span>
   </button>
 </span>
@@ -48,7 +48,7 @@ The base chip should be the go-to chip for most of your needs.
 
 ```html
 <span class="d-chip-container">
-  <button class="d-chip">
+  <button class="d-chip" type="button">
     <span class="d-chip__icon">...</span>
     <span>Chip</span>
   </button>
@@ -62,11 +62,11 @@ The base chip should be the go-to chip for most of your needs.
 
 ```html
 <span class="d-chip-container">
-  <button class="d-chip">
+  <button class="d-chip" type="button">
     <span class="d-chip__icon">...</span>
     <span>Chip</span>
   </button>
-  <button class="d-chip-close-btn" aria-label="close">...</button>
+  <button class="d-chip-close-btn" type="button" aria-label="close"/>
 </span>
 ```
 
@@ -77,11 +77,11 @@ The base chip should be the go-to chip for most of your needs.
 
 ```html
 <span class="d-chip-container">
-  <button class="d-chip">
+  <button class="d-chip" type="button">
     <span class="d-avatar">...</span>
     <span>...</span>
   </button>
-  <button class="d-chip-close-btn" aria-label="close">...</button>
+  <button class="d-chip-close-btn" type="button" aria-label="close"/>
 </span>
 ```
 
@@ -98,7 +98,7 @@ the close button can still be interactive even if the chip is non-interactive.
   <span class="d-chip">
     <span>Chip</span>
   </span>
-   <button class="d-chip-close-btn" aria-label="close">...</button>
+  <button class="d-chip-close-btn" aria-label="close"/>
 </span>
 ```
 
@@ -111,10 +111,10 @@ To truncate text, add `.d-truncate` to the content element, and set the width of
 
 ```html
 <span class="d-chip-container">
-  <button class="d-chip d-w102">
+  <button class="d-chip d-w102" type="button">
     <span class="d-truncate">Chip loooooong name</span>
   </button>
-  <button class="d-chip-close-btn" aria-label="close">...</button>
+  <button class="d-chip-close-btn" type="button" aria-label="close"/>
 </span>
 ```
 
@@ -127,25 +127,25 @@ To truncate text, add `.d-truncate` to the content element, and set the width of
 
 ```html
 <span class="d-chip-container">
-  <button class="d-chip d-chip--xs">
+  <button class="d-chip d-chip--xs" type="button">
     <span class="d-chip__icon">...</span>
     <span>Chip</span>
   </button>
-  <button class="d-chip-close-btn d-chip-close-btn--xs" aria-label="close">...</button>
+  <button class="d-chip-close-btn d-chip-close-btn--xs" type="button" aria-label="close"/>
 </span>
 <span class="d-chip-container">
-  <button class="d-chip d-chip--sm">
+  <button class="d-chip d-chip--sm" type="button">
     <span class="d-avatar">...</span>
     <span>Chip</span>
   </button>
-  <button class="d-chip-close-btn d-chip-close-btn--sm" aria-label="close">...</button>
+  <button class="d-chip-close-btn d-chip-close-btn--sm" type="button" aria-label="close"/>
 </span>
 <span class="d-chip-container">
-  <button class="d-chip">
+  <button class="d-chip" type="button">
     <span class="d-chip__icon">...</span>
     <span>Chip</span>
   </button>
-  <button class="d-chip-close-btn" aria-label="close">...</button>
+  <button class="d-chip-close-btn" type="button" aria-label="close"/>
 </span>
 ```
 

--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -54,9 +54,7 @@ The base chip should be the go-to chip for most of your needs.
 <span class="d-chip">
   <button class="d-chip__label" type="button">
     <span class="d-chip__icon">
-      <span class="d-btn__icon">
-        <svg>...</svg>
-      </span>
+      <svg>...</svg>
     </span>
     <span class="d-chip__text">Chip</span>
   </button>
@@ -72,9 +70,7 @@ The base chip should be the go-to chip for most of your needs.
 <span class="d-chip">
   <button class="d-chip__label" type="button">
     <span class="d-chip__icon">
-      <span class="d-btn__icon">
-        <svg>...</svg>
-      </span>
+      <svg>...</svg>
     </span>
     <span class="d-chip__text">Chip</span>
   </button>
@@ -156,7 +152,9 @@ To truncate text, add `.d-truncate` to the content element, and set the width of
 ```html
 <span class="d-chip">
   <button class="d-chip__label d-chip__label--xs" type="button">
-    <span class="d-chip__icon">...</span>
+    <span class="d-chip__icon">
+      <svg>...</svg>
+    </span>
     <span class="d-chip__text">Chip</span>
   </button>
   <button class="d-chip__close d-chip__close--xs" type="button" aria-label="close">
@@ -178,7 +176,9 @@ To truncate text, add `.d-truncate` to the content element, and set the width of
 </span>
 <span class="d-chip">
   <button class="d-chip__label" type="button">
-    <span class="d-chip__icon">...</span>
+    <span class="d-chip__icon">
+      <svg>...</svg>
+    </span>
     <span class="d-chip__text">Chip</span>
   </button>
   <button class="d-chip__close" type="button" aria-label="close">

--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -20,9 +20,11 @@ The base chip should be the go-to chip for most of your needs.
 </code-well-header>
 
 ```html
-<span class="d-chip d-chip--interactive" tabindex="0">
-  <span>...</span>
-  <button class="d-btn d-btn--circle" aria-label="close" type="button" >...</button>
+<span class="d-chip-container">
+  <button class="d-chip">
+    <span>Chip</span>
+  </button>
+  <button class="d-btn d-btn--circle d-chip-close-btn" aria-label="close">...</button>
 </span>
 ```
 
@@ -32,7 +34,11 @@ The base chip should be the go-to chip for most of your needs.
 </code-well-header>
 
 ```html
-<span class="d-chip d-chip--interactive" tabindex="0">...</span>
+<span class="d-chip-container">
+  <button class="d-chip">
+    <span>Chip</span>
+  </button>
+</span>
 ```
 
 ### With icon
@@ -41,9 +47,11 @@ The base chip should be the go-to chip for most of your needs.
 </code-well-header>
 
 ```html
-<span class="d-chip d-chip--interactive" tabindex="0">
-  <span class="d-chip__icon">...</span>
-  <span>...</span>
+<span class="d-chip-container">
+  <button class="d-chip">
+    <span class="d-chip__icon">...</span>
+    <span>Chip</span>
+  </button>
 </span>
 ```
 
@@ -53,10 +61,12 @@ The base chip should be the go-to chip for most of your needs.
 </code-well-header>
 
 ```html
-<span class="d-chip d-chip--interactive" tabindex="0">
-  <span class="d-chip__icon">...</span>
-  <span>...</span>
-  <button class="d-btn d-btn--circle" type="button">...</button>
+<span class="d-chip-container">
+  <button class="d-chip">
+    <span class="d-chip__icon">...</span>
+    <span>Chip</span>
+  </button>
+  <button class="d-btn d-btn--circle d-chip-close-btn" aria-label="close">...</button>
 </span>
 ```
 
@@ -66,24 +76,29 @@ The base chip should be the go-to chip for most of your needs.
 </code-well-header>
 
 ```html
-<span class="d-chip d-chip--interactive" tabindex="0">
-  <span class="d-avatar">...</span>
-  <span>...</span>
-  <button class="d-btn d-btn--circle" type="button">...</button>
+<span class="d-chip-container">
+  <button class="d-chip">
+    <span class="d-avatar">...</span>
+    <span>...</span>
+  </button>
+  <button class="d-btn d-btn--circle d-chip-close-btn" aria-label="close">...</button>
 </span>
 ```
 
 ### Non Interactive
-No `.d-chip--interactive` class.
+To make Chip non-interactive, change the d-chip element from a button to a span. Note
+the close button can still be interactive even if the chip is non-interactive.
 
 <code-well-header>
   <example-chip label="Chip" :interactive="false"/>
 </code-well-header>
 
 ```html
-<span class="d-chip" tabindex="-1">
-  <span>...</span>
-  <button class="d-btn d-btn--circle" type="button">...</button>
+<span class="d-chip-container">
+  <span class="d-chip">
+    <span>Chip</span>
+  </span>
+   <button class="d-btn d-btn--circle d-chip-close-btn" aria-label="close">...</button>
 </span>
 ```
 
@@ -95,9 +110,11 @@ No `.d-chip--interactive` class.
 </code-well-header>
 
 ```html
-<span class="d-chip d-chip--interactive d-w102" tabindex="0">
-  <span class="d-truncate">...</span>
-  <button class="d-btn d-btn--circle" type="button">...</button>
+<span class="d-chip-container">
+  <button class="d-chip d-w102">
+    <span class="d-truncate">Chip loooooong name</span>
+  </button>
+  <button class="d-btn d-btn--circle d-chip-close-btn" aria-label="close">...</button>
 </span>
 ```
 
@@ -109,9 +126,27 @@ No `.d-chip--interactive` class.
 </code-well-header>
 
 ```html
-<span class="d-chip d-chip--xs d-chip--interactive" tabindex="0">...</span>
-<span class="d-chip d-chip--sm d-chip--interactive" tabindex="0">...</span>
-<span class="d-chip d-chip--interactive" tabindex="0">...</span>
+<span class="d-chip-container">
+  <button class="d-chip d-chip--xs">
+    <span class="d-chip__icon">...</span>
+    <span>Chip</span>
+  </button>
+  <button class="d-btn d-btn--circle d-chip-close-btn--xs" aria-label="close">...</button>
+</span>
+<span class="d-chip-container">
+  <button class="d-chip d-chip--sm">
+    <span class="d-avatar">...</span>
+    <span>Chip</span>
+  </button>
+  <button class="d-btn d-btn--circle d-chip-close-btn--sm" aria-label="close">...</button>
+</span>
+<span class="d-chip-container">
+  <button class="d-chip">
+    <span class="d-chip__icon">...</span>
+    <span>Chip</span>
+  </button>
+  <button class="d-btn d-btn--circle d-chip-close-btn" aria-label="close">...</button>
+</span>
 ```
 
 <script setup>

--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -24,7 +24,11 @@ The base chip should be the go-to chip for most of your needs.
   <button class="d-chip" type="button">
     <span>Chip</span>
   </button>
-  <button class="d-chip-close-btn" type="button" aria-label="close"/>
+  <button class="d-chip-close-btn" type="button" aria-label="close">
+    <span class="d-btn__icon">
+      <svg>...</svg>
+    </span>
+  </button>
 </span>
 ```
 
@@ -66,7 +70,11 @@ The base chip should be the go-to chip for most of your needs.
     <span class="d-chip__icon">...</span>
     <span>Chip</span>
   </button>
-  <button class="d-chip-close-btn" type="button" aria-label="close"/>
+  <button class="d-chip-close-btn" type="button" aria-label="close">
+    <span class="d-btn__icon">
+      <svg>...</svg>
+    </span>
+  </button>
 </span>
 ```
 
@@ -81,7 +89,11 @@ The base chip should be the go-to chip for most of your needs.
     <span class="d-avatar">...</span>
     <span>...</span>
   </button>
-  <button class="d-chip-close-btn" type="button" aria-label="close"/>
+  <button class="d-chip-close-btn" type="button" aria-label="close">
+    <span class="d-btn__icon">
+      <svg>...</svg>
+    </span>
+  </button>
 </span>
 ```
 
@@ -98,7 +110,11 @@ the close button can still be interactive even if the chip is non-interactive.
   <span class="d-chip">
     <span>Chip</span>
   </span>
-  <button class="d-chip-close-btn" aria-label="close"/>
+  <button class="d-chip-close-btn" type="button" aria-label="close">
+    <span class="d-btn__icon">
+      <svg>...</svg>
+    </span>
+  </button>
 </span>
 ```
 
@@ -114,7 +130,11 @@ To truncate text, add `.d-truncate` to the content element, and set the width of
   <button class="d-chip d-w102" type="button">
     <span class="d-truncate">Chip loooooong name</span>
   </button>
-  <button class="d-chip-close-btn" type="button" aria-label="close"/>
+  <button class="d-chip-close-btn" type="button" aria-label="close">
+    <span class="d-btn__icon">
+      <svg>...</svg>
+    </span>
+  </button>
 </span>
 ```
 
@@ -131,21 +151,33 @@ To truncate text, add `.d-truncate` to the content element, and set the width of
     <span class="d-chip__icon">...</span>
     <span>Chip</span>
   </button>
-  <button class="d-chip-close-btn d-chip-close-btn--xs" type="button" aria-label="close"/>
+  <button class="d-chip-close-btn d-chip-close-btn--xs" type="button" aria-label="close">
+    <span class="d-btn__icon">
+      <svg>...</svg>
+    </span>
+  </button>
 </span>
 <span class="d-chip-container">
   <button class="d-chip d-chip--sm" type="button">
     <span class="d-avatar">...</span>
     <span>Chip</span>
   </button>
-  <button class="d-chip-close-btn d-chip-close-btn--sm" type="button" aria-label="close"/>
+  <button class="d-chip-close-btn d-chip-close-btn--sm" type="button" aria-label="close">
+    <span class="d-btn__icon">
+      <svg>...</svg>
+    </span>
+  </button>
 </span>
 <span class="d-chip-container">
   <button class="d-chip" type="button">
     <span class="d-chip__icon">...</span>
     <span>Chip</span>
   </button>
-  <button class="d-chip-close-btn" type="button" aria-label="close"/>
+  <button class="d-chip-close-btn" type="button" aria-label="close">
+    <span class="d-btn__icon">
+      <svg>...</svg>
+    </span>
+  </button>
 </span>
 ```
 

--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -20,11 +20,11 @@ The base chip should be the go-to chip for most of your needs.
 </code-well-header>
 
 ```html
-<span class="d-chip-container">
-  <button class="d-chip" type="button">
-    <span>Chip</span>
+<span class="d-chip">
+  <button class="d-chip__label" type="button">
+    <span class="d-chip__text">Chip</span>
   </button>
-  <button class="d-chip-close-btn" type="button" aria-label="close">
+  <button class="d-chip__close" type="button" aria-label="close">
     <span class="d-btn__icon">
       <svg>...</svg>
     </span>
@@ -38,9 +38,9 @@ The base chip should be the go-to chip for most of your needs.
 </code-well-header>
 
 ```html
-<span class="d-chip-container">
-  <button class="d-chip" type="button">
-    <span>Chip</span>
+<span class="d-chip">
+  <button class="d-chip__label" type="button">
+    <span class="d-chip__text">Chip</span>
   </button>
 </span>
 ```
@@ -51,10 +51,14 @@ The base chip should be the go-to chip for most of your needs.
 </code-well-header>
 
 ```html
-<span class="d-chip-container">
-  <button class="d-chip" type="button">
-    <span class="d-chip__icon">...</span>
-    <span>Chip</span>
+<span class="d-chip">
+  <button class="d-chip__label" type="button">
+    <span class="d-chip__icon">
+      <span class="d-btn__icon">
+        <svg>...</svg>
+      </span>
+    </span>
+    <span class="d-chip__text">Chip</span>
   </button>
 </span>
 ```
@@ -65,12 +69,16 @@ The base chip should be the go-to chip for most of your needs.
 </code-well-header>
 
 ```html
-<span class="d-chip-container">
-  <button class="d-chip" type="button">
-    <span class="d-chip__icon">...</span>
-    <span>Chip</span>
+<span class="d-chip">
+  <button class="d-chip__label" type="button">
+    <span class="d-chip__icon">
+      <span class="d-btn__icon">
+        <svg>...</svg>
+      </span>
+    </span>
+    <span class="d-chip__text">Chip</span>
   </button>
-  <button class="d-chip-close-btn" type="button" aria-label="close">
+  <button class="d-chip__close" type="button" aria-label="close">
     <span class="d-btn__icon">
       <svg>...</svg>
     </span>
@@ -84,12 +92,12 @@ The base chip should be the go-to chip for most of your needs.
 </code-well-header>
 
 ```html
-<span class="d-chip-container">
-  <button class="d-chip" type="button">
+<span class="d-chip">
+  <button class="d-chip__label" type="button">
     <span class="d-avatar">...</span>
-    <span>...</span>
+    <span class="d-chip__text">Chip</span>
   </button>
-  <button class="d-chip-close-btn" type="button" aria-label="close">
+  <button class="d-chip__close" type="button" aria-label="close">
     <span class="d-btn__icon">
       <svg>...</svg>
     </span>
@@ -106,11 +114,11 @@ the close button can still be interactive even if the chip is non-interactive.
 </code-well-header>
 
 ```html
-<span class="d-chip-container">
-  <span class="d-chip">
-    <span>Chip</span>
+<span class="d-chip">
+  <span class="d-chip__label">
+    <span class="d-chip__text">Chip</span>
   </span>
-  <button class="d-chip-close-btn" type="button" aria-label="close">
+  <button class="d-chip__close" type="button" aria-label="close">
     <span class="d-btn__icon">
       <svg>...</svg>
     </span>
@@ -126,11 +134,11 @@ To truncate text, add `.d-truncate` to the content element, and set the width of
 </code-well-header>
 
 ```html
-<span class="d-chip-container">
-  <button class="d-chip d-w102" type="button">
-    <span class="d-truncate">Chip loooooong name</span>
+<span class="d-chip">
+  <button class="d-chip__label d-w102" type="button">
+    <span class="d-chip__text d-truncate">Chip loooooong name</span>
   </button>
-  <button class="d-chip-close-btn" type="button" aria-label="close">
+  <button class="d-chip__close" type="button" aria-label="close">
     <span class="d-btn__icon">
       <svg>...</svg>
     </span>
@@ -146,34 +154,34 @@ To truncate text, add `.d-truncate` to the content element, and set the width of
 </code-well-header>
 
 ```html
-<span class="d-chip-container">
-  <button class="d-chip d-chip--xs" type="button">
+<span class="d-chip">
+  <button class="d-chip__label d-chip__label--xs" type="button">
     <span class="d-chip__icon">...</span>
-    <span>Chip</span>
+    <span class="d-chip__text">Chip</span>
   </button>
-  <button class="d-chip-close-btn d-chip-close-btn--xs" type="button" aria-label="close">
+  <button class="d-chip__close d-chip__close--xs" type="button" aria-label="close">
     <span class="d-btn__icon">
       <svg>...</svg>
     </span>
   </button>
 </span>
-<span class="d-chip-container">
-  <button class="d-chip d-chip--sm" type="button">
+<span class="d-chip">
+  <button class="d-chip__label d-chip__label--sm" type="button">
     <span class="d-avatar">...</span>
-    <span>Chip</span>
+    <span class="d-chip__text">Chip</span>
   </button>
-  <button class="d-chip-close-btn d-chip-close-btn--sm" type="button" aria-label="close">
+  <button class="d-chip__close d-chip__close--sm" type="button" aria-label="close">
     <span class="d-btn__icon">
       <svg>...</svg>
     </span>
   </button>
 </span>
-<span class="d-chip-container">
-  <button class="d-chip" type="button">
+<span class="d-chip">
+  <button class="d-chip__label" type="button">
     <span class="d-chip__icon">...</span>
-    <span>Chip</span>
+    <span class="d-chip__text">Chip</span>
   </button>
-  <button class="d-chip-close-btn" type="button" aria-label="close">
+  <button class="d-chip__close" type="button" aria-label="close">
     <span class="d-btn__icon">
       <svg>...</svg>
     </span>

--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -24,7 +24,7 @@ The base chip should be the go-to chip for most of your needs.
   <button class="d-chip">
     <span>Chip</span>
   </button>
-  <button class="d-btn d-btn--circle d-chip-close-btn" aria-label="close">...</button>
+  <button class="d-chip-close-btn" aria-label="close">...</button>
 </span>
 ```
 
@@ -66,7 +66,7 @@ The base chip should be the go-to chip for most of your needs.
     <span class="d-chip__icon">...</span>
     <span>Chip</span>
   </button>
-  <button class="d-btn d-btn--circle d-chip-close-btn" aria-label="close">...</button>
+  <button class="d-chip-close-btn" aria-label="close">...</button>
 </span>
 ```
 
@@ -81,7 +81,7 @@ The base chip should be the go-to chip for most of your needs.
     <span class="d-avatar">...</span>
     <span>...</span>
   </button>
-  <button class="d-btn d-btn--circle d-chip-close-btn" aria-label="close">...</button>
+  <button class="d-chip-close-btn" aria-label="close">...</button>
 </span>
 ```
 
@@ -98,12 +98,12 @@ the close button can still be interactive even if the chip is non-interactive.
   <span class="d-chip">
     <span>Chip</span>
   </span>
-   <button class="d-btn d-btn--circle d-chip-close-btn" aria-label="close">...</button>
+   <button class="d-chip-close-btn" aria-label="close">...</button>
 </span>
 ```
 
 ### Truncated
-`.d-truncate` is added to text content by default.
+To truncate text, add `.d-truncate` to the content element, and set the width of the `.d-chip` element.
 
 <code-well-header>
   <example-chip label="Chip loooooong name" truncate/>
@@ -114,7 +114,7 @@ the close button can still be interactive even if the chip is non-interactive.
   <button class="d-chip d-w102">
     <span class="d-truncate">Chip loooooong name</span>
   </button>
-  <button class="d-btn d-btn--circle d-chip-close-btn" aria-label="close">...</button>
+  <button class="d-chip-close-btn" aria-label="close">...</button>
 </span>
 ```
 
@@ -131,21 +131,21 @@ the close button can still be interactive even if the chip is non-interactive.
     <span class="d-chip__icon">...</span>
     <span>Chip</span>
   </button>
-  <button class="d-btn d-btn--circle d-chip-close-btn--xs" aria-label="close">...</button>
+  <button class="d-chip-close-btn d-chip-close-btn--xs" aria-label="close">...</button>
 </span>
 <span class="d-chip-container">
   <button class="d-chip d-chip--sm">
     <span class="d-avatar">...</span>
     <span>Chip</span>
   </button>
-  <button class="d-btn d-btn--circle d-chip-close-btn--sm" aria-label="close">...</button>
+  <button class="d-chip-close-btn d-chip-close-btn--sm" aria-label="close">...</button>
 </span>
 <span class="d-chip-container">
   <button class="d-chip">
     <span class="d-chip__icon">...</span>
     <span>Chip</span>
   </button>
-  <button class="d-btn d-btn--circle d-chip-close-btn" aria-label="close">...</button>
+  <button class="d-chip-close-btn" aria-label="close">...</button>
 </span>
 ```
 

--- a/lib/build/less/components/chip.less
+++ b/lib/build/less/components/chip.less
@@ -14,13 +14,18 @@
 //  ============================================================================
 //  $   BASE STYLE
 //  ----------------------------------------------------------------------------
+.d-chip-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
 .d-chip {
   //  Component CSS Vars
   --chip--fc: var(--fc-dark);
   --chip--bgc: var(--black-050);
   --chip--br: var(--su102);
 
-  position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -31,40 +36,19 @@
   font-family: inherit;
   line-height: var(--lh4);
   background-color: var(--chip--bgc);
+  border: none;
   border-radius: var(--chip--br);
   transition-timing-function: var(--ttf-in-out);
   transition-duration: 75ms;
   transition-property: background-color;
 
-  .d-chip-btn-holder {
+  // Reserves space within the chip for the close button, since the close button is
+  // not nested within the chip. Only apply if close button exists (more than one child).
+  &:not(:only-child)::after {
     flex-shrink: 0;
     width: calc(var(--su16) + var(--su2));
     height: calc(var(--su16) + var(--su2));
-  }
-
-  .d-chip-btn-container {
-    position: absolute;
-    top: var(--su0);
-    right: var(--su0);
-    padding: var(--su2) var(--su2) var(--su2) var(--su0);
-    cursor: pointer;
-
-    .d-btn {
-      padding: calc(var(--su2) + var(--su1));
-      border-width: var(--su0);
-    }
-
-    &:hover {
-      .d-btn {
-        --button--bgc: hsla(var(--black-800-hsl) ~' / ' 15%);
-      }
-    }
-
-    &:active {
-      .d-btn {
-        --button--bgc: hsla(var(--black-800-hsl) ~' / ' 25%);
-      }
-    }
+    content: '';
   }
 
   .d-avatar {
@@ -73,8 +57,51 @@
     margin: var(--sun2) var(--su4) var(--sun2) var(--sun6);
   }
 
-  .d-svg,
-  .d-btn .d-btn__icon .d-svg {
+  .d-svg {
+    width: @icon18;
+    height: @icon18;
+  }
+}
+
+button.d-chip {
+  cursor: pointer;
+
+  &:hover {
+    --chip--bgc: var(--black-075);
+  }
+
+  &:active {
+    --chip--bgc: var(--black-100);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--bs-focus-ring-muted);
+  }
+}
+
+.d-chip-close-btn {
+  position: absolute;
+  right: var(--su2);
+  padding: calc(var(--su2) + var(--su1));
+  border-width: var(--su0);
+
+  &::before {
+    position: absolute;
+    width: 2.6rem;
+    height: 2.8rem;
+    content: '';
+  }
+
+  &:hover {
+    --button--bgc: hsla(var(--black-800-hsl) ~' / ' 15%);
+  }
+
+  &:active {
+    --button--bgc: hsla(var(--black-800-hsl) ~' / ' 25%);
+  }
+
+  .d-btn__icon .d-svg {
     width: @icon18;
     height: @icon18;
   }
@@ -90,24 +117,6 @@
 }
 
 //  ============================================================================
-//  $   INTERACTIVITY
-//  ----------------------------------------------------------------------------
-//  $$  INTERACTIVE (DEFAULT)
-//  ----------------------------------------------------------------------------
-.d-chip--interactive {
-  cursor: pointer;
-
-  &:hover {
-    --chip--bgc: var(--black-075);
-  }
-
-  &:focus-visible {
-    outline: none;
-    box-shadow: var(--bs-focus-ring-muted);
-  }
-}
-
-//  ============================================================================
 //  $   SIZES
 //  ----------------------------------------------------------------------------
 //  $$  EXTRA SMALL
@@ -116,25 +125,25 @@
   padding: var(--su2) var(--su6);
   font-size: var(--fs12);
 
-  .d-btn .d-btn__icon .d-svg,
+  &::before {
+    position: absolute;
+    width: var(--su24);
+    height: var(--su24);
+    content: '';
+  }
+
   .d-svg {
     width: @icon14;
     height: @icon14;
   }
 
-  .d-chip-btn-holder {
+  // reserves space within the chip for the close button, since the close button is
+  // not nested within the chip.
+  &::after {
+    flex-shrink: 0;
     width: var(--su12);
     height: var(--su12);
-  }
-
-  .d-chip-btn-container {
-    top: calc(var(--sun1) + var(--sun2));
-    right: var(--sun2);
-    padding: var(--su4);
-
-    .d-btn {
-      padding: var(--su1);
-    }
+    content: '';
   }
 
   .d-avatar {
@@ -145,31 +154,50 @@
   }
 }
 
+.d-chip-close-btn--xs {
+  position: absolute;
+  padding: var(--su1);
+  border-width: var(--su0);
+
+  &:hover {
+    --button--bgc: hsla(var(--black-800-hsl) ~' / ' 15%);
+  }
+
+  &:active {
+    --button--bgc: hsla(var(--black-800-hsl) ~' / ' 25%);
+  }
+
+  .d-btn__icon .d-svg {
+    width: @icon14;
+    height: @icon14;
+  }
+}
+
 //  $$ SMALL
 //  ----------------------------------------------------------------------------
 .d-chip--sm {
   padding: var(--su2) var(--su8);
   font-size: var(--fs16);
 
-  .d-btn .d-btn__icon .d-svg,
+  &::before {
+    position: absolute;
+    width: var(--su24);
+    height: var(--su24);
+    content: '';
+  }
+
   .d-svg {
     width: @icon16;
     height: @icon16;
   }
 
-  .d-chip-btn-holder {
+  // reserves space within the chip for the close button, since the close button is
+  // not nested within the chip.
+  &::after {
+    flex-shrink: 0;
     width: calc(var(--su12) + var(--su2));
     height: calc(var(--su12) + var(--su2));
-  }
-
-  .d-chip-btn-container {
-    top: var(--sun1);
-    right: var(--su0);
-    padding: var(--su2);
-
-    .d-btn {
-      padding: var(--su2);
-    }
+    content: '';
   }
 
   .d-avatar {
@@ -177,5 +205,24 @@
 
     margin-right: var(--su4);
     margin-left: var(--sun6);
+  }
+}
+
+.d-chip-close-btn--sm {
+  position: absolute;
+  padding: var(--su2);
+  border-width: var(--su0);
+
+  &:hover {
+    --button--bgc: hsla(var(--black-800-hsl) ~' / ' 15%);
+  }
+
+  &:active {
+    --button--bgc: hsla(var(--black-800-hsl) ~' / ' 25%);
+  }
+
+  .d-btn__icon .d-svg {
+    width: @icon16;
+    height: @icon16;
   }
 }

--- a/lib/build/less/components/chip.less
+++ b/lib/build/less/components/chip.less
@@ -14,13 +14,13 @@
 //  ============================================================================
 //  $   BASE STYLE
 //  ----------------------------------------------------------------------------
-.d-chip-container {
+.d-chip {
   position: relative;
   display: inline-flex;
   align-items: center;
 }
 
-.d-chip {
+.d-chip__label {
   //  Component CSS Vars
   --chip--fc: var(--fc-dark);
   --chip--bgc: var(--black-050);
@@ -64,7 +64,7 @@
 }
 
 // Only set these properties if d-chip is interactive (a button).
-button.d-chip {
+button.d-chip__label {
   cursor: pointer;
 
   &:hover {
@@ -81,7 +81,7 @@ button.d-chip {
   }
 }
 
-a.d-chip {
+a.d-chip__label {
   text-decoration: none;
   cursor: pointer;
 
@@ -101,7 +101,7 @@ a.d-chip {
   }
 }
 
-.d-chip-close-btn {
+.d-chip__close {
   .d-btn();
   .d-btn--circle();
 
@@ -136,7 +136,7 @@ a.d-chip {
   line-height: 0;
 }
 
-.d-chip--active {
+.d-chip__label--active {
   background-color: var(--black-100);
 }
 
@@ -145,7 +145,7 @@ a.d-chip {
 //  ----------------------------------------------------------------------------
 //  $$  EXTRA SMALL
 //  ----------------------------------------------------------------------------
-.d-chip--xs {
+.d-chip__label--xs {
   padding: var(--su2) var(--su6);
   font-size: var(--fs12);
 
@@ -173,7 +173,7 @@ a.d-chip {
   }
 }
 
-.d-chip-close-btn--xs {
+.d-chip__close--xs {
   padding: var(--su1);
 
   // Clickable area for the close button.
@@ -190,7 +190,7 @@ a.d-chip {
 
 //  $$ SMALL
 //  ----------------------------------------------------------------------------
-.d-chip--sm {
+.d-chip__label--sm {
   padding: var(--su2) var(--su8);
   font-size: var(--fs16);
 
@@ -216,7 +216,7 @@ a.d-chip {
   }
 }
 
-.d-chip-close-btn--sm {
+.d-chip__close--sm {
   padding: var(--su2);
 
   &::before {

--- a/lib/build/less/components/chip.less
+++ b/lib/build/less/components/chip.less
@@ -63,6 +63,7 @@
   }
 }
 
+// Only set these properties if d-chip is interactive (a button).
 button.d-chip {
   cursor: pointer;
 
@@ -81,6 +82,9 @@ button.d-chip {
 }
 
 .d-chip-close-btn {
+  .d-btn();
+  .d-btn--circle();
+
   position: absolute;
   right: var(--su2);
   padding: calc(var(--su2) + var(--su1));
@@ -125,12 +129,7 @@ button.d-chip {
   padding: var(--su2) var(--su6);
   font-size: var(--fs12);
 
-  &::before {
-    position: absolute;
-    width: var(--su24);
-    height: var(--su24);
-    content: '';
-  }
+
 
   .d-svg {
     width: @icon14;
@@ -155,16 +154,12 @@ button.d-chip {
 }
 
 .d-chip-close-btn--xs {
-  position: absolute;
   padding: var(--su1);
-  border-width: var(--su0);
 
-  &:hover {
-    --button--bgc: hsla(var(--black-800-hsl) ~' / ' 15%);
-  }
-
-  &:active {
-    --button--bgc: hsla(var(--black-800-hsl) ~' / ' 25%);
+  // Clickable area for the close button.
+  &::before {
+    width: var(--su24);
+    height: var(--su24);
   }
 
   .d-btn__icon .d-svg {
@@ -178,13 +173,6 @@ button.d-chip {
 .d-chip--sm {
   padding: var(--su2) var(--su8);
   font-size: var(--fs16);
-
-  &::before {
-    position: absolute;
-    width: var(--su24);
-    height: var(--su24);
-    content: '';
-  }
 
   .d-svg {
     width: @icon16;
@@ -209,16 +197,11 @@ button.d-chip {
 }
 
 .d-chip-close-btn--sm {
-  position: absolute;
   padding: var(--su2);
-  border-width: var(--su0);
 
-  &:hover {
-    --button--bgc: hsla(var(--black-800-hsl) ~' / ' 15%);
-  }
-
-  &:active {
-    --button--bgc: hsla(var(--black-800-hsl) ~' / ' 25%);
+  &::before {
+    width: var(--su24);
+    height: var(--su24);
   }
 
   .d-btn__icon .d-svg {

--- a/lib/build/less/components/chip.less
+++ b/lib/build/less/components/chip.less
@@ -81,6 +81,26 @@ button.d-chip {
   }
 }
 
+a.d-chip {
+  text-decoration: none;
+  cursor: pointer;
+
+  &:hover {
+    --chip--bgc: var(--black-075);
+
+    text-decoration: none;
+  }
+
+  &:active {
+    --chip--bgc: var(--black-100);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--bs-focus-ring-muted);
+  }
+}
+
 .d-chip-close-btn {
   .d-btn();
   .d-btn--circle();

--- a/lib/build/less/components/chip.less
+++ b/lib/build/less/components/chip.less
@@ -64,23 +64,7 @@
 }
 
 // Only set these properties if d-chip is interactive (a button).
-button.d-chip__label {
-  cursor: pointer;
-
-  &:hover {
-    --chip--bgc: var(--black-075);
-  }
-
-  &:active {
-    --chip--bgc: var(--black-100);
-  }
-
-  &:focus-visible {
-    outline: none;
-    box-shadow: var(--bs-focus-ring-muted);
-  }
-}
-
+button.d-chip__label,
 a.d-chip__label {
   text-decoration: none;
   cursor: pointer;

--- a/lib/build/less/components/chip.less
+++ b/lib/build/less/components/chip.less
@@ -51,6 +51,30 @@
     content: '';
   }
 
+  // These properties are only set if d-chip is interactive (ex: a button).
+  &:is(a),
+  &:is(button),
+  &:is([role='button']),
+  &:is([role='link']) {
+    text-decoration: none;
+    cursor: pointer;
+
+    &:hover {
+      --chip--bgc: var(--black-075);
+
+      text-decoration: none;
+    }
+
+    &:active {
+      --chip--bgc: var(--black-100);
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow: var(--bs-focus-ring-muted);
+    }
+  }
+
   .d-avatar {
     --avatar--size: var(--su24);
 
@@ -60,28 +84,6 @@
   .d-svg {
     width: @icon18;
     height: @icon18;
-  }
-}
-
-// Only set these properties if d-chip is interactive (a button).
-button.d-chip__label,
-a.d-chip__label {
-  text-decoration: none;
-  cursor: pointer;
-
-  &:hover {
-    --chip--bgc: var(--black-075);
-
-    text-decoration: none;
-  }
-
-  &:active {
-    --chip--bgc: var(--black-100);
-  }
-
-  &:focus-visible {
-    outline: none;
-    box-shadow: var(--bs-focus-ring-muted);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4611,9 +4611,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.152",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.152.tgz",
-      "integrity": "sha512-jk4Ju5SGZAQQJ1iI4Rgru7dDlvkQPLpNPWH9gIZmwCD4YteA5Bbk1xPcPDUf5jUYs3e1e80RXdi8XgKQZaigeg==",
+      "version": "1.4.154",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.154.tgz",
+      "integrity": "sha512-GbV9djOkrnj6xmW+YYVVEI3VCQnJ0pnSTu7TW2JyjKd5cakoiSaG5R4RbEtfaD92GsY10DzbU3GYRe+IOA9kqA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -23266,9 +23266,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.152",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.152.tgz",
-      "integrity": "sha512-jk4Ju5SGZAQQJ1iI4Rgru7dDlvkQPLpNPWH9gIZmwCD4YteA5Bbk1xPcPDUf5jUYs3e1e80RXdi8XgKQZaigeg==",
+      "version": "1.4.154",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.154.tgz",
+      "integrity": "sha512-GbV9djOkrnj6xmW+YYVVEI3VCQnJ0pnSTu7TW2JyjKd5cakoiSaG5R4RbEtfaD92GsY10DzbU3GYRe+IOA9kqA==",
       "dev": true
     },
     "emoji-regex": {


### PR DESCRIPTION
## Description
Updated the chip component to use more semantic html as well as various other improvements:

- Chip will now be a `<button>` element when it is interactive and a `<span>` element when it is not.
- Removed `d-chip--interactive` class as now the element type determines whether it is interactive or not (button vs span)
- Removed tabindex
- Close button is no longer nested within the chip itself, it is now within a wrapper containing the chip and the button. Absolute positioning is used to position the close button within the chip.
- Created `d-chip-close-btn` class.
- Removed `d-chip-btn-holder` class, it is now automatically set via a pseudo class.
- Use pseudo class to perform "oversized clickable area" on close button.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/dmTcLrlCLNPfG/giphy.gif)
