### PR TITLE
fix: remove redundant `currentColor` from border utilities

### DIFF
--- a/docs/utilities/borders/direction.md
+++ b/docs/utilities/borders/direction.md
@@ -60,15 +60,15 @@ Use `d-b{t|r|b|l|x|y}` to add a border to only specific sides of your element.
         <th scope="row" class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">.d-b{{ i[0] }}</th>
         <td class="d-ff-mono d-fs-100">
           <span v-if="i === 'y'">
-            border-top: var(--su1) solid currentColor !important;<br/>
-            border-bottom: var(--su1) solid currentColor !important;
+            border-top: var(--su1) solid !important;<br/>
+            border-bottom: var(--su1) solid !important;
           </span>
           <span v-else-if="i === 'x'">
-            border-right: var(--su1) solid currentColor !important;<br/>
-            border-left: var(--su1) solid currentColor !important;
+            border-right: var(--su1) solid !important;<br/>
+            border-left: var(--su1) solid !important;
           </span>
           <span v-else>
-            border-{{i}}: var(--su1) solid currentColor !important;
+            border-{{i}}: var(--su1) solid !important;
           </span>
         </td>
       </tr>

--- a/docs/utilities/borders/divide-width.md
+++ b/docs/utilities/borders/divide-width.md
@@ -110,24 +110,24 @@ If an element's `flex-direction` is reversed, apply `d-divide-{y|x}-reverse` to 
                 <span v-if="i === 'default'">1</span>
                 <span v-else>{{ i }}</span>
                 px *(1 - var(--divide-{{ d }}-reverse))
-              ) solid currentColor !important;<br/>
+              ) solid !important;<br/>
               border-bottom: calc(
                 <span v-if="i === 'default'">1</span>
                 <span v-else>{{ i }}</span>
 px* var(--divide-{{ d }}-reverse)
-              ) solid currentColor !important;
+              ) solid !important;
             </span>
             <span v-else>
               border-right: calc(
                 <span v-if="i === 'default'">1</span>
                 <span v-else>{{ i }}</span>
                 px *(1 - var(--divide-{{ d }}-reverse))
-              ) solid currentColor !important;<br/>
+              ) solid !important;<br/>
               border-left: calc(
                 <span v-if="i === 'default'">1</span>
                 <span v-else>{{ i }}</span>
 px* var(--divide-{{ d }}-reverse)
-              ) solid currentColor !important;
+              ) solid !important;
             </span>
           </td>
         </tr>

--- a/lib/build/less/utilities/borders.less
+++ b/lib/build/less/utilities/borders.less
@@ -32,11 +32,11 @@
 
 //  $$ DIRECTION
 //  ----------------------------------------------------------------------------
-.d-ba { border: var(--su1) solid currentColor !important; }
-.d-bt { border-top: var(--su1) solid currentColor !important; }
-.d-br { border-right: var(--su1) solid currentColor !important; }
-.d-bb { border-bottom: var(--su1) solid currentColor !important; }
-.d-bl { border-left: var(--su1) solid currentColor !important; }
+.d-ba { border: var(--su1) solid !important; }
+.d-bt { border-top: var(--su1) solid !important; }
+.d-br { border-right: var(--su1) solid !important; }
+.d-bb { border-bottom: var(--su1) solid !important; }
+.d-bl { border-left: var(--su1) solid !important; }
 .d-bx { .d-br(); .d-bl(); }
 .d-by { .d-bt(); .d-bb(); }
 .d-ba-none { border: none !important; }
@@ -173,29 +173,29 @@
 .d-divide-y > * + * {
     --divide-y-reverse: 0;
 
-    border-top: calc(~'1px * (1 - var(--divide-y-reverse))') solid currentColor !important;
-    border-bottom: calc(~'1px * var(--divide-y-reverse)') solid currentColor !important;
+    border-top: calc(~'1px * (1 - var(--divide-y-reverse))') solid !important;
+    border-bottom: calc(~'1px * var(--divide-y-reverse)') solid !important;
 }
 
 .d-divide-y0 > * + * {
     --divide-y-reverse: 0;
 
-    border-top: calc(~'0 * (1 - var(--divide-y-reverse))') solid currentColor !important;
-    border-bottom: calc(~'0 * var(--divide-y-reverse)') solid currentColor !important;
+    border-top: calc(~'0 * (1 - var(--divide-y-reverse))') solid !important;
+    border-bottom: calc(~'0 * var(--divide-y-reverse)') solid !important;
 }
 
 .d-divide-y2 > * + * {
     --divide-y-reverse: 0;
 
-    border-top: calc(~'2px * (1 - var(--divide-y-reverse))') solid currentColor !important;
-    border-bottom: calc(~'2px * var(--divide-y-reverse)') solid currentColor !important;
+    border-top: calc(~'2px * (1 - var(--divide-y-reverse))') solid !important;
+    border-bottom: calc(~'2px * var(--divide-y-reverse)') solid !important;
 }
 
 .d-divide-y4 > * + * {
     --divide-y-reverse: 0;
 
-    border-top: calc(~'4px * (1 - var(--divide-y-reverse))') solid currentColor !important;
-    border-bottom: calc(~'4px * var(--divide-y-reverse)') solid currentColor !important;
+    border-top: calc(~'4px * (1 - var(--divide-y-reverse))') solid !important;
+    border-bottom: calc(~'4px * var(--divide-y-reverse)') solid !important;
 }
 .d-divide-y-reverse > * + * { --divide-y-reverse: 1; }
 
@@ -204,28 +204,28 @@
 .d-divide-x > * + * {
     --divide-x-reverse: 0;
 
-    border-right: calc(~'1px * var(--divide-x-reverse)') solid currentColor !important;
-    border-left: calc(~'1px * (1 - var(--divide-x-reverse))') solid currentColor !important;
+    border-right: calc(~'1px * var(--divide-x-reverse)') solid !important;
+    border-left: calc(~'1px * (1 - var(--divide-x-reverse))') solid !important;
 }
 
 .d-divide-x0 > * + * {
     --divide-x-reverse: 0;
 
-    border-right: calc(~'0 * var(--divide-x-reverse)') solid currentColor !important;
-    border-left: calc(~'0 * (1 - var(--divide-x-reverse))') solid currentColor !important;
+    border-right: calc(~'0 * var(--divide-x-reverse)') solid !important;
+    border-left: calc(~'0 * (1 - var(--divide-x-reverse))') solid !important;
 }
 
 .d-divide-x2 > * + * {
     --divide-x-reverse: 0;
 
-    border-right: calc(~'2px * var(--divide-x-reverse)') solid currentColor !important;
-    border-left: calc(~'2px * (1 - var(--divide-x-reverse))') solid currentColor !important;
+    border-right: calc(~'2px * var(--divide-x-reverse)') solid !important;
+    border-left: calc(~'2px * (1 - var(--divide-x-reverse))') solid !important;
 }
 
 .d-divide-x4 > * + * {
     --divide-x-reverse: 0;
 
-    border-right: calc(~'4px * var(--divide-x-reverse)') solid currentColor !important;
-    border-left: calc(~'4px * (1 - var(--divide-x-reverse))') solid currentColor !important;
+    border-right: calc(~'4px * var(--divide-x-reverse)') solid !important;
+    border-left: calc(~'4px * (1 - var(--divide-x-reverse))') solid !important;
 }
 .d-divide-x-reverse > * + * { --divide-x-reverse: 1; }


### PR DESCRIPTION
## Description
`currentColor` as a property of these CSS utilities are redundant. They appropriately get stripped when minimized, but some products don't minimize them (or they are minimizing but not stripping it out). The resulting bug results in `currentColor` overriding accompanying `border-color` CSS utilities or extensions.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
