### PR TITLE
feat(colors): remove primary color variable

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -73,7 +73,7 @@ All Dialtone classes available to users are prefixed with `d-`.
 .d-stack8 {}
 ```
 
-Note that variables are not classes and do not follow this convention. For example: `@purple-300` or `--primary-color`.
+Note that variables are not classes and do not follow this convention. For example: `@purple-300` (`LESS`) or `var(--su12)` (CSS Custom Property).
 
 #### Utility Classes
 

--- a/docs/.vuepress/theme/layouts/Layout.vue
+++ b/docs/.vuepress/theme/layouts/Layout.vue
@@ -112,12 +112,12 @@ watch(isMobile, (current) => {
     }
 
     .toc-item > a {
-      color: var(--primary-color);
+      color: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
       text-decoration: underline;
     }
 
     .toc-item > a:hover {
-      color: var(--primary-color-hover);
+      color: hsl(var(--purple-500-h) var(--purple-500-s) calc(var(--purple-500-l) - 10%));
       text-decoration: underline;
       background-color: transparent;
     }

--- a/docs/_data/type.json
+++ b/docs/_data/type.json
@@ -185,10 +185,6 @@
       "output": "black-600"
     },
     {
-      "var": "primary",
-      "output": "primary-color"
-    },
-    {
       "var": "purple",
       "output": "purple-500"
     },

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -75,13 +75,3 @@ If you would like to verify your final output svg file run `npm run build` and l
 7. Commit and push your branch to Dialtone.
 8. Open a pull request.
 9. Once approved it can be merged into staging and will go out in the next dialtone release.
-
-### A note on theming
-
-Spot Illustrations allow for theming, meaning the primary color of the illustration will change when the theme changes.
-If your spot illustration svg contains a fill or a stroke with the dialtone primary color `#6C3DFF`
-then it will automatically change when the theme's primary color changes.
-
-You may often wish to derive lighter or darker colors based on the primary color when making a spot illustration.
-In these instances it is recommended to set opacity while still using the primary color as the base color so these
-colors will also change with the theme.

--- a/docs/assets/less/dialtone-docs.less
+++ b/docs/assets/less/dialtone-docs.less
@@ -137,7 +137,7 @@ nav a.router-link-active {
   }
 
   &.active {
-    color: var(--primary-color);
+    color: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
     font-weight: var(--fw-bold);
 
     &::before {
@@ -146,7 +146,7 @@ nav a.router-link-active {
       bottom: var(--su0);
       left: var(--sun4);
       width: var(--su4);
-      background-color: var(--primary-color);
+      background-color: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
       border-radius: var(--br4);
       content: '';
     }

--- a/docs/assets/less/overrides.less
+++ b/docs/assets/less/overrides.less
@@ -113,7 +113,7 @@ samp {
   a:not([class]) {
     text-decoration: underline;
     &:hover {
-      color: var(--primary-color-hover);
+      color: hsl(var(--purple-500-h) var(--purple-500-s) calc(var(--purple-500-l) - 10%));
       text-decoration: none;
     }
   }

--- a/docs/design/illustrations/spot.md
+++ b/docs/design/illustrations/spot.md
@@ -6,10 +6,4 @@ next:
   link: /design/spacing/spacing-system
 ---
 
-## Theming
-
-It is possible for the primary color of your spot illustration to change with the theme. See [Adding Icons](/design/icons/add.html) for details on how to do this.
-
-## Illustrations
-
 <icons kind="spot" size="large"></icons>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,8 +72,6 @@ const replace = settings.svgs ? require('gulp-replace') : null;
 //  @@ BUILD
 const cp = settings.build ? require('child_process') : null;
 
-const PRIMARY_COLOR = '#6c3dff';
-
 //  ================================================================================
 //  @  PATHS
 //     Where everything is in this project
@@ -435,13 +433,9 @@ const buildPatternSVGs = function (done) {
 const buildSpotIllustrationSVGs = function (done) {
   //  Make sure this feature is activated before running
   if (!settings.spot) return done();
-  const strokeRegex = new RegExp(`stroke="${PRIMARY_COLOR}"`, 'gi');
-  const fillRegex = new RegExp(`fill="${PRIMARY_COLOR}"`, 'gi');
   //  Compile system icons
   return src(paths.spot.input)
   // replace any instances of the primary color in SVG with the theme class
-    .pipe(replace(strokeRegex, 'class="d-svg-primary--stroke"'))
-    .pipe(replace(fillRegex, 'class="d-svg-primary--fill"'))
     .pipe(replace('<svg', function (match) {
       const name = path.parse(this.file.path).name;
       const converted = name.toLowerCase().replace(/-(.)/g, function (match, group1) {

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -20,7 +20,7 @@
 .d-btn {
     //  Component specific CSS Vars
     //  ------------------------------------------------------------------------
-    --button--fc: var(--primary-color);
+    --button--fc: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
     --button--bgc: transparent;
     --button--bc: transparent;
     --button--br: var(--base--corner-radius);
@@ -52,15 +52,15 @@
     //  --  STATES
     //  ------------------------------------------------------------------------
     &:hover {
-        --button--fc: var(--primary-color-hover);
-        --button--bgc: hsla(var(--primary-color-hsl) ~' / ' 3%);
+        --button--fc: hsl(var(--purple-500-h) var(--purple-500-s) calc(var(--purple-500-l) - 10%));
+        --button--bgc: hsla(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l) ~' / ' 3%);
     }
 
     &:active,
     &.d-btn--active,
     &.d-btn--active:active {
-        --button--fc: var(--primary-color-hover);
-        --button--bgc: hsla(var(--primary-color-hsl) ~' / ' 9%);
+        --button--fc: hsl(var(--purple-500-h) var(--purple-500-s) calc(var(--purple-500-l) - 10%));
+        --button--bgc: hsla(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l) ~' / ' 9%);
     }
 
 
@@ -276,25 +276,25 @@
 //  $$  OUTLINED BUTTON
 //  ----------------------------------------------------------------------------
 .d-btn--outlined {
-    --button--bc: var(--primary-color);
+    --button--bc: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
 }
 
 //  $$  PRIMARY BUTTON
 //  ----------------------------------------------------------------------------
 .d-btn--primary {
     --button--fc: var(--white);
-    --button--bgc: var(--primary-color);
+    --button--bgc: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
 
     &:hover {
       --button--fc: var(--white);
-      --button--bgc: hsl(var(--primary-color-h), var(--primary-color-s), 65%);
+      --button--bgc: hsl(var(--purple-500-h), var(--purple-500-s), 65%);
     }
 
     &:active,
     &.d-btn--active,
     &.d-btn--active:active {
       --button--fc: var(--white);
-      --button--bgc: hsl(var(--primary-color-h), var(--primary-color-s), 42%);
+      --button--bgc: hsl(var(--purple-500-h), var(--purple-500-s), 42%);
     }
 }
 
@@ -397,18 +397,18 @@
 
     //  --  PRIMARY
     &.d-btn--primary {
-        --button--fc: var(--primary-color);
+        --button--fc: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
         --button--bgc: hsl(var(--purple-100-h), var(--purple-100-s), 100%);
 
         &:hover {
-            --button--fc: var(--primary-color-hover);
+            --button--fc: hsl(var(--purple-500-h) var(--purple-500-s) calc(var(--purple-500-l) - 10%));
             --button--bgc: hsl(var(--purple-100-h), var(--purple-100-s), 94%);
         }
 
         &:active,
         &.d-btn--active,
         &.d-btn--active:active {
-            --button--fc: var(--primary-color-hover);
+            --button--fc: hsl(var(--purple-500-h) var(--purple-500-s) calc(var(--purple-500-l) - 10%));
             --button--bgc: hsl(var(--purple-100-h), var(--purple-100-s), 91%);
         }
     }

--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -33,7 +33,7 @@
 .d-textarea {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
-    --input--focus-bc: var(--primary-color);
+    --input--focus-bc: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
     --input--bc: var(--black-500);
     --input--bgc: var(--white);
     --input--fc: var(--black-800);

--- a/lib/build/less/components/link.less
+++ b/lib/build/less/components/link.less
@@ -21,7 +21,7 @@
     box-sizing: border-box;
     margin: var(--su0);
     padding: var(--su0);
-    color: var(--primary-color);
+    color: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
     font: inherit;
     text-decoration: underline;
     background-color: transparent;
@@ -35,7 +35,7 @@
     fill: currentColor;
 
     &:hover {
-        color: var(--primary-color-hover);
+        color: hsl(var(--purple-500-h) var(--purple-500-s) calc(var(--purple-500-l) - 10%));
         text-decoration: none;
         cursor: pointer;
     }

--- a/lib/build/less/components/list-group.less
+++ b/lib/build/less/components/list-group.less
@@ -33,16 +33,16 @@
 
     &:hover {
         color: var(--black-900);
-        background-color: hsla(var(--primary-color-hsl) ~' / ' 85%);
+        background-color: hsla(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l) ~' / ' 85%);
     }
 
     &-selected {
         color: var(--white);
-        background-color: var(--primary-color);
+        background-color: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
 
         &:hover {
             color: var(--white);
-            background-color: hsl(var(--primary-color-h) var(--primary-color-s) calc(var(--primary-color-l) + 10%));
+            background-color: hsl(var(--purple-500-h) var(--purple-500-s) calc(var(--purple-500-l) + 10%));
         }
     }
 }

--- a/lib/build/less/components/radio-checkbox.less
+++ b/lib/build/less/components/radio-checkbox.less
@@ -25,7 +25,7 @@
 .d-radio {
     //  Component specific CSS Vars
     //  ------------------------------------------------------------------------
-    --check-radio--color: var(--primary-color);
+    --check-radio--color: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
     --check-radio--bc: var(--black-500);
     --check-radio--bgc: var(--white);
 

--- a/lib/build/less/components/selects.less
+++ b/lib/build/less/components/selects.less
@@ -115,7 +115,7 @@
   --select--bc: var(--black-500);
 
   &:focus {
-    --select--bc: var(--primary-color);
+    --select--bc: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
 
     box-shadow: var(--bs-focus-ring);
   }

--- a/lib/build/less/components/tabs.less
+++ b/lib/build/less/components/tabs.less
@@ -103,18 +103,18 @@
 //  $   SELECTED STYLE
 //  ----------------------------------------------------------------------------
 .d-tab--selected {
-    --tab--fc: var(--primary-color);
+    --tab--fc: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
 
     z-index: var(--zi-selected);
 
     &:hover {
-        --tab--bgc: hsla(var(--primary-color-hsl) ~' / ' 10%);
-        --tab--fc: var(--primary-color-hover);
+        --tab--bgc: hsla(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l) ~' / ' 10%);
+        --tab--fc: hsl(var(--purple-500-h) var(--purple-500-s) calc(var(--purple-500-l) - 10%));
     }
 
     &::after,
     &:hover::after {
-        --tab--bgc: var(--primary-color);
+        --tab--bgc: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
     }
 }
 

--- a/lib/build/less/components/toggle.less
+++ b/lib/build/less/components/toggle.less
@@ -74,7 +74,7 @@
 //  $$  CHECKED TOGGLE
 //  ----------------------------------------------------------------------------
 .d-toggle--checked {
-  --toggle-bc: var(--primary-color);
+  --toggle-bc: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
 
   .d-toggle__inner {
     left: var(--su6);

--- a/lib/build/less/dialtone-globals.less
+++ b/lib/build/less/dialtone-globals.less
@@ -51,14 +51,6 @@ body {
     }
 }
 
-.d-svg-primary--stroke {
-    stroke: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
-}
-
-.d-svg-primary--fill {
-    fill: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
-}
-
 //  ============================================================================
 //  @   FOCUS VISIBLE
 //  ----------------------------------------------------------------------------

--- a/lib/build/less/dialtone-globals.less
+++ b/lib/build/less/dialtone-globals.less
@@ -52,11 +52,11 @@ body {
 }
 
 .d-svg-primary--stroke {
-    stroke: var(--primary-color);
+    stroke: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
 }
 
 .d-svg-primary--fill {
-    fill: var(--primary-color);
+    fill: hsl(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l));
 }
 
 //  ============================================================================

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -34,12 +34,6 @@
 
 
 @theme-vars: {
-    primary-color-h:                        var(--purple-500-h);
-    primary-color-s:                        var(--purple-500-s);
-    primary-color-l:                        var(--purple-500-l);
-    primary-color-hsl:                      var(--primary-color-h) var(--primary-color-s) var(--primary-color-l);
-    primary-color:                          hsl(var(--primary-color-h) var(--primary-color-s) var(--primary-color-l));
-    primary-color-hover:                    hsl(var(--primary-color-h) var(--primary-color-s) calc(var(--primary-color-l) - 10%));
     nav-background-color-h:                 var(--purple-800-h);
     nav-background-color-s:                 var(--purple-800-s);
     nav-background-color-l:                 var(--purple-800-l);

--- a/lib/build/less/themes/example.less
+++ b/lib/build/less/themes/example.less
@@ -25,16 +25,8 @@
 //  $$  SET THESE
 //      Currently only the following items are themeable in Dialtone.
 //
-//      @primary-color:         This is used for all selected and primary states
-//                              in elements and components (i.e. buttons, input focus,
-//                              links, etc).
-//
-//      @primary-color--hover:  Hover state color for @primary-color.
-//
 //      @nav__background-color: This sets the navigation background color.
 //  ----------------------------------------------------------------------------
-@primary-color:                 @purple-500;
-@primary-color--hover:          darken(@primary-color, 10%);
 @nav__background-color:         @black-400;
 
 //  \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
@@ -43,14 +35,6 @@
 //      Warning:    We use these to extract the HSL values of the HEX code and
 //                  restate them in the CSS Variables.
 //  ----------------------------------------------------------------------------
-@primary-color--h:              hue(@primary-color);
-@primary-color--s:              saturation(@primary-color);
-@primary-color--l:              lightness(@primary-color);
-
-@primary-color--hover--h:       hue(@primary-color--hover);
-@primary-color--hover--s:       saturation(@primary-color--hover);
-@primary-color--hover--l:       lightness(@primary-color--hover);
-
 @nav__background-color--h:      hue(@nav__background-color);
 @nav__background-color--s:      saturation(@nav__background-color);
 @nav__background-color--l:      lightness(@nav__background-color);
@@ -59,23 +43,10 @@
 //  --  RE-DECLARE CSS VARIABLES WITH NEW COLORS
 //  ----------------------------------------------------------------------------
 @theme-vars: {
-    primary-color:              @primary-color;
-    primary-color--h:           @primary-color--h;
-    primary-color--s:           @primary-color--s;
-    primary-color--l:           @primary-color--l;
-
-    primary-color--hover:       @primary-color--hover;
-    primary-color--hover--h:    @primary-color--hover--h;
-    primary-color--hover--s:    @primary-color--hover--s;
-    primary-color--hover--l:    @primary-color--l;
-
     nav__background-color:      @nav__background-color;
     nav__background-color--h:   @nav__background-color--h;
     nav__background-color--s:   @nav__background-color--s;
     nav__background-color--l:   @nav__background-color--l;
-
-    btn--inverted__bg--hover:   fade(mix(#fff, @primary-color, 90%), 25%);
-    btn--inverted--primary__bg--hover: mix(#fff, @primary-color, 90%);
 }
 
 //  ============================================================================

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -67,7 +67,7 @@
 #d-internals #generate-hover-focus(d-fc-success, {.d-fc-success();});
 
 .d-fc-yellow { &:extend(.d-fc-yellow-600); }
-.d-fc-warning { color: var(--fc-warning) }
+.d-fc-warning { color: var(--fc-warning); }
 #d-internals #generate-hover-focus(d-fc-yellow, {.d-fc-yellow();});
 #d-internals #generate-hover-focus(d-fc-warning, {.d-fc-warning();});
 

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -38,11 +38,6 @@
 #d-internals #color-classes(green-700);
 #d-internals #color-classes(red-700);
 
-.d-fc-primary {
-    color: hsla(var(--primary-color-h) var(--primary-color-s) var(--primary-color-l)  ~' / ' var(--fco)) !important;
-}
-#d-internals #generate-hover-focus(d-fc-primary, {.d-fc-primary();});
-
 //  $$  TEXT COLORS
 //  ----------------------------------------------------------------------------
 .d-fc-dark { &:extend(.d-fc-black-900); }

--- a/lib/build/less/variables/colors.less
+++ b/lib/build/less/variables/colors.less
@@ -106,7 +106,7 @@
 //      Used on inputs, buttons, and other focusable elements.
 //  ----------------------------------------------------------------------------
 @focus-rings: {
-    focus-ring:                 hsla(var(--primary-color-hsl) ~' / ' 75%);
+    focus-ring:                 hsla(var(--purple-500-h) var(--purple-500-s) var(--purple-500-l) ~' / ' 75%);
     focus-ring-success:         hsla(var(--success-color-hsl) ~' / ' 75%);
     focus-ring-warning:         hsla(var(--warning-color-hsl) ~' / ' 75%);
     focus-ring-error:           hsla(var(--error-color-hsl) ~' / ' 75%);
@@ -136,7 +136,6 @@
     fc-warning:                 hsla(var(--yellow-500-h) var(--yellow-500-s) calc(var(--yellow-500-l) - 20%) ~' / ' var(--alpha, 100%));
     fc-warning-hover:           hsla(var(--yellow-500-h) var(--yellow-500-s) calc(var(--yellow-500-l) - 30%) ~' / ' var(--alpha, 100%));
     fc-muted:                   var(--black-900);
-    fc-primary:                 var(--primary-color);
 
     //  --  BASE TEMPLATE
     base--text-color:           var(--black-900);


### PR DESCRIPTION
## Description
Remove all "Primary Color" variables and Dialtone references ([DT-607](https://dialpad.atlassian.net/browse/DT-607)).

> The arguments against [Primary Color variable] inclusion is that all the theming proposals we've seen so far have restricted theming only to certain areas within DP such as the top bar and left sidebar. This would allow the team to have tighter control (and predictability) for core feature areas (calling, messaging, profile, integrations) without needing to worry about poor theming choices.

This is a precursor to New Theming Variables (https://github.com/dialpad/dialtone/issues/637 and [DT-603](https://dialpad.atlassian.net/browse/DT-603)).

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
<img width="547" alt="image" src="https://user-images.githubusercontent.com/1165933/185716232-1875d3bb-2086-4478-b798-9ea668cb23dd.png">

