### PR TITLE
chore(semantic-release): use @dialpad/conventional-changelog-angular

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -18,7 +18,8 @@
         "test"
       ]
     ],
-    "header-max-length": [2, "always", 72],
+    "scope-case": [2, "always", "kebab-case"],
+    "header-max-length": [2, "always", 120],
     "body-max-line-length": [0, "always", 100],
     "subject-full-stop": [0, "never", "."]
   },

--- a/.github/COMMIT_CONVENTION.md
+++ b/.github/COMMIT_CONVENTION.md
@@ -40,10 +40,19 @@ Must be one of the following:
 
 ### Scope:
 
-The optional scope allows to specify the place of the change. For instance, if the commit affects a specific component, use the component's name as scope:
+The optional scope allows to specify the place of the change.
+For instance, if the commit affects a specific component, use the component's name as scope:
+
+Note: use lowercase and kebab-case syntax for the scope, that means all in lowercase and separate the words with dash.
 
 ```
 feat(select-menu): add leftIcon prop
+```
+
+In case of multiple scopes, separate them with comma.
+
+```
+fix(combobox, combobox-with-popover): fix keyboard navigation
 ```
 
 ### Subject:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "7.4.1",
       "license": "MIT",
       "dependencies": {
-        "@dialpad/dialtone-icons": "^0.0.7-vue3",
+        "@dialpad/dialtone-icons": "0.0.7-vue3",
         "@docsearch/js": "^3.2.1",
         "docopt": "^0.6.2",
         "precss": "^4.0.0"
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@commitlint/cli": "^17.1.2",
         "@commitlint/config-conventional": "^17.1.0",
+        "@dialpad/conventional-changelog-angular": "^1.0.0",
         "@dialpad/dialtone-combinator": "^0.3.1",
         "@dialpad/dialtone-vue": "^3.13.0",
         "@dialpad/postcss-responsive-variations": "^1.1.3",
@@ -946,6 +947,19 @@
       "peerDependencies": {
         "postcss": "^8.2",
         "postcss-selector-parser": "^6.0.10"
+      }
+    },
+    "node_modules/@dialpad/conventional-changelog-angular": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/conventional-changelog-angular/-/conventional-changelog-angular-1.0.0.tgz",
+      "integrity": "sha512-dsJx+bxLrtar4xAbAETG6QXJB96YeZv0G8analp7U4ZVM3LGDB8QnzthZKskYOkZ3DVtvqPNYv8UfZ9byZg+WQ==",
+      "dev": true,
+      "dependencies": {
+        "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@dialpad/dialtone": {
@@ -29026,6 +29040,16 @@
       "integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
       "dev": true,
       "requires": {}
+    },
+    "@dialpad/conventional-changelog-angular": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/conventional-changelog-angular/-/conventional-changelog-angular-1.0.0.tgz",
+      "integrity": "sha512-dsJx+bxLrtar4xAbAETG6QXJB96YeZv0G8analp7U4ZVM3LGDB8QnzthZKskYOkZ3DVtvqPNYv8UfZ9byZg+WQ==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0",
+        "q": "^1.5.1"
+      }
     },
     "@dialpad/dialtone": {
       "version": "7.4.1",

--- a/package.json
+++ b/package.json
@@ -10,14 +10,30 @@
   ],
   "homepage": "https://dialpad.design",
   "bugs": {
-    "email" : "dialtone@dialpad.com"
+    "email": "dialtone@dialpad.com"
   },
   "license": "MIT",
   "contributors": [
-    {"name":"Brad Paugh","email":"brad.paugh@dialpad.com","url":"https://github.com/braddialpad"},
-    {"name":"Francis Rupert","email":"francis.rupert@dialpad.com","url":"https://github.com/francisrupert"},
-    {"name":"Julio Ortega","email":"julio.ortega@dialpad.com","url":"https://github.com/juliodialpad"},
-    {"name":"Jose Silva","email":"jose.silva@dialpad.com","url":"https://github.com/josedialpad"}
+    {
+      "name": "Brad Paugh",
+      "email": "brad.paugh@dialpad.com",
+      "url": "https://github.com/braddialpad"
+    },
+    {
+      "name": "Francis Rupert",
+      "email": "francis.rupert@dialpad.com",
+      "url": "https://github.com/francisrupert"
+    },
+    {
+      "name": "Julio Ortega",
+      "email": "julio.ortega@dialpad.com",
+      "url": "https://github.com/juliodialpad"
+    },
+    {
+      "name": "Jose Silva",
+      "email": "jose.silva@dialpad.com",
+      "url": "https://github.com/josedialpad"
+    }
   ],
   "files": [
     "lib",
@@ -66,6 +82,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
+    "@dialpad/conventional-changelog-angular": "^1.0.0",
     "@dialpad/dialtone-combinator": "^0.3.1",
     "@dialpad/dialtone-vue": "^3.13.0",
     "@dialpad/postcss-responsive-variations": "^1.1.3",

--- a/release-ci.config.js
+++ b/release-ci.config.js
@@ -13,7 +13,9 @@ module.exports = {
   ],
   plugins: [
     '@semantic-release/commit-analyzer',
-    '@semantic-release/release-notes-generator',
+    ['@semantic-release/release-notes-generator', {
+      config: '@dialpad/conventional-changelog-angular',
+    }],
     '@semantic-release/github',
   ],
 };

--- a/release-local.config.js
+++ b/release-local.config.js
@@ -13,7 +13,9 @@ module.exports = {
   ],
   plugins: [
     '@semantic-release/commit-analyzer',
-    '@semantic-release/release-notes-generator',
+    ['@semantic-release/release-notes-generator', {
+      config: '@dialpad/conventional-changelog-angular',
+    }],
     '@semantic-release/changelog',
     ['@semantic-release/npm', {
       npmPublish: false,


### PR DESCRIPTION
# Update conventional-changelog to make the scope human-readable in the release notes and changelog

## Description
Applied the same configuration as in dialtone-vue https://github.com/dialpad/dialtone-vue/pull/537

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [ ] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://i.giphy.com/media/0oZdEVtozNpfo8EZ3g/giphy.webp)