### PR TITLE
fix: dt-547 disable 'calt' font feature setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 lib/dist
 docs/assets/css
 docs/assets/fonts
+docs/.vuepress/public/fonts
 docs/_includes/icons
 docs/_includes/patterns
 docs/_includes/spot

--- a/docs/assets/less/dialtone-docs.less
+++ b/docs/assets/less/dialtone-docs.less
@@ -411,13 +411,13 @@ nav a.router-link-active {
 //  ----------------------------------------------------------------------------
 
 .dialtone-usage {
-
   & {
     display: flex;
-    margin-top: var(--su16);
-    margin-bottom: var(--su16);
     flex-direction: column;
     gap: var(--su24);
+    margin-top: var(--su16);
+    margin-bottom: var(--su16);
+
     @media screen and (min-width: 640px) {
       flex-direction: row;
     }
@@ -425,46 +425,51 @@ nav a.router-link-active {
 
   &__hd {
     display: flex;
-    align-items: center;
     gap: var(--su8);
+    align-items: center;
     font-size: var(--fs16);
+
     &--do {
       color: var(--green-600);
     }
+
     &--dont {
       color: var(--red-600);
     }
   }
 
   &__item {
-    padding: var(--su16);
-    background-color: var(--black-025);
     display: flex;
+    flex: 1;
     flex-direction: column;
     gap: var(--su8);
-    flex: 1;
+    padding: var(--su16);
+    background-color: var(--black-025);
     border-radius: var(--br8);
+
     &--do {
       background-color: var(--green-100);
     }
+
     &--dont {
       background-color: var(--red-100);
     }
   }
 
   &__bd {
+    padding-left: var(--su4);
+    padding-left: var(--su4);
     font-size: var(--fs14);
-    padding-left: var(--su4);
-    padding-left: var(--su4);
+
     > div > ul,
     > ul {
       .d-stack8();
-      list-style: none;
-      padding: 0;
+
       margin: 0;
+      padding: 0;
+      list-style: none;
     }
   }
-
 }
 
 
@@ -475,15 +480,19 @@ nav a.router-link-active {
 
 .dialtone-doc-table {
   thead {
-    tr, th, td {
+    tr,
+ th,
+ td {
       border: unset;
     }
   }
+
   tbody {
-    th, td {
+    th,
+ td {
+      border-right: unset;
       border-bottom: var(--su1) solid var(--table-bc);
       border-left: unset;
-      border-right: unset;
     }
   }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -133,7 +133,7 @@ var paths = {
     fonts: {
         input: './lib/build/fonts/*.woff2',
         outputLib: './lib/dist/fonts/',
-        outputDocs: './docs/assets/fonts/'
+        outputDocs: './docs/.vuepress/public/fonts/'
     },
     mobile: {
         output: './lib/dist/ios/'

--- a/lib/build/less/dialtone-globals.less
+++ b/lib/build/less/dialtone-globals.less
@@ -29,6 +29,7 @@ body {
     color: var(--base--text-color);
     font-size: var(--base--font-size); // [2]
     font-family: var(--base--font-family);
+    font-feature-settings: var(--base--font-feature-settings);
     line-height: var(--base--line-height);
     background-color: var(--base--background-color);
     font-kerning: normal;

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -49,6 +49,7 @@
 
     base--font-size:                        var(--fs16);
     base--font-family:                      @ff-custom;
+    base--font-feature-settings:            'calt' 0;
     base--line-height:                      var(--lh-normal);
     base--corner-radius:                    0.25em;
 }


### PR DESCRIPTION
## Description
Bit of an odd "intentional feature" of the Inter font was causing some issues with text alignment within inputs. Original report here: https://dialpad.atlassian.net/browse/DP-51979

Confirmation that this is an intentional feature of the font: https://github.com/rsms/inter/issues/243

Disabled by setting the "calt" font-feature-setting on the body to 0, same place we set the font family.

Additionally, fonts were not loading in vuepress locally, so I moved them to the correct directory.

![31d973ca-63f0-4977-927f-3247fad24d36](https://user-images.githubusercontent.com/64808812/176306051-3dc6eb4e-6a99-44e0-9b52-dc42fbd75271.png)
