### PR TITLE
feat: add linux and android system fonts to the stack

### DIFF
--- a/docs/_data/type.json
+++ b/docs/_data/type.json
@@ -112,11 +112,11 @@
   "fontFamily": [
     {
       "var": "custom",
-      "output": "-apple-system, BlinkMacSystemFont, \"Segoe UI Adjusted\", \"Segoe UI\", SFMono, \"Helvetica Neue\", Arial, \"Noto Sans\", sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\""
+      "output": "-apple-system, BlinkMacSystemFont, \"Segoe UI Adjusted\", \"Segoe UI\", SFMono, \"Helvetica Neue\", Cantarell, Ubuntu, Roboto, Arial, \"Noto Sans\", sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\""
     },
     {
       "var": "sans",
-      "output": "-apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
+      "output": "-apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Cantarell, Ubuntu, Roboto, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
     },
     {
       "var": "mono",
@@ -124,15 +124,15 @@
     },
     {
       "var": "marketing",
-      "output": "\"Archivo\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
+      "output": "\"Archivo\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Cantarell, Ubuntu, Roboto, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
     },
     {
       "var": "marketing-semi-expanded",
-      "output": "\"ArchivoSemiExpanded\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
+      "output": "\"ArchivoSemiExpanded\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Cantarell, Ubuntu, Roboto, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
     },
     {
       "var": "marketing-expanded",
-      "output": "\"ArchivoExpanded\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
+      "output": "\"ArchivoExpanded\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Cantarell, Ubuntu, Roboto, Arial,  sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
     },
     {
       "var": "unset",
@@ -445,7 +445,7 @@
     },
     {
       "class": "sans",
-      "output": "-apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
+      "output": "-apple-system, BlinkMacSystemFont, \"Segoe UI\", Helvetica, Cantarell, Ubuntu, Roboto, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\""
     },
     {
       "class": "mono",

--- a/lib/build/less/variables/typography.less
+++ b/lib/build/less/variables/typography.less
@@ -19,8 +19,8 @@
 //  $   FONT FAMILY
 //  ----------------------------------------------------------------------------
 @define-ff-custom-name:                    -apple-system, BlinkMacSystemFont, 'Segoe UI Adjusted',  'Segoe UI', SFMono,
-                                           'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji',
-                                           'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
+                                           'Helvetica Neue', Cantarell, Ubuntu, Roboto, Arial, 'Noto Sans', sans-serif,
+                                           'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji';
 @define-ff-mono:                           @ff-sf-mono;
 @define-ff-mono-name:                      'SFMono';
 @define-ff-marketing:                      @ff-archivo;
@@ -66,7 +66,8 @@
 
 
 @ff-custom: @define-ff-custom-name;
-@ff-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+@ff-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Cantarell, Ubuntu, Roboto, Arial, sans-serif,
+          'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 @ff-mono: @define-ff-mono-name, SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier, monospace;
 @ff-marketing: @define-ff-marketing-name, @ff-sans;
 @ff-marketing-semi-expanded: @define-ff-marketing-semi-expanded-name, @ff-sans;


### PR DESCRIPTION
## Description
Apparently since we changed to our new system font stack it looks like this on Ubuntu:

![](https://user-images.githubusercontent.com/64808812/194655190-1ceb5366-6f10-49a8-b756-f41f78a92136.png)

Seems on linux sometimes none of our font stack exists and it was defaulting to joypixels in this case.

Included Ubuntu (Ubuntu system font), Cantarell (Gnome system font) and Roboto (Android system font) into the font stack.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/4N5ddOOJJ7gtKTgNac/giphy.gif)
