### PR TITLE
fix(toggle): dt-569 toggle default padding

### DIFF
--- a/docs/.vuepress/exampleComponents/ExampleToggle.vue
+++ b/docs/.vuepress/exampleComponents/ExampleToggle.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="d-toggle-copy d-mr6">
+  <div class="d-toggle-copy">
     <label
       class="d-toggle-label"
       for="Dialtone-Toggle1"

--- a/docs/components/toggle.md
+++ b/docs/components/toggle.md
@@ -66,7 +66,7 @@ The Toggle component acts as a way to allow the User to switch between two mutua
 ```html
 <fieldset class="d-stack8">
   <div class="d-toggle-group d-d-flex d-ai-center">
-    <div class="d-toggle-copy d-mr6">
+    <div class="d-toggle-copy">
       <label class="d-toggle-label" for="Dialtone-Toggle1">Unchecked Toggle</label>
     </div>
     <div class="d-toggle-button">
@@ -76,7 +76,7 @@ The Toggle component acts as a way to allow the User to switch between two mutua
     </div>
   </div>
   <div class="d-toggle-group d-d-flex d-ai-center">
-    <div class="d-toggle-copy d-mr6">
+    <div class="d-toggle-copy">
       <label class="d-toggle-label" for="Dialtone-Toggle2">Checked Toggle</label>
     </div>
     <div class="d-toggle-button">
@@ -86,7 +86,7 @@ The Toggle component acts as a way to allow the User to switch between two mutua
     </div>
   </div>
   <div class="d-toggle-group d-d-flex d-ai-center">
-    <div class="d-toggle-copy d-mr6">
+    <div class="d-toggle-copy">
       <label class="d-toggle-label" for="Dialtone-Toggle3">Unchecked Disabled</label>
     </div>
     <div class="d-toggle-button">
@@ -96,7 +96,7 @@ The Toggle component acts as a way to allow the User to switch between two mutua
     </div>
   </div>
   <div class="d-toggle-group d-d-flex d-ai-center">
-    <div class="d-toggle-copy d-mr6">
+    <div class="d-toggle-copy">
       <label class="d-toggle-label" for="Dialtone-Toggle4">Checked Disabled</label>
     </div>
     <div class="d-toggle-button">
@@ -143,7 +143,7 @@ The Toggle component acts as a way to allow the User to switch between two mutua
       <h3 class="d-mr4">DND</h3>
     </div>
     <div class="row d-d-flex d-ai-center d-jc-space-between d-mb6">
-      <div class="d-toggle-copy d-mr6">
+      <div class="d-toggle-copy">
         <label class="d-toggle-label" for="Dialtone-Toggle5">Acorn Tech</label>
       </div>
       <div class="d-toggle-button">
@@ -153,7 +153,7 @@ The Toggle component acts as a way to allow the User to switch between two mutua
       </div>
     </div>
     <div class="row d-d-flex d-ai-center d-jc-space-between d-mb6">
-      <div class="d-toggle-copy d-mr6">
+      <div class="d-toggle-copy">
         <label class="d-toggle-label" for="Dialtone-Toggle5">California Zoo</label>
       </div>
       <div class="d-toggle-button">
@@ -163,7 +163,7 @@ The Toggle component acts as a way to allow the User to switch between two mutua
       </div>
     </div>
     <div class="row d-d-flex d-ai-center d-jc-space-between d-mb6">
-      <div class="d-toggle-copy d-mr6">
+      <div class="d-toggle-copy">
         <label class="d-toggle-label" for="Dialtone-Toggle5">Montana Centre</label>
       </div>
       <div class="d-toggle-button">
@@ -173,7 +173,7 @@ The Toggle component acts as a way to allow the User to switch between two mutua
       </div>
     </div>
     <div class="row d-d-flex d-ai-center d-jc-space-between d-mb6">
-      <div class="d-toggle-copy d-mr6">
+      <div class="d-toggle-copy">
         <label class="d-toggle-label" for="Dialtone-Toggle5">Wilson Centre</label>
       </div>
       <div class="d-toggle-button">

--- a/lib/build/less/components/toggle.less
+++ b/lib/build/less/components/toggle.less
@@ -37,6 +37,10 @@
   border-radius: var(--su48);
   cursor: pointer;
 
+  &-copy {
+    margin-right: var(--su6);
+  }
+
   &__inner {
     position: absolute;
     top: calc(var(--su4) - var(--su1));


### PR DESCRIPTION
## Description
Add default margin to toggle component `.d-toggle-copy` class. Remove `.d-mr6` classes from documentation and examples. 

Bug fix based on the [Jira ticket](https://dialpad.atlassian.net/browse/DT-569?atlOrigin=eyJpIjoiMTQ3MmEzYWEwMjcwNGNhNTkyNjE0MjZkOWM3NjFjN2QiLCJwIjoiaiJ9).

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/ToMjGppLes0ENI5osCc/giphy.gif)
