### PR TITLE
feat(type): typography classes body, headline, label, helper, code

### DIFF
--- a/docs/_data/site-nav.json
+++ b/docs/_data/site-nav.json
@@ -400,6 +400,10 @@
       "text": "Typography",
       "children": [
         {
+          "text": "Styles",
+          "link": "/utilities/typography/styles.html"
+        },
+        {
           "text": "Color",
           "link": "/utilities/typography/color.html"
         },

--- a/docs/_data/type.json
+++ b/docs/_data/type.json
@@ -1,4 +1,102 @@
 {
+  "typographyStyles": [
+    {
+      "var": "d-headline-eyebrow",
+      "output": "line-height: var(--lh-300); font-size: var(--fs-100); font-weight: var(--fw-normal); text-transform: uppercase;"
+    },
+    {
+      "var": "d-headline-small",
+      "output": "line-height: var(--lh-300); font-size: var(--fs-100); font-weight: var(--fw-bold);"
+    },
+    {
+      "var": "d-headline-medium",
+      "output": "line-height: var(--lh-400); font-size: var(--fs-200); font-weight: var(--fw-bold);"
+    },
+    {
+      "var": "d-headline-compact-small",
+      "output": "line-height: var(--lh-200); font-size: var(--fs-100); font-weight: var(--fw-bold);"
+    },
+    {
+      "var": "d-headline-compact-base",
+      "output": "line-height: var(--lh-300); font-size: var(--fs-200); font-weight: var(--fw-bold);"
+    },
+    {
+      "var": "d-headline-large",
+      "output": "line-height: var(--lh-400); font-size: var(--fs-300); font-weight: var(--fw-bold);"
+    },
+    {
+      "var": "d-headline-extra-large",
+      "output": "line-height: var(--lh-200); font-size: var(--fs-400); font-weight: var(--fw-medium);"
+    },
+    {
+      "var": "d-headline-extra-extra-large",
+      "output": "line-height: var(--lh-200); font-size: var(--fs-500); font-weight: var(--fw-medium);"
+    },
+    {
+      "var": "d-body-base",
+      "output": "line-height: var(--lh-400); font-size: var(--fs-200);"
+    },
+    {
+      "var": "d-body-compact",
+      "output": "line-height: var(--lh-300); font-size: var(--fs-200);"
+    },
+    {
+      "var": "d-body-small",
+      "output": "line-height: var(--lh-300); font-size: var(--fs-100);"
+    },
+    {
+      "var": "d-body-compact-small",
+      "output": "line-height: var(--lh-200); font-size: var(--fs-100);"
+    },
+    {
+      "var": "d-label-base",
+      "output": "line-height: var(--lh-400); font-size: var(--fs-200); font-weight: var(--fw-semibold);"
+    },
+    {
+      "var": "d-label-small",
+      "output": "line-height: var(--lh-300); font-size: var(--fs-100); font-weight: var(--fw-semibold);"
+    },
+    {
+      "var": "d-label-compact",
+      "output": "line-height: var(--lh-300); font-size: var(--fs-200); font-weight: var(--fw-semibold);"
+    },
+    {
+      "var": "d-label-plain",
+      "output": "line-height: var(--lh-400); font-size: var(--fs-200);"
+    },
+    {
+      "var": "d-label-compact-plain",
+      "output": "line-height: var(--lh-400); font-size: var(--fs-200);"
+    },
+    {
+      "var": "d-label-compact-small",
+      "output": "line-height: var(--lh-200); font-size: var(--fs-100); font-weight: var(--fw-semibold);"
+    },
+    {
+      "var": "d-label-plain-small",
+      "output": "line-height: var(--lh-300); font-size: var(--fs-100);"
+    },
+    {
+      "var": "d-label-compact-plain-small",
+      "output": "line-height: var(--lh-200); font-size: var(--fs-100);"
+    },
+    {
+      "var": "d-helper-base",
+      "output": "line-height: var(--lh-300); font-size: var(--fs-200);"
+    },
+    {
+      "var": "d-helper-small",
+      "output": "line-height: var(--lh-200); font-size: var(--fs-100);"
+    },
+    {
+      "var": "d-code-base",
+      "output": "font-family: var(--ff-mono); line-height: var(--lh-200); font-size: var(--fs-200);"
+    },
+    {
+      "var": "d-code-small",
+      "output": "font-family: var(--ff-mono); line-height: var(--lh-200); font-size: var(--fs-100);"
+    }
+  ],
   "fontFamily": [
     {
       "var": "custom",

--- a/docs/_data/type.json
+++ b/docs/_data/type.json
@@ -66,7 +66,7 @@
     },
     {
       "var": "d-label-compact-plain",
-      "output": "line-height: var(--lh-400); font-size: var(--fs-200);"
+      "output": "line-height: var(--lh-300); font-size: var(--fs-200);"
     },
     {
       "var": "d-label-compact-small",

--- a/docs/_data/type.json
+++ b/docs/_data/type.json
@@ -31,6 +31,30 @@
   ],
   "lineHeight": [
     {
+      "class": "-100",
+      "output": "1"
+    },
+    {
+      "class": "-200",
+      "output": "1.2"
+    },
+    {
+      "class": "-300",
+      "output": "1.4"
+    },
+    {
+      "class": "-400",
+      "output": "1.6"
+    },
+    {
+      "class": "-500",
+      "output": "1.8"
+    },
+    {
+      "class": "-600",
+      "output": "2"
+    },
+    {
       "class": "0",
       "output": "1em"
     },
@@ -69,26 +93,6 @@
     {
       "class": "24",
       "output": "calc(1em + 24px)"
-    },
-    {
-      "class": "-tighter",
-      "output": "1.125"
-    },
-    {
-      "class": "-tight",
-      "output": "1.25"
-    },
-    {
-      "class": "-normal",
-      "output": "1.5"
-    },
-    {
-      "class": "-loose",
-      "output": "1.75"
-    },
-    {
-      "class": "-looser",
-      "output": "2"
     },
     {
       "class": "-unset",

--- a/docs/_data/type.json
+++ b/docs/_data/type.json
@@ -285,6 +285,14 @@
       "output": "400"
     },
     {
+      "name": "medium",
+      "output": "500"
+    },
+    {
+      "name": "semibold",
+      "output": "600"
+    },
+    {
       "name": "bold",
       "output": "700"
     }

--- a/docs/utilities/typography/font-weight.md
+++ b/docs/utilities/typography/font-weight.md
@@ -28,13 +28,19 @@ Use `d-fw-{n}` to change an element's font-weight.
   <div class="d-d-grid d-gg16 d-ai-center" style="grid-template-columns: 10rem 1fr">
     <div class="d-fs-100 d-ff-mono d-fc-purple-400">.d-fw-normal</div>
     <div><p class="d-fs-300 d-fw-normal">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400">.d-fw-semibold</div>
+    <div><p class="d-fs-300 d-fw-medium">The quick brown fox jumps over the lazy dog.</p></div>
     <div class="d-fs-100 d-ff-mono d-fc-purple-400">.d-fw-bold</div>
+    <div><p class="d-fs-300 d-fw-semibold">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400">.d-fw-medium</div>
     <div><p class="d-fs-300 d-fw-bold">The quick brown fox jumps over the lazy dog.</p></div>
   </div>
 </code-well-header>
 
 ```html
 <p class="d-fw-normal">...</p>
+<p class="d-fw-medium">...</p>
+<p class="d-fw-semibold">...</p>
 <p class="d-fw-bold">...</p>
 ```
 

--- a/docs/utilities/typography/line-height.md
+++ b/docs/utilities/typography/line-height.md
@@ -9,25 +9,28 @@ Use `d-lh-{n}` to change an element's line-height relatively. This means no unit
 
 <code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-purple-100 d-w100p d-hmn102" custom>
   <div class="d-d-grid d-gg16 d-ai-center" style="grid-template-columns: 10rem 1fr">
-    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">.d-lh-tighter</div>
-    <div><p class="d-fs-300 d-lh-tighter d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
-    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">.d-lh-tight</div>
-    <div><p class="d-fs-300 d-lh-tight d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
-    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">.d-lh-normal</div>
-    <div><p class="d-fs-300 d-lh-normal d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
-    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">.d-lh-loose</div>
-    <div><p class="d-fs-300 d-lh-loose d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
-    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">.d-lh-looser</div>
-    <div><p class="d-fs-300 d-lh-looser d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">.d-lh-100</div>
+    <div><p class="d-fs-300 d-lh-100 d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">.d-lh-200</div>
+    <div><p class="d-fs-300 d-lh-200 d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">.d-lh-300</div>
+    <div><p class="d-fs-300 d-lh-300 d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">.d-lh-400</div>
+    <div><p class="d-fs-300 d-lh-400 d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">.d-lh-500</div>
+    <div><p class="d-fs-300 d-lh-500 d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">.d-lh-600</div>
+    <div><p class="d-fs-300 d-lh-600 d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
   </div>
 </code-well-header>
 
 ```html
-<p class="d-lh-tighter">...</p>
-<p class="d-lh-tight">...</p>
-<p class="d-lh-normal">...</p>
-<p class="d-lh-loose">...</p>
-<p class="d-lh-looser">...</p>
+<p class="d-lh-100">...</p>
+<p class="d-lh-200">...</p>
+<p class="d-lh-300">...</p>
+<p class="d-lh-400">...</p>
+<p class="d-lh-500">...</p>
+<p class="d-lh-600">...</p>
 ```
 
 ## Fixed line-heights

--- a/docs/utilities/typography/styles.md
+++ b/docs/utilities/typography/styles.md
@@ -1,0 +1,108 @@
+---
+title: Typography Styles
+desc: Core typographic styles for body text and headlines.
+---
+
+## Headlines
+
+<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-purple-100 d-w100p d-hmn102" custom>
+  <div class="d-d-grid d-gg16 d-ai-center" style="grid-template-columns: 21rem 1fr">
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-headline-eyebrow</div>
+    <div><p class="d-headline-eyebrow d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-headline-small</div>
+    <div><p class="d-headline-small d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-headline-medium</div>
+    <div><p class="d-headline-medium d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-headline-compact-small</div>
+    <div><p class="d-headline-compact-small d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-headline-compact-base</div>
+    <div><p class="d-headline-compact-base d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-headline-large</div>
+    <div><p class="d-headline-large d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-headline-extra-large</div>
+    <div><p class="d-headline-extra-large d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-headline-extra-extra-large</div>
+    <div><p class="d-headline-extra-extra-large d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+  </div>
+</code-well-header>
+
+## Body
+
+<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-purple-100 d-w100p d-hmn102" custom>
+  <div class="d-d-grid d-gg16 d-ai-center" style="grid-template-columns: 21rem 1fr">
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-body-base</div>
+    <div><p class="d-body-base d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-body-compact</div>
+    <div><p class="d-body-compact d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-body-small</div>
+    <div><p class="d-body-small d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-body-compact-small</div>
+    <div><p class="d-body-compact-small d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+  </div>
+</code-well-header>
+
+## Label
+
+<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-purple-100 d-w100p d-hmn102" custom>
+  <div class="d-d-grid d-gg16 d-ai-center" style="grid-template-columns: 21rem 1fr">
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-label-base</div>
+    <div><p class="d-label-base d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-label-small</div>
+    <div><p class="d-label-small d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-label-compact</div>
+    <div><p class="d-label-compact d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-label-plain</div>
+    <div><p class="d-label-plain d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-label-compact-plain</div>
+    <div><p class="d-label-compact-plain d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-label-compact-small</div>
+    <div><p class="d-label-compact-small d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-label-plain-small</div>
+    <div><p class="d-label-plain-small d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-label-compact-plain-small</div>
+    <div><p class="d-label-compact-plain-small d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+  </div>
+</code-well-header>
+
+## Helper
+
+<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-purple-100 d-w100p d-hmn102" custom>
+  <div class="d-d-grid d-gg16 d-ai-center" style="grid-template-columns: 21rem 1fr">
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-helper-base</div>
+    <div><p class="d-helper-base d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-helper-small</div>
+    <div><p class="d-helper-small d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+  </div>
+</code-well-header>
+
+## Code
+
+<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-purple-100 d-w100p d-hmn102" custom>
+  <div class="d-d-grid d-gg16 d-ai-center" style="grid-template-columns: 21rem 1fr">
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-code-base</div>
+    <div><p class="d-code-base d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+    <div class="d-fs-100 d-ff-mono d-fc-purple-400 d-fco75">d-code-small</div>
+    <div><p class="d-code-small d-bgc-purple-200 d-bgo25">The quick brown fox jumps over the lazy dog.</p></div>
+  </div>
+</code-well-header>
+
+<script setup>
+  import { typographyStyles } from '@data/type.json';
+</script>
+
+## Classes
+
+<table class="d-table dialtone-doc-table">
+  <thead>
+    <tr>
+      <th scope="col" class="d-w40p">Class</th>
+      <th scope="col">Output</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr v-for="{ var: varName, output } in typographyStyles">
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">.{{ varName }}</td>
+      <td class="d-ff-mono d-fs-100">{{ output }}</td>
+    </tr>
+  </tbody>
+</table>

--- a/lib/build/less/utilities/typography.less
+++ b/lib/build/less/utilities/typography.less
@@ -184,11 +184,12 @@ ul {
 .d-lh16 { line-height: var(--lh16) !important; }
 .d-lh20 { line-height: var(--lh20) !important; }
 .d-lh24 { line-height: var(--lh24) !important; }
-.d-lh-tighter { line-height: var(--lh-200) !important; }
-.d-lh-tight { line-height: var(--lh-200) !important; }
-.d-lh-normal { line-height: var(--lh-300) !important; }
-.d-lh-loose { line-height: var(--lh-400) !important; }
-.d-lh-looser { line-height: var(--lh-500) !important; }
+.d-lh-100 { line-height: var(--lh-100) !important; }
+.d-lh-200 { line-height: var(--lh-200) !important; }
+.d-lh-300 { line-height: var(--lh-300) !important; }
+.d-lh-400 { line-height: var(--lh-400) !important; }
+.d-lh-500 { line-height: var(--lh-500) !important; }
+.d-lh-600 { line-height: var(--lh-600) !important; }
 .d-lh-unset { line-height: unset !important; }
 
 

--- a/lib/build/less/utilities/typography.less
+++ b/lib/build/less/utilities/typography.less
@@ -73,6 +73,51 @@ ul {
 }
 
 //  ============================================================================
+//  $   BODY STYLES
+//  ----------------------------------------------------------------------------
+.d-body {
+    &,
+    &-base          { line-height: var(--lh-400); font-size: var(--fs-200); }
+    &-small         { line-height: var(--lh-300); font-size: var(--fs-100); }
+    &-compact       { line-height: var(--lh-300); font-size: var(--fs-200); }
+    &-compact-small { line-height: var(--lh-200); font-size: var(--fs-100); }
+}
+
+//  ============================================================================
+//  $   LABEL STYLES
+//  ----------------------------------------------------------------------------
+.d-label {
+    &,
+    &-base                { font-weight: var(--fw-semibold); line-height: var(--lh-400); font-size: var(--fs-200); }
+    &-small               { font-weight: var(--fw-semibold); line-height: var(--lh-300); font-size: var(--fs-100); }
+    &-compact             { font-weight: var(--fw-semibold); line-height: var(--lh-300); font-size: var(--fs-200); }
+    &-plain               {                                  line-height: var(--lh-400); font-size: var(--fs-200); }
+    &-compact-plain       {                                  line-height: var(--lh-400); font-size: var(--fs-200); }
+    &-compact-small       { font-weight: var(--fw-semibold); line-height: var(--lh-200); font-size: var(--fs-100); }
+    &-plain-small         {                                  line-height: var(--lh-300); font-size: var(--fs-100); }
+    &-compact-plain-small {                                  line-height: var(--lh-200); font-size: var(--fs-100); }
+}
+
+//  ============================================================================
+//  $   HELPER STYLES
+//  ----------------------------------------------------------------------------
+.d-helper {
+    &,
+    &-base  { line-height: var(--lh-300); font-size: var(--fs-200); }
+    &-small { line-height: var(--lh-200); font-size: var(--fs-100); }
+}
+
+//  ============================================================================
+//  $   CODE STYLES
+//  ----------------------------------------------------------------------------
+
+.d-code {
+    &,
+    &-base  { font-family: var(--ff-mono); line-height: var(--lh-200); font-size: var(--fs-200); }
+    &-small { font-family: var(--ff-mono); line-height: var(--lh-200); font-size: var(--fs-100); }
+}
+
+//  ============================================================================
 //  $   FONT SIZE
 //  ----------------------------------------------------------------------------
 .d-fs-100 { font-size: var(--fs-100) !important; }

--- a/lib/build/less/utilities/typography.less
+++ b/lib/build/less/utilities/typography.less
@@ -141,6 +141,15 @@ ul {
 .d-headline48 { .d-fs-500(); font-weight: @headline-weight !important; }
 .d-headline54 { .d-fs-500(); font-weight: @headline-weight !important; }
 
+.d-headline-eyebrow            {  line-height: var(--lh-300); font-size: var(--fs-100); font-weight: var(--fw-normal); .d-tt-uppercase(); }
+.d-headline-small              {  line-height: var(--lh-300); font-size: var(--fs-100); font-weight: var(--fw-bold); }
+.d-headline-medium             {  line-height: var(--lh-400); font-size: var(--fs-200); font-weight: var(--fw-bold); }
+.d-headline-compact-small      {  line-height: var(--lh-200); font-size: var(--fs-100); font-weight: var(--fw-bold); }
+.d-headline-compact-base       {  line-height: var(--lh-300); font-size: var(--fs-200); font-weight: var(--fw-bold); }
+.d-headline-large              {  line-height: var(--lh-400); font-size: var(--fs-300); font-weight: var(--fw-bold); }
+.d-headline-extra-large        {  line-height: var(--lh-200); font-size: var(--fs-400); font-weight: var(--fw-medium); }
+.d-headline-extra-extra-large  {  line-height: var(--lh-200); font-size: var(--fs-500); font-weight: var(--fw-medium); }
+
 .d-fs-unset { font-size: unset !important; }
 
 

--- a/lib/build/less/utilities/typography.less
+++ b/lib/build/less/utilities/typography.less
@@ -87,7 +87,7 @@ ul {
 .d-label-small               { line-height: var(--lh-300); font-size: var(--fs-100); font-weight: var(--fw-semibold); }
 .d-label-compact             { line-height: var(--lh-300); font-size: var(--fs-200); font-weight: var(--fw-semibold); }
 .d-label-plain               { line-height: var(--lh-400); font-size: var(--fs-200);                                  }
-.d-label-compact-plain       { line-height: var(--lh-400); font-size: var(--fs-200);                                  }
+.d-label-compact-plain       { line-height: var(--lh-300); font-size: var(--fs-200);                                  }
 .d-label-compact-small       { line-height: var(--lh-200); font-size: var(--fs-100); font-weight: var(--fw-semibold); }
 .d-label-plain-small         { line-height: var(--lh-300); font-size: var(--fs-100);                                  }
 .d-label-compact-plain-small { line-height: var(--lh-200); font-size: var(--fs-100);                                  }

--- a/lib/build/less/utilities/typography.less
+++ b/lib/build/less/utilities/typography.less
@@ -40,7 +40,7 @@
 #d-internals #font-face(@define-ff-marketing-expanded, @define-ff-marketing-expanded-name);
 
 @font-face {
-    font-family: "Segoe UI Adjusted";
+    font-family: 'Segoe UI Adjusted';
     src: local(Segoe UI Bold);
     ascent-override: 90%;
     font-weight: 700;
@@ -75,47 +75,35 @@ ul {
 //  ============================================================================
 //  $   BODY STYLES
 //  ----------------------------------------------------------------------------
-.d-body {
-    &,
-    &-base          { line-height: var(--lh-400); font-size: var(--fs-200); }
-    &-small         { line-height: var(--lh-300); font-size: var(--fs-100); }
-    &-compact       { line-height: var(--lh-300); font-size: var(--fs-200); }
-    &-compact-small { line-height: var(--lh-200); font-size: var(--fs-100); }
-}
+.d-body-base          { line-height: var(--lh-400); font-size: var(--fs-200); }
+.d-body-small         { line-height: var(--lh-300); font-size: var(--fs-100); }
+.d-body-compact       { line-height: var(--lh-300); font-size: var(--fs-200); }
+.d-body-compact-small { line-height: var(--lh-200); font-size: var(--fs-100); }
 
 //  ============================================================================
 //  $   LABEL STYLES
 //  ----------------------------------------------------------------------------
-.d-label {
-    &,
-    &-base                { line-height: var(--lh-400); font-size: var(--fs-200); font-weight: var(--fw-semibold); }
-    &-small               { line-height: var(--lh-300); font-size: var(--fs-100); font-weight: var(--fw-semibold); }
-    &-compact             { line-height: var(--lh-300); font-size: var(--fs-200); font-weight: var(--fw-semibold); }
-    &-plain               { line-height: var(--lh-400); font-size: var(--fs-200);                                  }
-    &-compact-plain       { line-height: var(--lh-400); font-size: var(--fs-200);                                  }
-    &-compact-small       { line-height: var(--lh-200); font-size: var(--fs-100); font-weight: var(--fw-semibold); }
-    &-plain-small         { line-height: var(--lh-300); font-size: var(--fs-100);                                  }
-    &-compact-plain-small { line-height: var(--lh-200); font-size: var(--fs-100);                                  }
-}
+.d-label-base                { line-height: var(--lh-400); font-size: var(--fs-200); font-weight: var(--fw-semibold); }
+.d-label-small               { line-height: var(--lh-300); font-size: var(--fs-100); font-weight: var(--fw-semibold); }
+.d-label-compact             { line-height: var(--lh-300); font-size: var(--fs-200); font-weight: var(--fw-semibold); }
+.d-label-plain               { line-height: var(--lh-400); font-size: var(--fs-200);                                  }
+.d-label-compact-plain       { line-height: var(--lh-400); font-size: var(--fs-200);                                  }
+.d-label-compact-small       { line-height: var(--lh-200); font-size: var(--fs-100); font-weight: var(--fw-semibold); }
+.d-label-plain-small         { line-height: var(--lh-300); font-size: var(--fs-100);                                  }
+.d-label-compact-plain-small { line-height: var(--lh-200); font-size: var(--fs-100);                                  }
 
 //  ============================================================================
 //  $   HELPER STYLES
 //  ----------------------------------------------------------------------------
-.d-helper {
-    &,
-    &-base  { line-height: var(--lh-300); font-size: var(--fs-200); }
-    &-small { line-height: var(--lh-200); font-size: var(--fs-100); }
-}
+.d-helper-base  { line-height: var(--lh-300); font-size: var(--fs-200); }
+.d-helper-small { line-height: var(--lh-200); font-size: var(--fs-100); }
 
 //  ============================================================================
 //  $   CODE STYLES
 //  ----------------------------------------------------------------------------
 
-.d-code {
-    &,
-    &-base  { font-family: var(--ff-mono); line-height: var(--lh-200); font-size: var(--fs-200); }
-    &-small { font-family: var(--ff-mono); line-height: var(--lh-200); font-size: var(--fs-100); }
-}
+.d-code-base  { font-family: var(--ff-mono); line-height: var(--lh-200); font-size: var(--fs-200); }
+.d-code-small { font-family: var(--ff-mono); line-height: var(--lh-200); font-size: var(--fs-100); }
 
 //  ============================================================================
 //  $   FONT SIZE

--- a/lib/build/less/utilities/typography.less
+++ b/lib/build/less/utilities/typography.less
@@ -88,14 +88,14 @@ ul {
 //  ----------------------------------------------------------------------------
 .d-label {
     &,
-    &-base                { font-weight: var(--fw-semibold); line-height: var(--lh-400); font-size: var(--fs-200); }
-    &-small               { font-weight: var(--fw-semibold); line-height: var(--lh-300); font-size: var(--fs-100); }
-    &-compact             { font-weight: var(--fw-semibold); line-height: var(--lh-300); font-size: var(--fs-200); }
-    &-plain               {                                  line-height: var(--lh-400); font-size: var(--fs-200); }
-    &-compact-plain       {                                  line-height: var(--lh-400); font-size: var(--fs-200); }
-    &-compact-small       { font-weight: var(--fw-semibold); line-height: var(--lh-200); font-size: var(--fs-100); }
-    &-plain-small         {                                  line-height: var(--lh-300); font-size: var(--fs-100); }
-    &-compact-plain-small {                                  line-height: var(--lh-200); font-size: var(--fs-100); }
+    &-base                { line-height: var(--lh-400); font-size: var(--fs-200); font-weight: var(--fw-semibold); }
+    &-small               { line-height: var(--lh-300); font-size: var(--fs-100); font-weight: var(--fw-semibold); }
+    &-compact             { line-height: var(--lh-300); font-size: var(--fs-200); font-weight: var(--fw-semibold); }
+    &-plain               { line-height: var(--lh-400); font-size: var(--fs-200);                                  }
+    &-compact-plain       { line-height: var(--lh-400); font-size: var(--fs-200);                                  }
+    &-compact-small       { line-height: var(--lh-200); font-size: var(--fs-100); font-weight: var(--fw-semibold); }
+    &-plain-small         { line-height: var(--lh-300); font-size: var(--fs-100);                                  }
+    &-compact-plain-small { line-height: var(--lh-200); font-size: var(--fs-100);                                  }
 }
 
 //  ============================================================================

--- a/lib/build/less/variables/typography.less
+++ b/lib/build/less/variables/typography.less
@@ -77,8 +77,8 @@
 //  $   FONT WEIGHTS
 //  ----------------------------------------------------------------------------
 @fw-normal:                     400;
-@fw-medium:                     500; // This is for marketing fonts
-@fw-semibold:                   600; // This is for marketing fonts
+@fw-medium:                     500;
+@fw-semibold:                   600;
 @fw-bold:                       700;
 
 
@@ -133,7 +133,6 @@
 @lh-500:            1.8;
 @lh-600:            2;
 
-
 //  ============================================================================
 //  $   CSS VARIABLES
 //  ----------------------------------------------------------------------------
@@ -187,8 +186,8 @@
     lh-600:                                 @lh-600;
 
     fw-normal:                              @fw-normal;
-    fw-medium:                              @fw-medium; // This is for marketing fonts
-    fw-semibold:                            @fw-semibold; // This is for marketing fonts
+    fw-medium:                              @fw-medium;
+    fw-semibold:                            @fw-semibold;
     fw-bold:                                @fw-bold;
 
     ls-content:                             '\1F44D';

--- a/lib/build/less/variables/typography.less
+++ b/lib/build/less/variables/typography.less
@@ -179,10 +179,12 @@
     lh16:                                   @lh16;
     lh20:                                   @lh20;
     lh24:                                   @lh24;
+    lh-100:                                 @lh-100;
     lh-200:                                 @lh-200;
     lh-300:                                 @lh-300;
     lh-400:                                 @lh-400;
     lh-500:                                 @lh-500;
+    lh-600:                                 @lh-600;
 
     fw-normal:                              @fw-normal;
     fw-medium:                              @fw-medium; // This is for marketing fonts

--- a/migration_guide/MIGRATION_GUIDE.md
+++ b/migration_guide/MIGRATION_GUIDE.md
@@ -391,6 +391,16 @@ Search for | Replace with
 Check updates to confirm desired readability. Most replacements are likely accurate, though they may need to be visually
 validated.
 
+#### Update relative line-height CSS classes usage
+
+Search for | Replace with
+:-:|:-:
+`d-lh-tighter` | `d-lh-200`
+`d-lh-tight`   | `d-lh-200`
+`d-lh-normal`  | `d-lh-300`
+`d-lh-loose`   | `d-lh-400`
+`d-lh-looser`  | `d-lh-500`
+
 #### Update line-height CSS variables
 
 Search for | Replace with

--- a/migration_guide/MIGRATION_GUIDE.md
+++ b/migration_guide/MIGRATION_GUIDE.md
@@ -122,6 +122,7 @@ New Color Ramp
 - Replaced `Inter` font with local system font stack.
 - Replaced `RobotoMono` font with `SFMono`.
 - Removed `fw-thin`, `fw-light` and `fw-black` variables (RobotoMono shims).
+- `fw-medium` and `fw-semibold` are no longer restricted to Marketing use.
 
 ### Typography: Updated Font Size Ramps
 - Removed `fs10`, `fs11`, `fs12`, `fs14`, `fs16`, `fs18`, `fs20`, `fs24`, `fs28`, `fs32`, `fs36`, `fs42`, `fs48`, `fs54`.

--- a/migration_guide/MIGRATION_GUIDE.md
+++ b/migration_guide/MIGRATION_GUIDE.md
@@ -12,7 +12,7 @@ While the migration is fairly straightforward, there may be instances where manu
 
 <img width="1818" alt="image" src="https://user-images.githubusercontent.com/1165933/190548054-3600c97a-07ce-4f86-9882-7f7836af1393.png">
 
-### Updated Color Ramps
+### Color: Updated Ramps
 
 #### Purple
 1. Updated color values for `purple-100`, `purple-200` and `purple-300` stops.
@@ -66,12 +66,12 @@ New Color Ramp
 6. Consolidated Dialtone v6's `red-600` stop into the redefined `red-400` stop.
 7. Consolidated Dialtone v6's `red-700` stop into the redefined `red-500` stop.
 
-### Removed Primary Color Theme
+### Color: Removed Primary Theme
 - Removed the `--primary-color` theme variable.
 - Removed `d-fc-primary` utility class.
 - Removed Spot Illustrations' theming capability.
 
-### New/Updated/Removed Text Color Variables
+### Color: New/Updated/Removed Text Color Variables
 
 - Removed `--fc-dark` variable
 - Removed `--fc-medium` variable
@@ -114,13 +114,39 @@ New Color Ramp
 - Removed `.d-fc-blue` CSS Utilities
 - Removed `.d-fc-tan` CSS Utilities
 
-### Updated Font Stack
+### Typography: Updated Font Stack
 - Replaced `Inter` font with local system font stack.
-- Replaced `RobotoMono` font with SFMono.
+- Replaced `RobotoMono` font with `SFMono`.
 - Removed `fw-thin`, `fw-light` and `fw-black` variables (RobotoMono shims).
 
-### Updated Font Size Ramps
+### Typography: Updated Font Size Ramps
 - Removed `fs10`, `fs11`, `fs12`, `fs14`, `fs16`, `fs18`, `fs20`, `fs24`, `fs28`, `fs32`, `fs36`, `fs42`, `fs48`, `fs54`.
+
+### Typography: New Body Styles
+
+#### Body
+* `d-body-base`
+* `d-body-small`
+* `d-body-compact`
+* `d-body-compact-small`
+
+#### Label
+* `d-label-base`
+* `d-label-small`
+* `d-label-compact`
+* `d-label-plain`
+* `d-label-compact-plain`
+* `d-label-compact-small`
+* `d-label-plain-small`
+* `d-label-compact-plain-small`
+
+#### Helper
+* `d-helper-base`
+* `d-helper-small`
+
+#### Code
+* `d-code-base`
+* `d-code-small`
 
 ## Migration Steps
 
@@ -327,7 +353,7 @@ Search for | Replace with
 `d-fs48` | `d-fs-500`
 `d-fs54` | `d-fs-500`
 
-####  Update font-size CSS variables
+#### Update font-size CSS variables
 
 Search for | Replace with
 :-:|:-:

--- a/migration_guide/MIGRATION_GUIDE.md
+++ b/migration_guide/MIGRATION_GUIDE.md
@@ -6,6 +6,8 @@ While the migration is fairly straightforward, there may be instances where manu
 
 **⚠️ Note for `dialtone-vue`:** Updating `dialtone-vue` to the latest beta version components automatically receive Color updates.
 
+---
+
 ## Changes
 
 ### Color updates
@@ -114,6 +116,8 @@ New Color Ramp
 - Removed `.d-fc-blue` CSS Utilities
 - Removed `.d-fc-tan` CSS Utilities
 
+---
+
 ### Typography: Updated Font Stack
 - Replaced `Inter` font with local system font stack.
 - Replaced `RobotoMono` font with `SFMono`.
@@ -147,6 +151,18 @@ New Color Ramp
 #### Code
 * `d-code-base`
 * `d-code-small`
+
+### Typography: New Headline Styles
+* `d-headline-eyebrow`
+* `d-headline-small`
+* `d-headline-medium`
+* `d-headline-compact-small`
+* `d-headline-compact-base`
+* `d-headline-large`
+* `d-headline-extra-large`
+* `d-headline-extra-extra-large`
+
+---
 
 ## Migration Steps
 

--- a/migration_guide/MIGRATION_GUIDE.md
+++ b/migration_guide/MIGRATION_GUIDE.md
@@ -158,7 +158,7 @@ Follow steps in this exact order.
 npm install @dialpad/dialtone@beta
 ```
 
-### 2. Replace color stops
+### 2. Color: Replace stops
 
 Search for | Replace with
 :-:|:-:
@@ -204,7 +204,7 @@ Search for | Replace with
 `d-fc-yellow` | `d-fc-gold`
 [others TBD, e.g. Green] | ...
 
-### 3. Replace "Primary Color" theme uses
+### 3. Color: Replace "Primary Color" theme uses
 
 #### Custom CSS references to expired "Primary Color" CSS Variables
 
@@ -223,7 +223,7 @@ Search for | Replace with
 :-:|:-:
 `d-fc-primary` | `d-fc-purple`
 
-### 4. Replace Text Color Styles
+### 4. Color: Replace Text Color Styles
 
 #### Update color CSS variables
 
@@ -245,7 +245,7 @@ Search for | Replace with
 `fc-light` | `fc-tertiary`
 `fc-purple` | `d-fc-purple-400`)
 
-### 5. Replace hardcoded HEX values
+### 5. Color: Replace hardcoded HEX values
 
 Any custom CSS authored with HEX values (e.g. `#ff0000`) should be replaced with its CSS Custom Property equivalent (e.g. `var(--[COLOR-STOP])`). If no equivalent exists, consult your Product Designer.
 
@@ -312,11 +312,11 @@ Search for | Replace with
 `#FFBC0F` | `var(--gold-300)`
 `#3F2D00` | `var(--gold-500)`
 
-### 6. Check color updates for readability
+### 6. Color: Check color updates for readability
 
 Check updates to confirm desired rendering and alignment to contrast accessibility requirements. When in doubt, confer with your Product Designer to identify a proper solution.
 
-### 7. Font updates
+### 7. Typography
 
 #### Update font-weight CSS classes usage
 


### PR DESCRIPTION
## Description

New typography styles for Body, Label, Helper, Code [[DT-667](https://dialpad.atlassian.net/browse/DT-667)]; and Headline [[DT-668](https://dialpad.atlassian.net/browse/DT-668)].

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![Phonics-Song](https://user-images.githubusercontent.com/1165933/191151422-079cc896-a770-4302-96af-af91ccc95c85.gif)

