### PR TITLE
feat(font-weight): migrate usages and update migration guide

### DIFF
--- a/docs/assets/less/dialtone-docs.less
+++ b/docs/assets/less/dialtone-docs.less
@@ -89,7 +89,7 @@ span.DocSearch-Button-Keys {
 //      Override search button with dialtone styles
 //  ----------------------------------------------------------------------------
 nav a.router-link-active {
-  font-weight: var(--fw-black);
+  font-weight: var(--fw-bold);
   text-decoration: none;
 }
 //  ============================================================================

--- a/migration_guide/MIGRATION_GUIDE.md
+++ b/migration_guide/MIGRATION_GUIDE.md
@@ -211,4 +211,18 @@ Check updates to confirm desired rendering and alignment to contrast accessibili
 
 ### 6. Font updates
 
-Remove any usages of deprecated `.d-fw-thin`, `.d-fw-light` and `.d-fw-dark` classes. 
+#### Update font-weight CSS classes usage
+
+Search for | Replace with
+:-:|:-:
+`d-fw-thin` | `d-fw-normal`
+`d-fw-light` | `d-fw-normal`
+`d-fw-black` | `d-fw-bold`
+
+#### Update font-weight CSS variables
+
+Search for | Replace with
+:-:|:-:
+`var(--fw-thin)` | `var(--fw-normal)`
+`var(--fw-light)` | `var(--fw-normal)`
+`var(--fw-black)` | `var(--fw-bold)`


### PR DESCRIPTION
## Description
Jira ticket: https://dialpad.atlassian.net/browse/DT-669

As part of the [system font stack update](https://dialpad.atlassian.net/browse/DT-644), made the migration of the font-weight and updated the migration guide.
Found just one usage of the deprecated classes/variables in the docsite, no usage in the lib.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/Kcu7P0G6EuCWpoRZE7/giphy-downsized.gif)
