### PR TITLE
fix(theme): resurrect nav-background-color variable

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @dialpad-drew @josedialpad @francisrupert @braddialpad
+*       @josedialpad @francisrupert @braddialpad

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -34,12 +34,18 @@
 
 
 @theme-vars: {
+
     primary-color-h:                                  var(--purple-500-h);
     primary-color-s:                                  var(--purple-500-s);
     primary-color-l:                                  var(--purple-500-l);
     primary-color-hsl:                                var(--primary-color-h) var(--primary-color-s) var(--primary-color-l);
     primary-color:                                    hsl(var(--primary-color-h) var(--primary-color-s) var(--primary-color-l));
     primary-color-hover:                              hsl(var(--primary-color-h) var(--primary-color-s) calc(var(--primary-color-l) - 10%));
+
+    nav-background-color-h:                           var(--purple-800-h);
+    nav-background-color-s:                           var(--purple-800-s);
+    nav-background-color-l:                           var(--purple-800-l);
+    nav-background-color:                             hsl(var(--nav-background-color-h) var(--nav-background-color-s) var(--nav-background-color-l));
 
     topbar-height:                                    var(--su64);
 
@@ -93,6 +99,7 @@
 .d-theme-presence-busy-unavailable { background-color: var(--theme-presence-color-background-busy-unavailable) !important; }
 .d-theme-presence-busy { background-color: var(--theme-presence-color-background-busy) !important; }
 .d-theme-mention { background-color: var(--theme-mention-color-background) !important; }
+
 
 //  ============================================================================
 //  $   OUTPUT VARIABLES


### PR DESCRIPTION
## Description
`--nav-background-color` was removed in favor of `--theme-topbar-color-background`. However, topbar work is behind an experiment so we need to support both colors for a while.

[DT-650](https://dialpad.atlassian.net/browse/DT-650)

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)

![](https://c.tenor.com/cRv8lH8WescAAAAC/in-a-rush-sponge-bob-square-pants.gif)

