### PR TITLE
fix: fix @define-font-path variable

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -197,6 +197,7 @@ var libStyles = function(done) {
     return src(paths.styles.inputLib)
         //.pipe(cache('libStyles'))
         .pipe(less())
+        .pipe(replace('../../fonts/', '../fonts/'))
         .pipe(postcss([ postcssResponsify, postcssFocusVisible ]))
         .pipe(dest(paths.styles.outputLib))
         .pipe(dest(paths.styles.outputDocs))

--- a/lib/build/less/utilities/internals.less
+++ b/lib/build/less/utilities/internals.less
@@ -14,6 +14,9 @@
 #d-internal-config {
     //  Do we want to generate font-face CSS?
     @generate-font-face:             true;
+
+    //  Path of the fonts that Dialtone provides
+    @define-font-path: '../../fonts/';
 }
 
 //  ============================================================================
@@ -378,15 +381,12 @@
     #font-face(@type, @name, @style: normal) {
         #d-internal-config();
 
-        //  Path of the fonts that Dialtone provides
-        @define-font-path: '../../fonts/';
-
         if((@generate-font-face = true), each(@type, {
             @font-face {
                 font-style: @style;
                 font-weight: @key;
                 font-family: @name;
-                src: url("./@{define-font-path}@{value}.woff2") format("woff2");
+                src: url("@{define-font-path}@{value}.woff2") format("woff2");
             };
         }));
     }


### PR DESCRIPTION
Jira ticket: https://dialpad.atlassian.net/browse/DT-528

## Description
Made the `@define-font-path` variable able to overwrite. In the Meetings codebase the fonts aren't used from Dialtone and are served from a static folder https://github.com/dialpad/firespotter/blob/master/uc_client/less/uc/variables.less#L9 so in this process is still need to overwrite this variable.
Also fixed the font path in the css version.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](path/to/gif)
