### PR TITLE
fix: input focus

### DIFF
--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -186,7 +186,8 @@
     --input--bc: var(--warning-color) !important;
     --input--focus-bc: var(--warning-color);
 
-    &:focus {
+    &:focus,
+    &:focus-within {
         box-shadow: var(--bs-focus-ring-warning) !important;
     }
 }
@@ -196,7 +197,8 @@
     --input--bc: var(--error-color) !important;
     --input--focus-bc: var(--error-color);
 
-    &:focus {
+    &:focus,
+    &:focus-within {
         box-shadow: var(--bs-focus-ring-error) !important;
     }
 }
@@ -206,7 +208,8 @@
     --input--bc: var(--success-color) !important;
     --input--focus-bc: var(--success-color);
 
-    &:focus {
+    &:focus,
+    &:focus-within {
         box-shadow: var(--bs-focus-ring-success) !important;
     }
 }


### PR DESCRIPTION
## Description
Fix input focus when input has icons and input__wrapper. Needs focus within so the wrapper gets the borders
<img width="548" alt="Screen Shot 2022-10-06 at 10 44 17" src="https://user-images.githubusercontent.com/29417442/194329070-d2a97297-e408-4e05-be9f-624bff17e806.png">


## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [ ] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](path/to/gif)
