### PR TITLE
fix(chip): incorrect width for xs and sm size when no close btn

### DIFF
--- a/lib/build/less/components/chip.less
+++ b/lib/build/less/components/chip.less
@@ -144,7 +144,7 @@
 
   // reserves space within the chip for the close button, since the close button is
   // not nested within the chip.
-  &::after {
+  &:not(:only-child)::after {
     flex-shrink: 0;
     width: var(--su12);
     height: var(--su12);
@@ -187,7 +187,7 @@
 
   // reserves space within the chip for the close button, since the close button is
   // not nested within the chip.
-  &::after {
+  &:not(:only-child)::after {
     flex-shrink: 0;
     width: calc(var(--su12) + var(--su2));
     height: calc(var(--su12) + var(--su2));


### PR DESCRIPTION
## Description
https://dialpad.atlassian.net/browse/DT-784

Chip was displaying incorrect width on sm and xs sizes as shown in the above ticket. Just needed to apply `&:not(:only-child)::after` to sm and xs classes, same way it is on the main class.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/xT39Dl1AHieEwAobq8/giphy-downsized-large.gif)
