### PR TITLE
build: add GHA to update version7 branch

### DIFF
--- a/.github/workflows/update-version7.yml
+++ b/.github/workflows/update-version7.yml
@@ -1,0 +1,31 @@
+name: Update Version 7 Branch
+
+on:
+  pull_request:
+    branches:
+      - staging
+    types: ["closed"]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  update_version_7:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    name: Cherry pick into version7 branch
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Create PR
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.1
+        with:
+          branch: version7
+          labels: |
+            cherry-pick
+          reviewers: |
+            braddialpad
+            josedialpad
+            juliodialpad


### PR DESCRIPTION
## Description

Added a GHA to cherry-pick commits from last PR into version7 branch.

Found my error, I was trying to run the GHA on push to staging, and it was trying to retrieve information from `github.event.pull_request`

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/peaYCo9NOXQ2PcJKFC/giphy.gif)
