### PR TITLE
fix: remove calt 0 and kerning

### DIFF
--- a/lib/build/less/dialtone-globals.less
+++ b/lib/build/less/dialtone-globals.less
@@ -29,10 +29,8 @@ body {
     color: var(--base--text-color);
     font-size: var(--base--font-size); // [2]
     font-family: var(--base--font-family);
-    font-feature-settings: var(--base--font-feature-settings);
     line-height: var(--base--line-height);
     background-color: var(--base--background-color);
-    font-kerning: normal;
     -webkit-text-size-adjust: 100%; // [3]
 }
 

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -49,7 +49,6 @@
 
     base--font-size:                                  var(--fs-200);
     base--font-family:                                @ff-custom;
-    base--font-feature-settings:                      'calt' 0;
     base--line-height:                                var(--lh-300);
     base--corner-radius:                              0.25em;
 


### PR DESCRIPTION
## Description
We previously set calt 0 font feature to fix an issue with the Inter font as you can see in [this PR](https://github.com/dialpad/dialtone/pull/622). Since we no longer use Inter we do not need to have this set anymore. It may be causing some issues with the system font stack. Also removed `kerning: normal` as there were some issues with vietnamese characters being too close together, the default (auto) should apply kerning only when needed to increase visibility.

Related issues:
https://dialpad.atlassian.net/browse/DT-748
https://dialpad.atlassian.net/browse/DP-58474

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/pjWYwl5RHR9ZW40RS9/giphy.gif)
