### PR TITLE
docs: update contrast values

### DIFF
--- a/docs/.vuepress/baseComponents/BaseColor.vue
+++ b/docs/.vuepress/baseComponents/BaseColor.vue
@@ -22,15 +22,15 @@
       <div>
         <strong>var(--{{ color }}{{ s.stop ? `-${s.stop}` : '' }})</strong>
         <br>
-        <span class="d-fc-dark-lighter">#{{ s.hex }}</span>
+        <span>#{{ s.hex }}</span>
       </div>
       <div class="d-d-flex d-fd-column d-fs-100 d-lh2 d-fw-bold d-bar-sm d-px4 py2">
-        <div class="">
+        <div>
           {{ s.contrast }}
         </div>
         <div
           v-if="s.darkContrast"
-          class="d-fc-dark"
+          class="d-fc-primary"
         >
           {{ s.darkContrast }}
         </div>

--- a/docs/_data/colors.json
+++ b/docs/_data/colors.json
@@ -5,22 +5,22 @@
       {
         "stop": "100",
         "hex": "EEE5FF",
-        "copy": "dark",
-        "contrast": "AAA 7.81",
+        "copy": "primary",
+        "contrast": "AAA 17.28",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "D3BCFF",
-        "copy": "dark",
-        "contrast": "AAA 11.35",
+        "copy": "primary",
+        "contrast": "AAA 12.4",
         "primary": "no"
       },
       {
         "stop": "300",
         "hex": "AB7EFF",
-        "copy": "dark",
-        "contrast": "AA 6.54",
+        "copy": "primary",
+        "contrast": "AAA 7.15",
         "primary": "no"
       },
       {
@@ -28,7 +28,7 @@
         "hex": "7C52FF",
         "copy": "white",
         "contrast": "AA 4.65",
-        "darkContrast": "AA 4.11",
+        "darkContrast": "AA 4.5",
         "primary": "yes"
       },
       {
@@ -53,36 +53,36 @@
       {
         "stop": "100",
         "hex": "F9F9F9",
-        "copy": "dark",
-        "contrast": "AAA 19.89",
+        "copy": "primary",
+        "contrast": "AAA 19.94",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "E9E9E9",
-        "copy": "dark",
-        "contrast": "AAA 17.24",
+        "copy": "primary",
+        "contrast": "AAA 17.29",
         "primary": "no"
       },
       {
         "stop": "300",
         "hex": "D2D2D2",
-        "copy": "dark",
-        "contrast": "AAA 12.65",
+        "copy": "primary",
+        "contrast": "AAA 13.88",
         "primary": "no"
       },
       {
         "stop": "400",
         "hex": "AAAAAA",
-        "copy": "dark",
+        "copy": "primary",
         "contrast": "AAA 9.03",
         "primary": "no"
       },
       {
         "stop": "500",
         "hex": "808080",
-        "copy": "dark",
-        "contrast": "AA 5.28",
+        "copy": "primary",
+        "contrast": "AA 5.31",
         "primary": "no"
       },
       {
@@ -96,7 +96,7 @@
         "stop": "700",
         "hex": "3A3A3A",
         "copy": "white",
-        "contrast": "AAA 11.29",
+        "contrast": "AAA 11.37",
         "primary": "no"
       },
       {
@@ -121,36 +121,36 @@
       {
         "stop": "100",
         "hex": "FFF035",
-        "copy": "dark",
-        "contrast": "AAA 17.50",
+        "copy": "primary",
+        "contrast": "AAA 18.84",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "FFCCA7",
-        "copy": "dark",
-        "contrast": "AAA 13.41",
+        "copy": "primary",
+        "contrast": "AAA 14.44",
         "primary": "no"
       },
       {
         "stop": "300",
         "hex": "FFA360",
-        "copy": "dark",
-        "contrast": "AAA 9.90",
+        "copy": "primary",
+        "contrast": "AAA 10.65",
         "primary": "no"
       },
       {
         "stop": "400",
         "hex": "FF7F23",
-        "copy": "dark",
-        "contrast": "AAA 7.72",
+        "copy": "primary",
+        "contrast": "AAA 8.31",
         "primary": "yes"
       },
       {
         "stop": "500",
         "hex": "E05E00",
-        "copy": "dark",
-        "contrast": "AA 5.35",
+        "copy": "primary",
+        "contrast": "AA 5.77",
         "primary": "no"
       },
       {
@@ -168,21 +168,21 @@
       {
         "stop": "100",
         "hex": "FF97D2",
-        "copy": "dark",
-        "contrast": "AAA 10.62",
+        "copy": "primary",
+        "contrast": "AAA 10.6",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "F756B1",
-        "copy": "dark",
+        "copy": "primary",
         "contrast": "AA 6.92",
         "primary": "no"
       },
       {
         "stop": "300",
         "hex": "F9008E",
-        "copy": "dark",
+        "copy": "primary",
         "contrast": "AA 5.41",
         "primary": "no"
       },
@@ -208,28 +208,28 @@
       {
         "stop": "100",
         "hex": "FFE793",
-        "copy": "dark",
-        "contrast": "AAA 17.12",
+        "copy": "primary",
+        "contrast": "AAA 17.1",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "FFD362",
-        "copy": "dark",
+        "copy": "primary",
         "contrast": "AAA 14.74",
         "primary": "no"
       },
       {
         "stop": "300",
         "hex": "F6AB3C",
-        "copy": "dark",
-        "contrast": "AAA 10.82",
+        "copy": "primary",
+        "contrast": "AAA 10.8",
         "primary": "yes"
       },
       {
         "stop": "400",
         "hex": "D28F2B",
-        "copy": "dark",
+        "copy": "primary",
         "contrast": "AAA 7.7",
         "primary": "no"
       },
@@ -237,7 +237,7 @@
         "stop": "500",
         "hex": "815008",
         "copy": "white",
-        "contrast": "AA 6.78",
+        "contrast": "AA 6.8",
         "primary": "no"
       }
     ]
@@ -248,29 +248,29 @@
       {
         "stop": "100",
         "hex": "FFDCDC",
-        "copy": "dark",
-        "contrast": "AAA 16.51",
+        "copy": "primary",
+        "contrast": "AAA 16.52",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "FF7474",
-        "copy": "dark",
-        "contrast": "AAA 7.99",
+        "copy": "primary",
+        "contrast": "AAA 8",
         "primary": "no"
       },
       {
         "stop": "300",
         "hex": "FF2E2E",
-        "copy": "dark",
-        "contrast": "AA 5.67",
+        "copy": "primary",
+        "contrast": "AA 5.68",
         "primary": "no"
       },
       {
         "stop": "400",
         "hex": "A41111",
         "copy": "white",
-        "contrast": "AAA 7.89",
+        "contrast": "AAA 7.87",
         "primary": "yes"
       },
       {
@@ -288,29 +288,29 @@
       {
         "stop": "100",
         "hex": "DDF4D9",
-        "copy": "dark",
+        "copy": "primary",
         "contrast": "AAA 18.01",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "9FFF90",
-        "copy": "dark",
+        "copy": "primary",
         "contrast": "AAA 17.18",
         "primary": "no"
       },
       {
         "stop": "300",
         "hex": "45F777",
-        "copy": "dark",
-        "contrast": "AAA 14.79",
+        "copy": "primary",
+        "contrast": "AAA 14.82",
         "primary": "no"
       },
       {
         "stop": "400",
         "hex": "1AA340",
-        "copy": "dark",
-        "contrast": "AA 3.3",
+        "copy": "primary",
+        "contrast": "AA 6.35",
         "primary": "yes"
       },
       {
@@ -328,36 +328,36 @@
       {
         "stop": "100",
         "hex": "E3EDF9",
-        "copy": "dark",
-        "contrast": "AAA 17.74:1",
+        "copy": "primary",
+        "contrast": "AAA 17.74",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "84BDFF",
-        "copy": "dark",
-        "contrast": "AAA 10.66:1",
+        "copy": "primary",
+        "contrast": "AAA 10.7",
         "primary": "no"
       },
       {
         "stop": "300",
         "hex": "51A0FE",
-        "copy": "dark",
-        "contrast": "AAA 7.8:1",
+        "copy": "primary",
+        "contrast": "AAA 7.8",
         "primary": "no"
       },
       {
         "stop": "400",
         "hex": "1768C6",
         "copy": "white",
-        "contrast": "AA 5.5:1",
+        "contrast": "AA 5.48",
         "primary": "yes"
       },
       {
         "stop": "500",
         "hex": "01326D",
         "copy": "white",
-        "contrast": "AAA 12.51:1",
+        "contrast": "AAA 12.51",
         "primary": "no"
       }
     ]
@@ -368,36 +368,36 @@
       {
         "stop": "100",
         "hex": "F2F0EE",
-        "copy": "dark",
-        "contrast": "AAA 18.47:1",
+        "copy": "primary",
+        "contrast": "AAA 18.47",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "CEC8C4",
-        "copy": "dark",
-        "contrast": "AAA 12.68:1",
+        "copy": "primary",
+        "contrast": "AAA 12.68",
         "primary": "no"
       },
       {
         "stop": "300",
         "hex": "87807B",
-        "copy": "dark",
-        "contrast": "AA 5.4:1",
+        "copy": "primary",
+        "contrast": "AA 5.4",
         "primary": "no"
       },
       {
         "stop": "400",
         "hex": "3F3D3C",
         "copy": "white",
-        "contrast": "AAA 10.8:1",
+        "contrast": "AAA 10.8",
         "primary": "yes"
       },
       {
         "stop": "500",
         "hex": "121212",
         "copy": "white",
-        "contrast": "AAA 18.73:1",
+        "contrast": "AAA 18.73",
         "primary": "no"
       }
     ]

--- a/docs/utilities/backgrounds/patterns.md
+++ b/docs/utilities/backgrounds/patterns.md
@@ -11,7 +11,7 @@ next:
 Use `d-bgg-pattern-{pattern}-{dark|light}` to apply a pattern.
 
 <code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-black-200 d-w100p d-hmn102 d-stack8" custom>
-  <div class="d-d-flex d-ai-center d-w100p d-h32 d-bar4 d-bgg-to-br d-bgg-from-gold-200 d-bgg-to-gold-200 d-bgg-pattern d-bgg-pattern-slanted-stripes-dark d-fs-200 d-fw-bold d-fc-dark">Ted's Call Center</div>
+  <div class="d-d-flex d-ai-center d-w100p d-h32 d-bar4 d-bgg-to-br d-bgg-from-gold-200 d-bgg-to-gold-200 d-bgg-pattern d-bgg-pattern-slanted-stripes-dark d-fs-200 d-fw-bold d-fc-primary">Ted's Call Center</div>
   <div class="d-d-flex d-ai-center d-w100p d-h32 d-bar4 d-bgg-to-br d-bgg-from-purple-400 d-bgg-to-purple-500 d-bgg-pattern d-bgg-pattern-dots-circles-light d-fs-200 d-fw-bold d-fc-white">Vicky's Department</div>
 </code-well-header>
 

--- a/docs/utilities/effects/transition.md
+++ b/docs/utilities/effects/transition.md
@@ -11,11 +11,11 @@ next:
 Use `d-t` to add a transition to an element.
 
 <code-well-header class="d-fl-center d-p24 d-bgc-purple-100 d-bgo50 d-w100p d-hmn102" custom>
-  <div class="d-fl-center d-p24 d-bar8 d-bgc-purple-300 h:d-bgc-gold-200 h:d-bs-lg d-fs-200 d-fw-bold d-fc-white h:d-fc-dark d-t d-c-pointer">Hover on me</div>
+  <div class="d-fl-center d-p24 d-bar8 d-bgc-purple-300 h:d-bgc-gold-200 h:d-bs-lg d-fs-200 d-fw-bold d-fc-white h:d-fc-primary d-t d-c-pointer">Hover on me</div>
 </code-well-header>
 
 ```html
-<div class="d-bgc-purple-300 h:d-bgc-gold-200 h:d-bs-lg d-fc-white h:d-fc-dark d-t">...</div>
+<div class="d-bgc-purple-300 h:d-bgc-gold-200 h:d-bs-lg d-fc-white h:d-fc-primary d-t">...</div>
 ```
 
 ## Changing transition duration
@@ -23,11 +23,11 @@ Use `d-t` to add a transition to an element.
 Use `d-td{n}` change an element's `transition-delay` from it's default `50ms` length.
 
 <code-well-header class="d-fl-col3 d-flg8 d-p24 d-bgc-magenta-100 d-bgo50 d-w100p d-hmn102 d-of-auto" custom>
-  <div class="d-fl-center d-p24 d-bar8 d-bgc-magenta-200 h:d-bgc-gold-200 h:d-bs-lg d-fs-200 d-fw-bold d-fc-white h:d-fc-dark d-t d-td0 d-c-pointer">0ms</div>
-  <div class="d-fl-center d-p24 d-bar8 d-bgc-magenta-200 h:d-bgc-gold-200 h:d-bs-lg d-fs-200 d-fw-bold d-fc-white h:d-fc-dark d-t d-c-pointer">50ms</div>
-  <div class="d-fl-center d-p24 d-bar8 d-bgc-magenta-200 h:d-bgc-gold-200 h:d-bs-lg d-fs-200 d-fw-bold d-fc-white h:d-fc-dark d-t d-td100 d-c-pointer">100ms</div>
-  <div class="d-fl-center d-p24 d-bar8 d-bgc-magenta-200 h:d-bgc-gold-200 h:d-bs-lg d-fs-200 d-fw-bold d-fc-white h:d-fc-dark d-t d-td150 d-c-pointer">150ms</div>
-  <div class="d-fl-center d-p24 d-bar8 d-bgc-magenta-200 h:d-bgc-gold-200 h:d-bs-lg d-fs-200 d-fw-bold d-fc-white h:d-fc-dark d-t d-td200 d-c-pointer">200ms</div>
+  <div class="d-fl-center d-p24 d-bar8 d-bgc-magenta-200 h:d-bgc-gold-200 h:d-bs-lg d-fs-200 d-fw-bold d-fc-white h:d-fc-primary d-t d-td0 d-c-pointer">0ms</div>
+  <div class="d-fl-center d-p24 d-bar8 d-bgc-magenta-200 h:d-bgc-gold-200 h:d-bs-lg d-fs-200 d-fw-bold d-fc-white h:d-fc-primary d-t d-c-pointer">50ms</div>
+  <div class="d-fl-center d-p24 d-bar8 d-bgc-magenta-200 h:d-bgc-gold-200 h:d-bs-lg d-fs-200 d-fw-bold d-fc-white h:d-fc-primary d-t d-td100 d-c-pointer">100ms</div>
+  <div class="d-fl-center d-p24 d-bar8 d-bgc-magenta-200 h:d-bgc-gold-200 h:d-bs-lg d-fs-200 d-fw-bold d-fc-white h:d-fc-primary d-t d-td150 d-c-pointer">150ms</div>
+  <div class="d-fl-center d-p24 d-bar8 d-bgc-magenta-200 h:d-bgc-gold-200 h:d-bs-lg d-fs-200 d-fw-bold d-fc-white h:d-fc-primary d-t d-td200 d-c-pointer">200ms</div>
 </code-well-header>
 
 ```html
@@ -57,12 +57,12 @@ Use `d-ttf-{n}` change an element's `transition-timing-function` (aka easing) fr
 Use `d-tp-{n}` change an what items within an element are transitioned.
 
 <code-well-header class="d-fl-col3 d-flg8 d-p24 d-bgc-gold-100 d-bgo50 d-w100p d-hmn102 d-of-auto" custom>
-  <div class="d-fl-center d-p24 d-bar8 d-bgc-gold-200 h:d-bgc-purple-100 h:d-bs-lg d-fs-200 d-fw-bold d-fc-dark h:d-fc-red-200 d-t d-td100 d-c-pointer">All</div>
-  <div class="d-fl-center d-p24 d-bar8 d-bgc-gold-200 d-fs-200 d-fw-bold d-fc-dark d-t d-td100 d-tp-o d-c-pointer h:d-o50">Opacity</div>
-  <div class="d-fl-center d-p24 d-bar8 d-bgc-gold-200 d-fs-200 d-fw-bold d-fc-dark d-t d-td100 d-tp-bs d-c-pointer d-bs-sm h:d-bs-lg">Box Shadow</div>
-  <div class="d-fl-center d-p24 d-bar8 d-bgc-gold-200 h:d-bgc-purple-100 d-fs-200 d-fw-bold d-fc-dark d-t d-td100 d-tp-bgc d-c-pointer">Background</div>
-  <div class="d-fl-center d-p24 d-bar8 d-bgc-gold-200 d-fs-200 d-fw-bold d-fc-dark d-t d-td100 d-tp-transform d-c-pointer">Transform</div>
-  <div class="d-fl-center d-p24 d-bar8 d-bgc-gold-200 h:d-bgc-purple-100 d-fs-200 d-fw-bold d-fc-dark h:d-fc-red-200 d-ba h:d-bc-gold-300 d-t d-td100 d-tp-colors d-c-pointer">Colors</div>
+  <div class="d-fl-center d-p24 d-bar8 d-bgc-gold-200 h:d-bgc-purple-100 h:d-bs-lg d-fs-200 d-fw-bold d-fc-primary h:d-fc-red-200 d-t d-td100 d-c-pointer">All</div>
+  <div class="d-fl-center d-p24 d-bar8 d-bgc-gold-200 d-fs-200 d-fw-bold d-fc-primary d-t d-td100 d-tp-o d-c-pointer h:d-o50">Opacity</div>
+  <div class="d-fl-center d-p24 d-bar8 d-bgc-gold-200 d-fs-200 d-fw-bold d-fc-primary d-t d-td100 d-tp-bs d-c-pointer d-bs-sm h:d-bs-lg">Box Shadow</div>
+  <div class="d-fl-center d-p24 d-bar8 d-bgc-gold-200 h:d-bgc-purple-100 d-fs-200 d-fw-bold d-fc-primary d-t d-td100 d-tp-bgc d-c-pointer">Background</div>
+  <div class="d-fl-center d-p24 d-bar8 d-bgc-gold-200 d-fs-200 d-fw-bold d-fc-primary d-t d-td100 d-tp-transform d-c-pointer">Transform</div>
+  <div class="d-fl-center d-p24 d-bar8 d-bgc-gold-200 h:d-bgc-purple-100 d-fs-200 d-fw-bold d-fc-primary h:d-fc-red-200 d-ba h:d-bc-gold-300 d-t d-td100 d-tp-colors d-c-pointer">Colors</div>
 </code-well-header>
 
 ```html

--- a/docs/utilities/typography/color.md
+++ b/docs/utilities/typography/color.md
@@ -19,7 +19,7 @@ Use `d-fc-{color}` to change an element's text color.
 </code-well-header>
 
 ```html
-<p class="d-fc-purple">...</p>
+<p class="d-fc-purple-400">...</p>
 ```
 
 ## Changing opacity

--- a/docs/utilities/typography/text-opacity.md
+++ b/docs/utilities/typography/text-opacity.md
@@ -45,7 +45,7 @@ Please note that because the opacity adjustments are made via CSS variables, a f
   <div  class="d-p8 d-bgc-red-200 d-bgo25 d-bar8">
 
   ```jsx
-  <p class="d-fc-dark">
+  <p class="d-fc-primary">
       <span class="d-fco75">The quick brown fox jumps over the lazy dog.</span>
   </p>
   ```
@@ -63,8 +63,8 @@ Please note that because the opacity adjustments are made via CSS variables, a f
   <div  class="d-p8 d-bgc-green-200 d-bgo25 d-bar8">
 
   ```jsx
-  <p class="d-fc-dark">
-      <span class="d-fc-dark d-fco75">The quick brown fox jumps over the lazy dog.</span>
+  <p class="d-fc-primary">
+      <span class="d-fc-primary d-fco75">The quick brown fox jumps over the lazy dog.</span>
   </p>
   ```
 


### PR DESCRIPTION
## Description

Most of contrast values in Color Palette had wrong values, updated and migrated usages of `d-fc-dark` -> `d-fc-primary`

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/MDJ9IbxxvDUQM/giphy.gif)
