### PR TITLE
feat(color): new ramps blue and tan

### DIFF
--- a/docs/_data/colors.json
+++ b/docs/_data/colors.json
@@ -158,28 +158,28 @@
         "hex": "FFA360",
         "copy": "dark",
         "contrast": "AAA 9.90",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "400",
         "hex": "FF7F23",
         "copy": "dark",
         "contrast": "AAA 7.72",
-          "primary": "yes"
+        "primary": "yes"
       },
       {
         "stop": "500",
         "hex": "E05E00",
         "copy": "dark",
         "contrast": "AA 5.35",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "600",
         "hex": "43220A",
         "copy": "white",
         "contrast": "AAA 14.26",
-          "primary": "no"
+        "primary": "no"
       }
     ]
   },
@@ -191,49 +191,49 @@
         "hex": "FFEBEC",
         "copy": "dark",
         "contrast": "AAA 17.04",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "200",
         "hex": "FFD8DA",
         "copy": "dark",
         "contrast": "AAA 14.94",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "300",
         "hex": "FDA2A8",
         "copy": "dark",
         "contrast": "AAA 10.13",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "400",
         "hex": "FF578A",
         "copy": "dark",
         "contrast": "AA 6.48",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "500",
         "hex": "E92A7A",
         "copy": "dark",
         "contrast": "AA 4.71",
-          "primary": "yes"
+        "primary": "yes"
       },
       {
         "stop": "600",
         "hex": "A2114D",
         "copy": "white",
         "contrast": "AAA 7.71",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "700",
         "hex": "57102E",
         "copy": "white",
         "contrast": "AAA 13.82",
-          "primary": "no"
+        "primary": "no"
       }
     ]
   },
@@ -245,49 +245,49 @@
         "hex": "FBF8F1",
         "copy": "dark",
         "contrast": "AAA 18.49",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "100",
         "hex": "FFF9E3",
         "copy": "dark",
         "contrast": "AAA 18.49",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "200",
         "hex": "FFEEB0",
         "copy": "dark",
         "contrast": "AAA 16.82",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "300",
         "hex": "FFCB59",
         "copy": "dark",
         "contrast": "AAA 14.42",
-          "primary": "yes"
+        "primary": "yes"
       },
       {
         "stop": "400",
         "hex": "FFCE1C",
         "copy": "dark",
         "contrast": "AAA 13.12",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "500",
         "hex": "FFBC0F",
         "copy": "dark",
         "contrast": "AAA 11.59",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "600",
         "hex": "3F2D00",
         "copy": "white",
         "contrast": "AAA 13.23",
-          "primary": "no"
+        "primary": "no"
       }
     ]
   },
@@ -299,49 +299,49 @@
         "hex": "FFF1F1",
         "copy": "dark",
         "contrast": "AAA 17.68",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "200",
         "hex": "FFD3D3",
         "copy": "dark",
         "contrast": "AAA 14.36",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "300",
         "hex": "FFA7A7",
         "copy": "dark",
         "contrast": "AAA 10.49",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "400",
         "hex": "FA4646",
         "copy": "dark",
         "contrast": "AA 5.58",
-          "primary": "yes"
+        "primary": "yes"
       },
       {
         "stop": "500",
         "hex": "D81616",
         "copy": "white",
         "contrast": "AA 5.19",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "600",
         "hex": "930000",
         "copy": "white",
         "contrast": "AAA 9.37",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "700",
         "hex": "480000",
         "copy": "white",
         "contrast": "AAA 16.46",
-          "primary": "no"
+        "primary": "no"
       }
     ]
   },
@@ -353,49 +353,89 @@
         "hex": "EBFFE2",
         "copy": "dark",
         "contrast": "AAA 18.89",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "200",
         "hex": "D1FFBC",
         "copy": "dark",
         "contrast": "AAA 17.40",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "300",
         "hex": "9CFF6D",
         "copy": "dark",
         "contrast": "AAA 15.73",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "400",
         "hex": "6BEE04",
         "copy": "dark",
         "contrast": "AAA 12.87",
-          "primary": "yes"
+        "primary": "yes"
       },
       {
         "stop": "500",
         "hex": "0C9B02",
         "copy": "dark",
         "contrast": "AA 5.29",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "600",
         "hex": "0A5B03",
         "copy": "white",
         "contrast": "AAA 8.36",
-          "primary": "no"
+        "primary": "no"
       },
       {
         "stop": "700",
         "hex": "052F01",
         "copy": "white",
         "contrast": "AAA 14.85",
-          "primary": "no"
+        "primary": "no"
+      }
+    ]
+  },
+  {
+    "color": "blue",
+    "stops": [
+      {
+        "stop": "100",
+        "hex": "E3EDF9",
+        "copy": "dark",
+        "contrast": "AAA 17.74:1",
+        "primary": "no"
+      },
+      {
+        "stop": "200",
+        "hex": "84BDFF",
+        "copy": "dark",
+        "contrast": "AAA 10.66:1",
+        "primary": "no"
+      },
+      {
+        "stop": "300",
+        "hex": "51A0FE",
+        "copy": "dark",
+        "contrast": "AAA 7.8:1",
+        "primary": "no"
+      },
+      {
+        "stop": "400",
+        "hex": "1768C6",
+        "copy": "white",
+        "contrast": "AA 5.5:1",
+        "primary": "yes"
+      },
+      {
+        "stop": "500",
+        "hex": "01326D",
+        "copy": "white",
+        "contrast": "AAA 12.51:1",
+        "primary": "no"
       }
     ]
   }

--- a/docs/_data/colors.json
+++ b/docs/_data/colors.json
@@ -438,5 +438,45 @@
         "primary": "no"
       }
     ]
+  },
+  {
+    "color": "tan",
+    "stops": [
+      {
+        "stop": "100",
+        "hex": "F2F0EE",
+        "copy": "dark",
+        "contrast": "AAA 18.47:1",
+        "primary": "no"
+      },
+      {
+        "stop": "200",
+        "hex": "CEC8C4",
+        "copy": "dark",
+        "contrast": "AAA 12.68:1",
+        "primary": "no"
+      },
+      {
+        "stop": "300",
+        "hex": "87807B",
+        "copy": "dark",
+        "contrast": "AA 5.4:1",
+        "primary": "no"
+      },
+      {
+        "stop": "400",
+        "hex": "3F3D3C",
+        "copy": "white",
+        "contrast": "AAA 10.8:1",
+        "primary": "yes"
+      },
+      {
+        "stop": "500",
+        "hex": "121212",
+        "copy": "white",
+        "contrast": "AAA 18.73:1",
+        "primary": "no"
+      }
+    ]
   }
 ]

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -118,6 +118,11 @@ body {
     #d-internals #color-vars(blue-300, @blue-300);
     #d-internals #color-vars(blue-400, @blue-400);
     #d-internals #color-vars(blue-500, @blue-500);
+    #d-internals #color-vars(tan-100, @tan-100);
+    #d-internals #color-vars(tan-200, @tan-200);
+    #d-internals #color-vars(tan-300, @tan-300);
+    #d-internals #color-vars(tan-400, @tan-400);
+    #d-internals #color-vars(tan-500, @tan-500);
 
     //  All the dark colored HSL vars
     &.theme-dark {

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -113,6 +113,11 @@ body {
     #d-internals #color-vars(red-500, @red-500);
     #d-internals #color-vars(red-600, @red-600);
     #d-internals #color-vars(red-700, @red-700);
+    #d-internals #color-vars(blue-100, @blue-100);
+    #d-internals #color-vars(blue-200, @blue-200);
+    #d-internals #color-vars(blue-300, @blue-300);
+    #d-internals #color-vars(blue-400, @blue-400);
+    #d-internals #color-vars(blue-500, @blue-500);
 
     //  All the dark colored HSL vars
     &.theme-dark {

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -22,6 +22,7 @@
 #d-internals #standard-stops(yellow);
 #d-internals #standard-stops(red);
 #d-internals #standard-stops(green);
+#d-internals #standard-stops(blue);
 
 //  --  A few additional colors that the standard-stops mixin misses
 #d-internals #color-classes(white);

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -88,6 +88,9 @@
 .d-fc-blue { &:extend(.d-fc-blue-400); }
 #d-internals #generate-hover-focus(d-fc-blue, {.d-fc-blue();});
 
+.d-fc-tan { &:extend(.d-fc-tan-400); }
+#d-internals #generate-hover-focus(d-fc-tan, {.d-fc-tan();});
+
 
 //  $$  BACKGROUND COLORS
 //  ----------------------------------------------------------------------------

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -123,7 +123,6 @@
 //  $   OPACITY CLASSES
 //  ----------------------------------------------------------------------------
 #d-internals #opacity-classes(99);
-#d-internals #opacity-classes(99);
 #d-internals #opacity-classes(95);
 #d-internals #opacity-classes(90);
 #d-internals #opacity-classes(75);

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -84,6 +84,9 @@
 .d-fc-unset { color: unset !important; }
 #d-internals #generate-hover-focus(d-fc-unset, {.d-fc-unset();});
 
+.d-fc-blue { &:extend(.d-fc-blue-400); }
+#d-internals #generate-hover-focus(d-fc-blue, {.d-fc-blue();});
+
 
 //  $$  BACKGROUND COLORS
 //  ----------------------------------------------------------------------------
@@ -115,6 +118,7 @@
 
 //  $   OPACITY CLASSES
 //  ----------------------------------------------------------------------------
+#d-internals #opacity-classes(99);
 #d-internals #opacity-classes(99);
 #d-internals #opacity-classes(95);
 #d-internals #opacity-classes(90);

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -23,6 +23,7 @@
 #d-internals #standard-stops(red);
 #d-internals #standard-stops(green);
 #d-internals #standard-stops(blue);
+#d-internals #standard-stops(tan);
 
 //  --  A few additional colors that the standard-stops mixin misses
 #d-internals #color-classes(white);

--- a/lib/build/less/variables/colors.less
+++ b/lib/build/less/variables/colors.less
@@ -79,6 +79,13 @@
 @blue-400:                      #1768C6;
 @blue-500:                      #01326D;
 
+@tan-100:                       #F2F0EE;
+@tan-200:                       #CEC8C4;
+@tan-300:                       #87807B;
+@tan-400:                       #3F3D3C;
+@tan-500:                       #121212;
+
+
 //  ============================================================================
 //  $   COLOR STATES
 //      Used for inputs, notices, and button statuses

--- a/lib/build/less/variables/colors.less
+++ b/lib/build/less/variables/colors.less
@@ -73,6 +73,12 @@
 @red-600:                       #930000;
 @red-700:                       #480000;
 
+@blue-100:                      #E3EDF9;
+@blue-200:                      #84BDFF;
+@blue-300:                      #51A0FE;
+@blue-400:                      #1768C6;
+@blue-500:                      #01326D;
+
 //  ============================================================================
 //  $   COLOR STATES
 //      Used for inputs, notices, and button statuses


### PR DESCRIPTION
## Description
Dialtone 7 and Visual Refresh efforts add two new Color Ramps, Blue and Tan. This is based off the `dialtone7` branch, rather than _"Use `staging` as your pull request's base branch."_

This completes tasks [DT-639](https://dialpad.atlassian.net/browse/DT-639) and [DT-638](https://dialpad.atlassian.net/browse/DT-638).

<img width="964" alt="image" src="https://user-images.githubusercontent.com/1165933/187310602-6a92b397-50d4-4a46-b9ec-d38094ebe028.png">

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
<img width="1244" alt="image" src="https://user-images.githubusercontent.com/1165933/187311222-7fcd008f-1d6e-4b52-9a67-d149f1766ae9.png">

