### PR TITLE
fix(modal): fix spacing and overriding styles in the docsite

### DIFF
--- a/docs/assets/less/overrides.less
+++ b/docs/assets/less/overrides.less
@@ -4,6 +4,7 @@
 @import (reference) '../../../lib/build/less/utilities/internals';
 @import (reference) '../../../lib/build/less/utilities/spacing';
 @import (reference) '../../../lib/build/less/utilities/typography';
+@import (reference) '../../../lib/build/less/components/modal';
 
 html {
   scroll-behavior: smooth;
@@ -154,6 +155,13 @@ samp {
     margin-top: 0!important;
   }
 
+}
+
+// Fix theme-default styles leaking into the modal
+.theme-default-content {
+  .d-modal__header {
+    .d-modal__header();
+  }
 }
 
 .page-nav {

--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -96,8 +96,6 @@
   visibility: hidden;
   opacity: 0;
   will-change: visibility, z-index, opacity, transform;
-
-  .d-stack16();
 }
 
 //  $$   MAKE THEM APPEAR
@@ -139,10 +137,10 @@
 //  ----------------------------------------------------------------------------
 .d-modal__header {
   margin: 0 !important;
-  padding: var(--su24) var(--su24) 0;
+  padding: var(--su24) var(--su24) 0 !important;
   color: var(--modal-header--fc);
   font-weight: var(--fw-bold);
-  font-size: var(--fs24);
+  font-size: var(--fs24) !important;
   line-height: var(--lh4);
 }
 
@@ -150,7 +148,7 @@
 //  ----------------------------------------------------------------------------
 .d-modal__content {
   max-width: 75ch;
-  margin: var(--su12) 0 0 !important;
+  margin: var(--su12) 0 !important;
   padding: var(--su4) var(--su24);
 }
 

--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -137,10 +137,10 @@
 //  ----------------------------------------------------------------------------
 .d-modal__header {
   margin: 0 !important;
-  padding: var(--su24) var(--su24) 0 !important;
+  padding: var(--su24) var(--su24) 0;
   color: var(--modal-header--fc);
   font-weight: var(--fw-bold);
-  font-size: var(--fs24) !important;
+  font-size: var(--fs24);
   line-height: var(--lh4);
 }
 
@@ -148,7 +148,7 @@
 //  ----------------------------------------------------------------------------
 .d-modal__content {
   max-width: 75ch;
-  margin: var(--su12) 0 !important;
+  margin: var(--su12) 0;
   padding: var(--su4) var(--su24);
 }
 


### PR DESCRIPTION
## Description
Fixes the overriding styles in the docsite.
It also fixes the spacing in the variant when no footer is provided.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://i.giphy.com/media/oGXg0VWvDLva/giphy.webp)
