### PR TITLE
docs: remove header links greater than L2

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -86,6 +86,9 @@ export default defineUserConfig({
 
   // markdown config
   markdown: {
+    anchor: {
+      level: [1, 2],
+    },
     code: {
       lineNumbers: false
     },


### PR DESCRIPTION
## Description
Header link anchors at any level greater than 2 were not working. We only want to display L2 links by design, this change removes all > L2 link anchors.
