### PR TITLE
fix(modal): add box sizing style in modal banner class

### DIFF
--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -169,6 +169,7 @@
 //  ----------------------------------------------------------------------------
 .d-modal__banner {
   position: relative;
+  box-sizing: border-box;
   width: 100%;
   max-width: var(--size628);
   padding: var(--su12) var(--su24);


### PR DESCRIPTION
## Description
Added `box-sizing` style in the banner.

This is how the banner looks removing the `box-sizing` style applied in the [doc site](https://github.com/dialpad/dialtone/blob/staging/docs/assets/less/dialtone-docs.less#L38-L44).
![2022-08-09 at 15 49 22@2x](https://user-images.githubusercontent.com/83774467/183738361-ef10590b-3ccc-4b5c-bac7-dbe94d508952.png)

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://i.giphy.com/media/hzAR4V86zuCKQKe6kP/giphy.webp)
