### PR TITLE
fix: roll back muted-color value

### DIFF
--- a/lib/build/less/variables/colors.less
+++ b/lib/build/less/variables/colors.less
@@ -91,9 +91,9 @@
     success-color-hsl:          var(--green-500-hsl);
     success-color-hover:        var(--green-500);
 
-    muted-color:                var(--fc-muted);
+    muted-color:                var(--black-800);
     muted-color-hsl:            var(--black-800-hsl);
-    muted-color-hover:          var(--fc-muted);
+    muted-color-hover:          var(--black-800);
 
     inverted-color:             var(--fc-primary-inverted);
     inverted-color-hsl:         var(--black-100-hsl);
@@ -109,7 +109,7 @@
     focus-ring-success:         hsla(var(--success-color-hsl) ~' / ' 75%);
     focus-ring-warning:         hsla(var(--warning-color-hsl) ~' / ' 75%);
     focus-ring-error:           hsla(var(--error-color-hsl) ~' / ' 75%);
-    focus-ring-muted:           hsla(var(--muted-color-hsl) ~' / ' 25%);
+    focus-ring-muted:           var(--focus-ring);
     focus-ring-inverted:        hsla(var(--inverted-color-hsl) ~' / ' 50%);
 }
 


### PR DESCRIPTION
## Description
`muted-color` prematurely mapped to new `fc-muted` value. Retain it, and going forward `fc-muted` will serve different purpose.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![image](https://user-images.githubusercontent.com/1165933/193114459-6f2e5f9c-058f-4666-927e-6941f148907f.png)

