### PR TITLE
fix: badge-300 font color

### DIFF
--- a/lib/build/less/components/badge.less
+++ b/lib/build/less/components/badge.less
@@ -93,6 +93,5 @@
 }
 
 .d-badge--red-300 {
-  --badge--fc: var(--white);
   --badge--bgc: var(--red-300);
 }


### PR DESCRIPTION
## Description

Badge-300 font color should be `--fc-primary` instead of `white` to meet accessibility requirements

![image](https://user-images.githubusercontent.com/87546543/195168823-e7191169-7871-4dda-bd9c-eca1a2b7d05f.png)
![image](https://user-images.githubusercontent.com/87546543/195168901-1fa231f1-ada0-4a12-b81a-23a08c0c2df3.png)
![image](https://user-images.githubusercontent.com/87546543/195168932-41d2c1d8-cc11-48e1-a138-24b69a7f4bfe.png)


## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/ZXKZWB13D6gFO/giphy.gif)
