### PR TITLE
chore: cleanup old vuepress GHA, add version7

### DIFF
--- a/.github/workflows/deploy-version7.yml
+++ b/.github/workflows/deploy-version7.yml
@@ -1,9 +1,9 @@
-name: Deploy Vuepress
+name: Deploy Version 7
 
 on:
   push:
     branches:
-      - VuePress_migration_base
+      - version7
 
 jobs:
   deploy:
@@ -23,11 +23,11 @@ jobs:
         run: npm install
 
       - name: Build Library and docsite
-        run: npm run build:docsite -- --deploySubdir /vuepress/
+        run: npm run build:docsite -- --deploySubdir /version7/
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4.2.5
         with:
           branch: gh-pages
           folder: docs/.vuepress/dist
-          target-folder: vuepress
+          target-folder: version7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,4 +50,4 @@ jobs:
           clean-exclude: |
             deploy-previews
             version5
-            vuepress
+            version7


### PR DESCRIPTION
Removed the old `vuepress` branch GHA workflow now that it is officially deployed. Added a new workflow to deploy our version7 branch to Github Pages.

Will CP this to version7 branch after merge