### PR TITLE
fix: input icon to position outside of input without absolute position

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -228,8 +228,8 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
         <label class="d-label" for="Dialtone--InputExample--IconRight">Label</label>
       </div>
       <div class="d-input__wrapper">
-        <span class="d-input-icon d-input-icon--right"><icon-lock /></span>
         <input class="d-input d-input-icon--right" id="Dialtone--InputExample--IconRight" type="text" placeholder="Placeholder" />
+         <span class="d-input-icon d-input-icon--right"><icon-lock /></span>
       </div>
     </div>
   </div>
@@ -246,8 +246,8 @@ Provides feedback to the user based on their interaction, or lack thereof, with 
 <div>
   <label class="d-label" for="Dialtone--InputExample--IconRight">...</label>
   <div class="d-input__wrapper">
-    <span class="d-input-icon d-input-icon--right">...</span>
     <input class="d-input d-input-icon--right" id="Dialtone--InputExample--IconRight" type="text" placeholder="..." />
+     <span class="d-input-icon d-input-icon--right">...</span>
   </div>
 </div>
 ```

--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -18,19 +18,12 @@
 //    - Sizes
 //  • INPUT ICONS
 //
-//  ============================================================================
-//  Inputs CSS Vars
-//  ----------------------------------------------------------------------------
-@inputs-icon-spacing--xs: calc(var(--su4) + @icon12 + var(--su8));
-@inputs-icon-spacing--sm: calc(var(--su4) + @icon14 + var(--su8));
-@inputs-icon-spacing:     calc(var(--su4) + @icon16 + var(--su8));
-@inputs-icon-spacing--lg: calc(var(--su4) + @icon20 + var(--su8));
-@inputs-icon-spacing--xl: calc(var(--su4) + @icon24 + var(--su8));
 
 //  $  INPUTS
 //  ----------------------------------------------------------------------------
 .d-input,
-.d-textarea {
+.d-textarea,
+.d-input__wrapper {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
     --input--focus-bc: var(--primary-color);
@@ -59,14 +52,6 @@
     transition-duration: 100ms;
     transition-property: border, box-shadow, background-color;
 
-    &.d-input-icon--right {
-        padding-right: @inputs-icon-spacing;
-    }
-
-    &.d-input-icon--left {
-        padding-left: @inputs-icon-spacing;
-    }
-
     //  --  Placeholder copy
     &::placeholder {
         color: var(--black-300);
@@ -76,7 +61,8 @@
         display: none;
     }
     //  --  FOCUS
-    &:focus {
+    &:focus,
+    &:focus-within {
         --input--bc: var(--input--focus-bc);
 
         outline: 0;
@@ -89,7 +75,8 @@
         --input--bgc: var(--black-075);
         --input--fc: var(--black-400);
 
-        &:focus {
+        &:focus,
+        &:focus-within {
             box-shadow: none !important;
         }
 
@@ -107,57 +94,54 @@
 //  $$  INPUT WRAPPER
 //  ----------------------------------------------------------------------------
 .d-input__wrapper {
-    position: relative;
+    padding: 0;
+
+    .d-input-icon.d-input-icon--right {
+        margin-right: var(--su8);
+    }
+
+    .d-input-icon.d-input-icon--left {
+        margin-left: var(--su8);
+    }
+
+    .d-input,
+    .d-textarea {
+        flex: 1;
+        border: none;
+        border-radius: var(--base--corner-radius);
+
+        &:focus {
+            border: none;
+            outline: 0;
+            box-shadow: none !important;
+        }
+
+        &.d-input-icon--right {
+            padding-right: var(--su6);
+        }
+
+        &.d-input-icon--left {
+            padding-left: var(--su6);
+        }
+    }
 }
 
 //  $$  SIZES
 //  ----------------------------------------------------------------------------
 .d-input.d-input--xs {
     .input-button-xs();
-
-    &.d-input-icon--right {
-        padding-right: @inputs-icon-spacing--xs;
-    }
-
-    &.d-input-icon--left {
-        padding-left: @inputs-icon-spacing--xs;
-    }
 }
 
 .d-input.d-input--sm {
     .input-button-sm();
-
-    &.d-input-icon--right {
-        padding-right: @inputs-icon-spacing--sm;
-    }
-
-    &.d-input-icon--left {
-        padding-left: @inputs-icon-spacing--sm;
-    }
 }
 
 .d-input.d-input--lg {
     .input-button-lg();
-
-    &.d-input-icon--right {
-        padding-right: @inputs-icon-spacing--lg;
-    }
-
-    &.d-input-icon--left {
-        padding-left: @inputs-icon-spacing--lg;
-    }
 }
 
 .d-input.d-input--xl {
     .input-button-xl();
-
-    &.d-input-icon--right {
-        padding-right: @inputs-icon-spacing--xl;
-    }
-
-    &.d-input-icon--left {
-        padding-left: @inputs-icon-spacing--xl;
-    }
 }
 
 
@@ -175,56 +159,24 @@
     .input-button-xs();
 
     min-height: 4rem;
-
-    &.d-input-icon--right {
-        padding-right: @inputs-icon-spacing--xs;
-    }
-
-    &.d-input-icon--left {
-        padding-left: @inputs-icon-spacing--xs;
-    }
 }
 
 .d-textarea--sm {
     .input-button-sm();
 
     min-height: 4.8rem;
-
-    &.d-input-icon--right {
-        padding-right: @inputs-icon-spacing--sm;
-    }
-
-    &.d-input-icon--left {
-        padding-left: @inputs-icon-spacing--sm;
-    }
 }
 
 .d-textarea--lg {
     .input-button-lg();
 
     min-height: 9.2rem;
-
-    &.d-input-icon--right {
-        padding-right: @inputs-icon-spacing--lg;
-    }
-
-    &.d-input-icon--left {
-        padding-left: @inputs-icon-spacing--lg;
-    }
 }
 
 .d-textarea--xl {
     .input-button-xl();
 
     min-height: 10rem;
-
-    &.d-input-icon--right {
-        padding-right: @inputs-icon-spacing--xl;
-    }
-
-    &.d-input-icon--left {
-        padding-left: @inputs-icon-spacing--xl;
-    }
 }
 
 //  $$  VALIDATION STATES
@@ -267,7 +219,6 @@
     //  ------------------------------------------------------------------------
     --input-icon-size: @icon16;
 
-    position: absolute;
     z-index: var(--zi-base1);
     display: inline-flex;
     align-items: center;
@@ -278,24 +229,6 @@
     svg {
         width: var(--input-icon-size);
         height: var(--input-icon-size);
-    }
-
-    &.d-input-icon--left {
-        left: var(--su8);
-        // Update padding for d-input if d-input-icon--left is present
-        & ~ .d-input,
-        & ~ .d-textarea {
-            padding-left: @inputs-icon-spacing;
-        }
-    }
-
-    &.d-input-icon--right {
-        right: var(--su8);
-
-        // Update padding for d-input if d-input-icon--right is present
-        & ~ .d-input {
-            padding-right: @inputs-icon-spacing;
-        }
     }
 }
 
@@ -309,19 +242,6 @@
 
 .d-input-icon--xs {
     --input-icon-size: @icon12;
-
-    // For backwards compatibility purposes only.
-    // Update padding for d-input, d-textarea if d-input-icon--left is present
-    &.d-input-icon--left ~ .d-input,
-    &.d-input-icon--left ~ .d-textarea {
-        padding-left: @inputs-icon-spacing--xs;
-    }
-
-    // For backwards compatibility purposes only.
-    // Update padding for d-input if d-input-icon--right is present
-    &.d-input-icon--right ~ .d-input {
-        padding-right: @inputs-icon-spacing--xs;
-    }
 }
 
 .d-input-icon.d-input--sm {
@@ -330,19 +250,6 @@
 
 .d-input-icon--sm {
     --input-icon-size: @icon14;
-
-    // For backwards compatibility purposes only.
-    // Update padding for d-input, d-textarea if d-input-icon--left is present
-    &.d-input-icon--left ~ .d-input,
-    &.d-input-icon--left ~ .d-textarea {
-        padding-left: @inputs-icon-spacing--sm;
-    }
-
-    // For backwards compatibility purposes only.
-    // Update padding for d-input if d-input-icon--right is present
-    &.d-input-icon--right ~ .d-input {
-        padding-right: @inputs-icon-spacing--sm;
-    }
 }
 
 .d-input-icon.d-input--lg {
@@ -351,19 +258,6 @@
 
 .d-input-icon--lg {
     --input-icon-size: @icon20;
-
-    // For backwards compatibility purposes only.
-    // Update padding for d-input, d-textarea if d-input-icon--left is present
-    &.d-input-icon--left ~ .d-input,
-    &.d-input-icon--left ~ .d-textarea {
-        padding-left: @inputs-icon-spacing--lg;
-    }
-
-    // For backwards compatibility purposes only.
-    // Update padding for d-input if d-input-icon--right is present
-    &.d-input-icon--right ~ .d-input {
-        padding-right: @inputs-icon-spacing--lg;
-    }
 }
 
 .d-input-icon.d-input--xl {
@@ -372,17 +266,4 @@
 
 .d-input-icon--xl {
     --input-icon-size: @icon24;
-
-    // For backwards compatibility purposes only.
-    // Update padding for d-input, d-textarea if d-input-icon--left is present
-    &.d-input-icon--left ~ .d-input,
-    &.d-input-icon--left ~ .d-textarea {
-        padding-left: @inputs-icon-spacing--xl;
-    }
-
-    // For backwards compatibility purposes only.
-    // Update padding for d-input if d-input-icon--right is present
-    &.d-input-icon--right ~ .d-input {
-        padding-right: @inputs-icon-spacing--xl;
-    }
 }


### PR DESCRIPTION
## Description
Change input icon to be outside of input without absolute position so when extensions such as lastpass positions icons inside the input, they don't overlap with our icons

<img width="571" alt="Screen Shot 2022-09-20 at 12 17 23" src="https://user-images.githubusercontent.com/29417442/191297606-49a7c3c0-5a41-48b5-bcdb-60dc56c0c5f6.png">


## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [ ] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](path/to/gif)
