### PR TITLE
docs(Google Analytics): add custom event

### DIFF
--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -14,7 +14,7 @@
                  :src="'https://img.shields.io/badge/Vue-v' + version + '-A687FF'">
           </a>
         </div>
-        <router-link class="d-btn d-btn--primary d-btn--lg" to="/getting-started/installation.html">Get Started</router-link>
+        <button class="d-btn d-btn--primary d-btn--lg" @click="handleClick">Get Started</button>
       </div>
       <img alt="" class="hero--image d-w50p d-as-flex-start" :src="$withBase('/assets/images/home-hero.png')" />
     </div>
@@ -50,15 +50,24 @@
 </template>
 
 <script setup>
-import {onBeforeMount, ref} from "vue";
-  import axios from "axios";
+  import { onBeforeMount, ref } from 'vue';
+  import { useRouter } from 'vue-router';
+  import axios from 'axios';
 
   const lede = "Documented styles, utility classes, and components to help you quickly design and build unified experiences across Dialpad and Dialpad Meetings.";
   const headline = "Improve your UI's reception with Dialtone";
-  const version = ref('0.0.0')
+  const version = ref('0.0.0');
+  const router = useRouter();
 
   onBeforeMount(async () => {
     const response = await axios.get('https://vue.dialpad.design/version.txt');
     version.value = response.data;
   })
+
+  function handleClick () {
+    window.gtag('event', 'click', {
+      'event_name': 'get_started_button_clicked'
+    });
+    router.push("/getting-started/installation.html");
+  }
 </script>

--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -14,7 +14,20 @@
                  :src="'https://img.shields.io/badge/Vue-v' + version + '-A687FF'">
           </a>
         </div>
-        <button class="d-btn d-btn--primary d-btn--lg" @click="handleClick">Get Started</button>
+        <router-link
+          to="/getting-started/installation.html"
+          custom
+          v-slot="{ navigate }"
+        >
+          <button
+            class="d-btn d-btn--primary d-btn--lg"
+            @click="(e) => { sendAnalyticsEvent(); navigate(e); }"
+            @keypress.enter="(e) => { sendAnalyticsEvent(); navigate(e); }"
+            role="link"
+          >
+            Get Started
+          </button>
+        </router-link>
       </div>
       <img alt="" class="hero--image d-w50p d-as-flex-start" :src="$withBase('/assets/images/home-hero.png')" />
     </div>
@@ -51,23 +64,19 @@
 
 <script setup>
   import { onBeforeMount, ref } from 'vue';
-  import { useRouter } from 'vue-router';
   import axios from 'axios';
 
   const lede = "Documented styles, utility classes, and components to help you quickly design and build unified experiences across Dialpad and Dialpad Meetings.";
   const headline = "Improve your UI's reception with Dialtone";
   const version = ref('0.0.0');
-  const router = useRouter();
 
   onBeforeMount(async () => {
     const response = await axios.get('https://vue.dialpad.design/version.txt');
     version.value = response.data;
   })
 
-  function handleClick () {
-    if (window.gtag) {
-      window.gtag('event', 'click', { 'event_name': 'get_started_button_clicked' });
-    }
-    router.push("/getting-started/installation.html");
+  function sendAnalyticsEvent () {
+    if (!window.gtag) return
+    window.gtag('event', 'click', { 'event_name': 'get_started_button_clicked' });
   }
 </script>

--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -65,9 +65,9 @@
   })
 
   function handleClick () {
-    window.gtag('event', 'click', {
-      'event_name': 'get_started_button_clicked'
-    });
+    if (window.gtag) {
+      window.gtag('event', 'click', { 'event_name': 'get_started_button_clicked' });
+    }
     router.push("/getting-started/installation.html");
   }
 </script>


### PR DESCRIPTION
## Description

Added custom google analytics event to detect when the "Getting Started" button on the Home Page is clicked.

[here](https://analytics.google.com/analytics/web/#/p318897337/realtime/overview?params=_u..nav%3Dmaui%26_u..pageSize%3D25&collectionId=life-cycle) you can see the realtime "click" custom event added

<img width="309" alt="Captura de Pantalla 2022-06-14 a la(s) 7 48 06 p m" src="https://user-images.githubusercontent.com/87546543/173713034-a8a5ab4b-f144-416f-aaa7-902e8bd08657.png">

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/Mtqip7Jor0DgAvzn6U/giphy.gif)
