### PR TITLE
fix: icons folder structure

### DIFF
--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -13,7 +13,7 @@ new: true
 
 ### SVG
 
-To use SVG icons use the following path: `@dialpad/dialtone/svg/v7/[CATEGORY]/icon-name.svg`
+To use SVG icons use the following path: `@dialpad/dialtone/lib/dist/svg/v7/icon-name.svg`
 
 ## Variants and examples
 
@@ -67,6 +67,6 @@ To use SVG icons use the following path: `@dialpad/dialtone/svg/v7/[CATEGORY]/ic
 </table>
 
 <script setup>
-    import InboxIcon from '@v7Icons/general/Inbox.vue';
+    import InboxIcon from '@v7Icons/Inbox.vue';
     import { sizes } from '@data/icon.json';
 </script>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -662,6 +662,7 @@ const buildNewSVGIcons = function (done) {
       xmlns="http://www.w3.org/2000/svg"`;
     }))
     .pipe(svgmin())
+    .pipe(rename({ dirname: '' }))
     .pipe(dest(paths.version7.outputLib))
     .pipe(replace('<svg', '<template>\n  <svg'))
     .pipe(replace('</svg>', '</svg>\n</template>'))


### PR DESCRIPTION
## Description

Removed `dist` icons folder structure to make it easier to import icons.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/2wYYlHuEw1UcsJYgAA/giphy.gif)
