### PR TITLE
fix: correct "busy" color

### DIFF
--- a/lib/build/less/components/presence.less
+++ b/lib/build/less/components/presence.less
@@ -9,38 +9,45 @@
 //  visit https://dialpad.design/components/presence
 
 .d-presence {
-  position: relative;
+  --color-border-base: var(--black-100);
+  --color-border-offline: var(--black-400);
+  --color-background-base: var(--white);
+  --color-background-active: var(--green-400);
+  --color-background-busy: var(--red-300);
+  --color-background-away: var(--gold-200);
+  --color-background-offline: var(--white);
+
   display: inline-block;
   box-sizing: border-box;
-  border-color: var(--black-100);
+  border-color: var(--color-border-base);
   border-style: solid;
   border-width: var(--su2);
   border-radius: 50%;
 
   &__inner {
-    position: relative;
     box-sizing: border-box;
     width: var(--su8);
     height: var(--su8);
+    background-color: var(--color-background-base);
     border: none;
     border-radius: 50%;
   }
 
   &__inner--active {
-    background-color: var(--green-400);
+    background-color: var(--color-background-active);
   }
 
   &__inner--busy {
-    background-color: var(--red-400);
+    background-color: var(--color-background-busy);
   }
 
   &__inner--away {
-    background-color: var(--gold-200);
+    background-color: var(--color-background-away);
   }
 
   &__inner--offline {
-    background-color: var(--white);
-    border-color: var(--black-400);
+    background-color: var(--color-background-offline);
+    border-color: var(--color-border-offline);
     border-style: solid;
     border-width: var(--su2);
   }


### PR DESCRIPTION
## Description
* Correct red "busy" color of Presence from `400` to `300`
* Made use of local css custom properties

/c @modialpad 

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![image](https://user-images.githubusercontent.com/1165933/198695829-7e0f8e0a-bddc-4e37-a5b9-7852b5bcf939.png)

