### PR TITLE
feat(theme): create and update theme variables

### DIFF
--- a/docs/_data/site-nav.json
+++ b/docs/_data/site-nav.json
@@ -57,6 +57,10 @@
         {
           "text": "Color Palette",
           "link": "/design/colors/color-palette.html"
+        },
+        {
+          "text": "Theme",
+          "link": "/design/colors/theme.html"
         }
       ]
     },

--- a/docs/design/colors/color-palette.md
+++ b/docs/design/colors/color-palette.md
@@ -5,8 +5,8 @@ prev:
   text: Getting Started - Tooling
   link: /getting-started/accessibility/tooling
 next:
-  text: Brand Icons
-  link: /design/icons/brand.html
+  text: Theme
+  link: /design/colors/theme.html
 ---
 
 <colors></colors>

--- a/docs/design/colors/theme.md
+++ b/docs/design/colors/theme.md
@@ -1,0 +1,330 @@
+---
+title: Theme
+desc:
+prev:
+  text: Color Palette
+  link: /design/colors/color-palette.html
+next:
+  text: Brand Icons
+  link: /design/icons/brand.html
+---
+
+<table class="d-table dialtone-doc-table d-mt16">
+  <thead>
+    <tr>
+      <th scope="col">
+        Section
+      </th>
+      <th scope="col">
+        Item
+      </th>
+      <th scope="col">
+        Property
+      </th>
+      <th scope="col">
+        Variable
+      </th>
+      <th scope="col">
+        CSS Utility
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Topbar
+      </th>
+      <td class="d-fw-normal">
+        Background
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        background-color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-topbar-color-background)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-topbar-fc"
+          </div>
+          <div class="d-fl-shrink0 d-m4 d-ml16 d-h32 d-w32 d-bar4 d-ba d-bc-black-100 d-theme-topbar-fc"></div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Topbar
+      </th>
+      <td class="d-fw-normal">
+        Text
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-topbar-color-hsl)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-topbar-fc"
+          </div>
+          <div class="d-fl0 d-fs16 d-m4 d-ta-center d-w32 d-lh4 d-ml16 d-theme-topbar-fc">
+            Aa
+          </div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Sidebar
+      </th>
+      <td class="d-fw-normal">
+        Background
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        background-color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-sidebar-color-background)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-sidebar-bgc"
+          </div>
+          <div class="d-fl-shrink0 d-m4 d-ml16 d-h32 d-w32 d-bar4 d-ba d-bc-black-100 d-theme-sidebar-bgc"></div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Sidebar
+      </th>
+      <td class="d-fw-normal">
+        Text: Name / Group
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-sidebar-color-hsl)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-sidebar-bgc"
+          </div>
+          <div class="d-fl0 d-fs16 d-m4 d-ta-center d-w32 d-lh4 d-ml16 d-theme-sidebar-fc">
+            Aa
+          </div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Sidebar
+      </th>
+      <td class="d-fw-normal">
+        Text: Status
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-sidebar-color-hsl)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-sidebar-fc d-fco75"
+          </div>
+          <div class="d-fl0 d-fs16 d-lh4 d-m4 d-ta-center d-w32 d-theme-sidebar-fc d-ml16 d-fco75">
+            Aa
+          </div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Sidebar
+      </th>
+      <td class="d-fw-normal">
+        Icon
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-sidebar-color-hsl)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-sidebar-fc d-fco85 h:d-fco100"
+          </div>
+          <div class="d-fl0 d-fs16 d-lh4 d-theme-sidebar-fc d-ta-center d-w32 d-m4 d-ml16 d-fco85 h:d-fco100">
+            <svg aria-hidden="true" aria-label="Info" class="d-svg d-svg--system d-svg__info" viewBox="0 0 24 24"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path></svg>
+          </div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Sidebar
+      </th>
+      <td class="d-fw-normal">
+        Background: Active Row
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        background-color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-sidebar-active-row-color-background)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-sidebar-row-active-bgc"
+          </div>
+          <div class="d-fl-shrink0 d-m4 d-ml16 d-h32 d-w32 d-bar4 d-ba d-bc-black-100 d-theme-sidebar-row-active-bgc"></div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Sidebar
+      </th>
+      <td class="d-fw-normal">
+        Text: Active Row
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-sidebar-active-row-color-hsl)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-sidebar-row-active-fc"
+          </div>
+          <div class="d-fl0 d-fs16 d-m4 d-ta-center d-w32 d-lh4 d-ml16 d-theme-sidebar-row-active-fc">
+            Aa
+          </div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Sidebar
+      </th>
+      <td class="d-fw-normal">
+        Background: Hover Row Color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        background-color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-sidebar-row-color-background-hover)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-sidebar-row-bgc"
+          </div>
+          <div class="d-fl-shrink0 d-m4 d-ml16 d-h32 d-w32 d-bar4 d-ba d-bc-black-100 d-theme-sidebar-row-bgc"></div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Sidebar
+      </th>
+      <td class="d-fw-normal">
+        Background: Mention Badges
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        background-color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-mention-color-background)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-mention"
+          </div>
+          <div class="d-fl-shrink0 d-m4 d-ml16 d-h32 d-w32 d-bar4 d-ba d-bc-black-100 d-theme-mention"></div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Presence
+      </th>
+      <td class="d-fw-normal">
+        Available
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        background-color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-presence-color-background-available)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-presence-available"
+          </div>
+          <div class="d-fl-shrink0 d-m4 d-ml16 d-h32 d-w32 d-bar4 d-ba d-bc-black-100 d-theme-presence-available"></div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Presence
+      </th>
+      <td class="d-fw-normal">
+        Actively Busy
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        background-color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-presence-color-background-busy-unavailable)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-presence-busy-unavailable"
+          </div>
+          <div class="d-fl-shrink0 d-m4 d-ml16 d-h32 d-w32 d-bar4 d-ba d-bc-black-100 d-theme-presence-busy-unavailable"></div>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-fw-normal">
+        Presence
+      </th>
+      <td class="d-fw-normal">
+        Busy
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        background-color
+      </td>
+      <td class="d-ff-mono d-fc-purple d-fw-normal d-fs12">
+        var(--theme-presence-color-background-busy)
+      </td>
+      <td>
+        <div class="d-d-flex d-jc-space-between d-ai-center">
+          <div class="d-fl1 d-ff-mono d-fc-orange d-fs12">
+            "d-theme-presence-busy"
+          </div>
+          <div class="d-fl-shrink0 d-m4 d-ml16 d-h32 d-w32 d-bar4 d-ba d-bc-black-100 d-theme-presence-busy"></div>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/design/icons/brand.md
+++ b/docs/design/icons/brand.md
@@ -2,8 +2,8 @@
 title: Brand Icons
 desc: The following brand icons are provided when full-color SVGs are desired or third-party icons.
 prev:
-  text: Color Palette
-  link: /design/colors/color-palette.html
+  text: Theme
+  link: /design/colors/theme.html
 ---
 
 <icons kind="brand"></icons>

--- a/docs/utilities/typography/text-opacity.md
+++ b/docs/utilities/typography/text-opacity.md
@@ -25,6 +25,7 @@ Use `d-fco{n}` to change a font-color's opacity. You can also change font-color'
 <p class="d-fc-pink-600 d-fco99">The quick brown fox jumps over the lazy dog.</p>
 <p class="d-fc-pink-600 d-fco95">The quick brown fox jumps over the lazy dog.</p>
 <p class="d-fc-pink-600 d-fco90">The quick brown fox jumps over the lazy dog.</p>
+<p class="d-fc-pink-600 d-fco85">The quick brown fox jumps over the lazy dog.</p>
 <p class="d-fc-pink-600 d-fco75">The quick brown fox jumps over the lazy dog.</p>
 <p class="d-fc-pink-600 d-fco50">The quick brown fox jumps over the lazy dog.</p>
 <p class="d-fc-pink-600 d-fco25">The quick brown fox jumps over the lazy dog.</p>

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -120,7 +120,7 @@ body {
     #d-internals #color-vars(black-900, @black-900);
     #d-internals #color-vars(purple-100, @purple-100);
     #d-internals #color-vars(purple-200, @purple-200);
-    #d-internals #color-vars(purple-3000, @purple-300);
+    #d-internals #color-vars(purple-300, @purple-300);
     #d-internals #color-vars(purple-400, @purple-400);
     #d-internals #color-vars(purple-500, @purple-500);
     #d-internals #color-vars(purple-600, @purple-600);

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -52,8 +52,35 @@
     base--font-feature-settings:            'calt' 0;
     base--line-height:                      var(--lh-normal);
     base--corner-radius:                    0.25em;
+
+    //  New Theme Variables
+    theme-top-bar-background-color:         #F9F9F9; // DT7 black-100?
+    theme-top-bar-font-color:               var(--black-900);
+    theme-sidebar-background-color:         #F9F9F9; // DT7 black-100?
+    theme-sidebar-font-color:               var(--black-900);
+    theme-sidebar-active-background-color:  #E9E9E9; // DT7 black-200?
+    theme-sidebar-active-font-color:        var(--black-900);
+    theme-sidebar-hover-background-color:   #E9E9E9; // DT7 black-200?
+    theme-sidebar-badge-background-color:   var(--purple-500);
+    theme-presence-available:               var(--green-500);
+    theme-presence-busy-unavailable:        var(--red-500);
+    theme-presence-busy:                    var(--yellow-500);
 }
 
+//  ============================================================================
+//  $   THEME CLASSES
+//  ============================================================================
+.d-theme-top-bar-bgc                { background-color: var(--theme-top-bar-background-color) !important; }
+.d-theme-top-bar-fc                 { color: var(--theme-top-bar-font-color) !important; }
+.d-theme-sidebar-bgc                { background-color: var(--theme-sidebar-background-color) !important; }
+.d-theme-sidebar-fc                 { color: var(--theme-sidebar-font-color) !important; }
+.d-theme-sidebar-active-bgc         { background-color: var(--theme-sidebar-active-background-color) !important; }
+.d-theme-sidebar-active-fc          { background-color: var(--theme-sidebar-active-font-color) !important; }
+.d-theme-sidebar-hover-bgc          { background-color: var(--theme-sidebar-hover-background-color) !important; }
+.d-theme-badge                      { background-color: var(--theme-sidebar-badge-background-color) !important; }
+.d-theme-presence-available         { background-color: var(--theme-presence-available) !important; }
+.d-theme-presence-busy-unavailable  { background-color: var(--theme-presence-busy-unavailable) !important; }
+.d-theme-presence-busy              { background-color: var(--theme-presence-busy) !important; }
 
 //  ============================================================================
 //  $   OUTPUT VARIABLES

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -34,56 +34,55 @@
 
 
 @theme-vars: {
-    primary-color-h:                        var(--purple-500-h);
-    primary-color-s:                        var(--purple-500-s);
-    primary-color-l:                        var(--purple-500-l);
-    primary-color-hsl:                      var(--primary-color-h) var(--primary-color-s) var(--primary-color-l);
-    primary-color:                          hsl(var(--primary-color-h) var(--primary-color-s) var(--primary-color-l));
-    primary-color-hover:                    hsl(var(--primary-color-h) var(--primary-color-s) calc(var(--primary-color-l) - 10%));
-    nav-background-color-h:                 var(--purple-800-h);
-    nav-background-color-s:                 var(--purple-800-s);
-    nav-background-color-l:                 var(--purple-800-l);
-    nav-background-color:                   hsl(var(--nav-background-color-h) var(--nav-background-color-s) var(--nav-background-color-l));
+    primary-color-h:                                  var(--purple-500-h);
+    primary-color-s:                                  var(--purple-500-s);
+    primary-color-l:                                  var(--purple-500-l);
+    primary-color-hsl:                                var(--primary-color-h) var(--primary-color-s) var(--primary-color-l);
+    primary-color:                                    hsl(var(--primary-color-h) var(--primary-color-s) var(--primary-color-l));
+    primary-color-hover:                              hsl(var(--primary-color-h) var(--primary-color-s) calc(var(--primary-color-l) - 10%));
 
-    topbar-height:                          var(--su64);
+    topbar-height:                                    var(--su64);
 
-    base--font-size:                        var(--fs16);
-    base--font-family:                      @ff-custom;
-    base--font-feature-settings:            'calt' 0;
-    base--line-height:                      var(--lh-normal);
-    base--corner-radius:                    0.25em;
+    base--font-size:                                  var(--fs16);
+    base--font-family:                                @ff-custom;
+    base--font-feature-settings:                      'calt' 0;
+    base--line-height:                                var(--lh-normal);
+    base--corner-radius:                              0.25em;
 
-    theme-topbar-color:                               var(--black-900);
-    theme-topbar-color-background:                    #f9f9f9; // DT7 black-100?
+    theme-topbar-color:                               hsl(var(--theme-topbar-color-hsl));
+    theme-topbar-color-hsl:                           var(--black-900-h) var(--black-900-s) var(--black-900-l); // Use with d-fco[##] Opacity utility
+    theme-topbar-color-background:                    #f9f9f9; // DT7 TBD, possibly black-100?
 
-    theme-sidebar-color:                              var(--black-900);
-    theme-sidebar-color-background:                   #f9f9f9; // DT7 black-100?
+    theme-sidebar-color:                              hsl(var(--theme-sidebar-color-hsl));
+    theme-sidebar-color-hsl:                          var(--black-900-h) var(--black-900-s) var(--black-900-l); // Use with d-fco[##] Opacity utility
+    theme-sidebar-color-background:                   #f9f9f9; // DT7 TBD, possibly black-100?
 
-    theme-sidebar-active-row-color:                   var(--black-900);
-    theme-sidebar-active-row-color-background:        #e9e9e9; // DT7 black-200?
+    theme-sidebar-active-row-color:                   hsl(var(--theme-sidebar-active-row-color-hsl));
+    theme-sidebar-active-row-color-hsl:               var(--black-900-h) var(--black-900-s) var(--black-900-l); // Use with d-fco[##] Opacity utility
+    theme-sidebar-active-row-color-background:        #e9e9e9; // DT7 TBD, possibly black-100?
     theme-sidebar-active-row-color-background-hover:  var(--purple-100);
-
-    theme-mention-color-background:                   var(--purple-500);
 
     theme-presence-color-background-available:        var(--green-500);
     theme-presence-color-background-busy-unavailable: var(--red-500);
     theme-presence-color-background-busy:             var(--yellow-500);
+
+    theme-mention-color-background:                   var(--purple-500);
 }
 
 //  ============================================================================
 //  $   THEME CLASSES
 //  ============================================================================
-.d-theme-top-bar-bgc { background-color: var(--theme-topbar-color-background) !important; }
-.d-theme-top-bar-fc { color: var(--theme-topbar-color) !important; }
+.d-theme-topbar-fc { color: hsla(var(--theme-topbar-color-hsl) / var(--fco)) !important; }
+.d-theme-topbar-bgc { background-color: var(--theme-topbar-color-background) !important; }
+.d-theme-sidebar-fc { color: hsla(var(--theme-sidebar-color-hsl) / var(--fco)) !important; }
 .d-theme-sidebar-bgc { background-color: var(--theme-sidebar-color-background) !important; }
-.d-theme-sidebar-fc { color: var(--theme-sidebar-color) !important; }
+.d-theme-sidebar-active-fc { color: hsla(var(--theme-sidebar-active-row-color-hsl) / var(--fco)) !important; }
 .d-theme-sidebar-active-bgc { background-color: var(--theme-sidebar-active-row-color-background) !important; }
 .d-theme-sidebar-active-bgc:hover { background-color: var(--theme-sidebar-active-row-color-background-hover) !important; }
-.d-theme-sidebar-active-fc { background-color: var(--theme-sidebar-active-row-color) !important; }
-.d-theme-badge { background-color: var(--theme-mention-color-background) !important; }
 .d-theme-presence-available { background-color: var(--theme-presence-color-background-available) !important; }
 .d-theme-presence-busy-unavailable { background-color: var(--theme-presence-color-background-busy-unavailable) !important; }
 .d-theme-presence-busy { background-color: var(--theme-presence-color-background-busy) !important; }
+.d-theme-mention { background-color: var(--theme-mention-color-background) !important; }
 
 //  ============================================================================
 //  $   OUTPUT VARIABLES
@@ -111,7 +110,7 @@ body {
     #d-internals #color-vars(black-900, @black-900);
     #d-internals #color-vars(purple-100, @purple-100);
     #d-internals #color-vars(purple-200, @purple-200);
-    #d-internals #color-vars(purple-300, @purple-300);
+    #d-internals #color-vars(purple-3000, @purple-300);
     #d-internals #color-vars(purple-400, @purple-400);
     #d-internals #color-vars(purple-500, @purple-500);
     #d-internals #color-vars(purple-600, @purple-600);

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -53,34 +53,37 @@
     base--line-height:                      var(--lh-normal);
     base--corner-radius:                    0.25em;
 
-    //  New Theme Variables
-    theme-top-bar-background-color:         #f9f9f9; // DT7 black-100?
-    theme-top-bar-font-color:               var(--black-900);
-    theme-sidebar-background-color:         #f9f9f9; // DT7 black-100?
-    theme-sidebar-font-color:               var(--black-900);
-    theme-sidebar-active-background-color:  #e9e9e9; // DT7 black-200?
-    theme-sidebar-active-font-color:        var(--black-900);
-    theme-sidebar-hover-background-color:   #e9e9e9; // DT7 black-200?
-    theme-sidebar-badge-background-color:   var(--purple-500);
-    theme-presence-available:               var(--green-500);
-    theme-presence-busy-unavailable:        var(--red-500);
-    theme-presence-busy:                    var(--yellow-500);
+    theme-topbar-color:                               var(--black-900);
+    theme-topbar-color-background:                    #f9f9f9; // DT7 black-100?
+
+    theme-sidebar-color:                              var(--black-900);
+    theme-sidebar-color-background:                   #f9f9f9; // DT7 black-100?
+
+    theme-sidebar-active-row-color:                   var(--black-900);
+    theme-sidebar-active-row-color-background:        #e9e9e9; // DT7 black-200?
+    theme-sidebar-active-row-color-background-hover:  var(--purple-100);
+
+    theme-mention-color-background:                   var(--purple-500);
+
+    theme-presence-color-background-available:        var(--green-500);
+    theme-presence-color-background-busy-unavailable: var(--red-500);
+    theme-presence-color-background-busy:             var(--yellow-500);
 }
 
 //  ============================================================================
 //  $   THEME CLASSES
 //  ============================================================================
-.d-theme-top-bar-bgc { background-color: var(--theme-top-bar-background-color) !important; }
-.d-theme-top-bar-fc { color: var(--theme-top-bar-font-color) !important; }
-.d-theme-sidebar-bgc { background-color: var(--theme-sidebar-background-color) !important; }
-.d-theme-sidebar-fc { color: var(--theme-sidebar-font-color) !important; }
-.d-theme-sidebar-active-bgc { background-color: var(--theme-sidebar-active-background-color) !important; }
-.d-theme-sidebar-active-fc { background-color: var(--theme-sidebar-active-font-color) !important; }
-.d-theme-sidebar-hover-bgc { background-color: var(--theme-sidebar-hover-background-color) !important; }
-.d-theme-badge { background-color: var(--theme-sidebar-badge-background-color) !important; }
-.d-theme-presence-available { background-color: var(--theme-presence-available) !important; }
-.d-theme-presence-busy-unavailable { background-color: var(--theme-presence-busy-unavailable) !important; }
-.d-theme-presence-busy { background-color: var(--theme-presence-busy) !important; }
+.d-theme-top-bar-bgc { background-color: var(--theme-topbar-color-background) !important; }
+.d-theme-top-bar-fc { color: var(--theme-topbar-color) !important; }
+.d-theme-sidebar-bgc { background-color: var(--theme-sidebar-color-background) !important; }
+.d-theme-sidebar-fc { color: var(--theme-sidebar-color) !important; }
+.d-theme-sidebar-active-bgc { background-color: var(--theme-sidebar-active-row-color-background) !important; }
+.d-theme-sidebar-active-bgc:hover { background-color: var(--theme-sidebar-active-row-color-background-hover) !important; }
+.d-theme-sidebar-active-fc { background-color: var(--theme-sidebar-active-row-color) !important; }
+.d-theme-badge { background-color: var(--theme-mention-color-background) !important; }
+.d-theme-presence-available { background-color: var(--theme-presence-color-background-available) !important; }
+.d-theme-presence-busy-unavailable { background-color: var(--theme-presence-color-background-busy-unavailable) !important; }
+.d-theme-presence-busy { background-color: var(--theme-presence-color-background-busy) !important; }
 
 //  ============================================================================
 //  $   OUTPUT VARIABLES

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -57,10 +57,11 @@
     theme-sidebar-color-hsl:                          var(--black-900-h) var(--black-900-s) var(--black-900-l); // Use with d-fco[##] Opacity utility
     theme-sidebar-color-background:                   #f9f9f9; // DT7 TBD, possibly black-100?
 
+//  theme-sidebar-row-color-background:               {UNUSED}
+    theme-sidebar-row-color-background-hover:         var(--purple-100);
     theme-sidebar-active-row-color:                   hsl(var(--theme-sidebar-active-row-color-hsl));
     theme-sidebar-active-row-color-hsl:               var(--black-900-h) var(--black-900-s) var(--black-900-l); // Use with d-fco[##] Opacity utility
     theme-sidebar-active-row-color-background:        #e9e9e9; // DT7 TBD, possibly black-100?
-    theme-sidebar-active-row-color-background-hover:  var(--purple-100);
 
     theme-presence-color-background-available:        var(--green-500);
     theme-presence-color-background-busy-unavailable: var(--red-500);
@@ -72,13 +73,22 @@
 //  ============================================================================
 //  $   THEME CLASSES
 //  ============================================================================
-.d-theme-topbar-fc { color: hsla(var(--theme-topbar-color-hsl) / var(--fco)) !important; }
+
+.d-theme-topbar-fc {
+    --fco: 75%;
+
+    color: hsla(var(--theme-topbar-color-hsl) / var(--fco)) !important;
+
+    &:hover {
+        --fco: 100%;
+    }
+}
 .d-theme-topbar-bgc { background-color: var(--theme-topbar-color-background) !important; }
 .d-theme-sidebar-fc { color: hsla(var(--theme-sidebar-color-hsl) / var(--fco)) !important; }
 .d-theme-sidebar-bgc { background-color: var(--theme-sidebar-color-background) !important; }
-.d-theme-sidebar-active-fc { color: hsla(var(--theme-sidebar-active-row-color-hsl) / var(--fco)) !important; }
-.d-theme-sidebar-active-bgc { background-color: var(--theme-sidebar-active-row-color-background) !important; }
-.d-theme-sidebar-active-bgc:hover { background-color: var(--theme-sidebar-active-row-color-background-hover) !important; }
+.d-theme-sidebar-row-bgc:hover { background-color: var(--theme-sidebar-row-color-background-hover) !important; }
+.d-theme-sidebar-row-active-fc { color: hsla(var(--theme-sidebar-active-row-color-hsl) / var(--fco)) !important; }
+.d-theme-sidebar-row-active-bgc { background-color: var(--theme-sidebar-active-row-color-background) !important; }
 .d-theme-presence-available { background-color: var(--theme-presence-color-background-available) !important; }
 .d-theme-presence-busy-unavailable { background-color: var(--theme-presence-color-background-busy-unavailable) !important; }
 .d-theme-presence-busy { background-color: var(--theme-presence-color-background-busy) !important; }

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -54,13 +54,13 @@
     base--corner-radius:                    0.25em;
 
     //  New Theme Variables
-    theme-top-bar-background-color:         #F9F9F9; // DT7 black-100?
+    theme-top-bar-background-color:         #f9f9f9; // DT7 black-100?
     theme-top-bar-font-color:               var(--black-900);
-    theme-sidebar-background-color:         #F9F9F9; // DT7 black-100?
+    theme-sidebar-background-color:         #f9f9f9; // DT7 black-100?
     theme-sidebar-font-color:               var(--black-900);
-    theme-sidebar-active-background-color:  #E9E9E9; // DT7 black-200?
+    theme-sidebar-active-background-color:  #e9e9e9; // DT7 black-200?
     theme-sidebar-active-font-color:        var(--black-900);
-    theme-sidebar-hover-background-color:   #E9E9E9; // DT7 black-200?
+    theme-sidebar-hover-background-color:   #e9e9e9; // DT7 black-200?
     theme-sidebar-badge-background-color:   var(--purple-500);
     theme-presence-available:               var(--green-500);
     theme-presence-busy-unavailable:        var(--red-500);
@@ -70,17 +70,17 @@
 //  ============================================================================
 //  $   THEME CLASSES
 //  ============================================================================
-.d-theme-top-bar-bgc                { background-color: var(--theme-top-bar-background-color) !important; }
-.d-theme-top-bar-fc                 { color: var(--theme-top-bar-font-color) !important; }
-.d-theme-sidebar-bgc                { background-color: var(--theme-sidebar-background-color) !important; }
-.d-theme-sidebar-fc                 { color: var(--theme-sidebar-font-color) !important; }
-.d-theme-sidebar-active-bgc         { background-color: var(--theme-sidebar-active-background-color) !important; }
-.d-theme-sidebar-active-fc          { background-color: var(--theme-sidebar-active-font-color) !important; }
-.d-theme-sidebar-hover-bgc          { background-color: var(--theme-sidebar-hover-background-color) !important; }
-.d-theme-badge                      { background-color: var(--theme-sidebar-badge-background-color) !important; }
-.d-theme-presence-available         { background-color: var(--theme-presence-available) !important; }
-.d-theme-presence-busy-unavailable  { background-color: var(--theme-presence-busy-unavailable) !important; }
-.d-theme-presence-busy              { background-color: var(--theme-presence-busy) !important; }
+.d-theme-top-bar-bgc { background-color: var(--theme-top-bar-background-color) !important; }
+.d-theme-top-bar-fc { color: var(--theme-top-bar-font-color) !important; }
+.d-theme-sidebar-bgc { background-color: var(--theme-sidebar-background-color) !important; }
+.d-theme-sidebar-fc { color: var(--theme-sidebar-font-color) !important; }
+.d-theme-sidebar-active-bgc { background-color: var(--theme-sidebar-active-background-color) !important; }
+.d-theme-sidebar-active-fc { background-color: var(--theme-sidebar-active-font-color) !important; }
+.d-theme-sidebar-hover-bgc { background-color: var(--theme-sidebar-hover-background-color) !important; }
+.d-theme-badge { background-color: var(--theme-sidebar-badge-background-color) !important; }
+.d-theme-presence-available { background-color: var(--theme-presence-available) !important; }
+.d-theme-presence-busy-unavailable { background-color: var(--theme-presence-busy-unavailable) !important; }
+.d-theme-presence-busy { background-color: var(--theme-presence-busy) !important; }
 
 //  ============================================================================
 //  $   OUTPUT VARIABLES

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -121,6 +121,7 @@
 
 //  $   OPACITY CLASSES
 //  ----------------------------------------------------------------------------
+#d-internals #opacity-classes(100);
 #d-internals #opacity-classes(99);
 #d-internals #opacity-classes(95);
 #d-internals #opacity-classes(90);

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -124,6 +124,7 @@
 #d-internals #opacity-classes(99);
 #d-internals #opacity-classes(95);
 #d-internals #opacity-classes(90);
+#d-internals #opacity-classes(85);
 #d-internals #opacity-classes(75);
 #d-internals #opacity-classes(50);
 #d-internals #opacity-classes(25);


### PR DESCRIPTION
## Description
Required for the Primer (aka 'fresh coat of paint') work in Dialpad, this commit adds new theme variables into Dialtone. None of the current theme variables in use today (`--nav-background-color` or `--primary-color`) are modified or removed. Instead all new theme variables have a new `--theme-[variable]` namespace.

This PR adds in CSS variables and accompanying CSS classes. No Less variables were created.

This address issue #637 .

### Outstanding questions

- [x] We currently don't document any theming variables within Dialtone. Do we need to document these new variables at this time?
- [x] Do we need Less variables created as well?

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](path/to/gif)
