### PR TITLE
docs: fix lists

### DIFF
--- a/docs/.vuepress/styles/palette.scss
+++ b/docs/.vuepress/styles/palette.scss
@@ -14,12 +14,17 @@ tr {
       margin-top: unset;
       margin-bottom: unset;
     }
+
     margin-top: unset;
     margin-bottom: unset;
     padding-top: unset;
     padding-bottom: unset;
     border-bottom: unset;
     font-size: unset;
+  }
+
+  ol, ul, li {
+    list-style: revert;
   }
 }
 

--- a/docs/assets/less/dialtone-docs.less
+++ b/docs/assets/less/dialtone-docs.less
@@ -478,7 +478,6 @@ nav a.router-link-active {
 
   &__bd {
     padding-left: var(--su4);
-    padding-left: var(--su4);
     font-size: var(--fs-200);
 
     > div > ul,


### PR DESCRIPTION
## Description

Lists in documentation site were missing bullets and numbers due to https://github.com/dialpad/dialtone/commit/5fcfc4fc419a274a5051d210634e7992bfd6bb70 global reset. Added `list-style: revert` to docsite lists to get them back.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/rGTX1QLlFNRhPJZIAS/giphy.gif)
