### PR TITLE
fix(toggle): small variant transition

### DIFF
--- a/lib/build/less/components/toggle.less
+++ b/lib/build/less/components/toggle.less
@@ -122,7 +122,7 @@
 
     &.d-toggle--small::after {
       right: var(--su1);
-      left: calc(var(--su16) + var(--fixed-value, 3px));
+      left: calc(var(--su16) + var(--su2) + var(--su1));
     }
   }
 

--- a/lib/build/less/components/toggle.less
+++ b/lib/build/less/components/toggle.less
@@ -122,7 +122,7 @@
 
     &.d-toggle--small::after {
       right: var(--su1);
-      left: auto;
+      left: calc(var(--su16) + var(--fixed-value, 3px));
     }
   }
 


### PR DESCRIPTION
## Description
[DT-770](https://dialpad.atlassian.net/browse/DT-770)

Transition of small variant toggle wasn't working because 'auto' will not work with the transition, it need a fixed value.
I replaced it with `left: calc(var(--su16) + var(--su2) + var(--su1));`, animation works now.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).