### PR TITLE
feat(color): updated lower ramp

### DIFF
--- a/docs/.vuepress/theme/components/PageHeader.vue
+++ b/docs/.vuepress/theme/components/PageHeader.vue
@@ -10,7 +10,7 @@
         />
         <span
           v-if="frontmatter.new"
-          class="d-badge d-badge--purple-500"
+          class="d-badge d-badge--bulletin"
         >New</span>
       </div>
       <p

--- a/docs/_data/colors.json
+++ b/docs/_data/colors.json
@@ -74,14 +74,14 @@
         "stop": "100",
         "hex": "F5F0FF",
         "copy": "primary",
-        "contrast": "AAA 17.28",
+        "contrast": "AAA 18.79",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "DAC7FF",
         "copy": "primary",
-        "contrast": "AAA 12.4",
+        "contrast": "AAA 13.59",
         "primary": "no"
       },
       {
@@ -122,14 +122,14 @@
         "stop": "100",
         "hex": "FFE0F2",
         "copy": "primary",
-        "contrast": "AAA 10.6",
+        "contrast": "AAA 17.9",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "F985C7",
         "copy": "primary",
-        "contrast": "AA 6.92",
+        "contrast": "AA 9.2",
         "primary": "no"
       },
       {
@@ -202,14 +202,14 @@
         "stop": "100",
         "hex": "FFE5E6",
         "copy": "primary",
-        "contrast": "AAA 16.52",
+        "contrast": "AAA 17.6",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "FF8585",
         "copy": "primary",
-        "contrast": "AAA 8",
+        "contrast": "AAA 8.94",
         "primary": "no"
       },
       {
@@ -242,14 +242,14 @@
         "stop": "100",
         "hex": "EDF9EB",
         "copy": "primary",
-        "contrast": "AAA 18.01",
+        "contrast": "AAA 18.35",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "B0FFA3",
         "copy": "primary",
-        "contrast": "AAA 17.18",
+        "contrast": "AAA 17.67",
         "primary": "no"
       },
       {
@@ -282,14 +282,14 @@
         "stop": "100",
         "hex": "EAF2FA",
         "copy": "primary",
-        "contrast": "AAA 17.74",
+        "contrast": "AAA 18.57",
         "primary": "no"
       },
       {
         "stop": "200",
         "hex": "99C8FF",
         "copy": "primary",
-        "contrast": "AAA 10.7",
+        "contrast": "AAA 12.06",
         "primary": "no"
       },
       {

--- a/docs/_data/colors.json
+++ b/docs/_data/colors.json
@@ -1,53 +1,5 @@
 [
   {
-    "color": "purple",
-    "stops": [
-      {
-        "stop": "100",
-        "hex": "EEE5FF",
-        "copy": "primary",
-        "contrast": "AAA 17.28",
-        "primary": "no"
-      },
-      {
-        "stop": "200",
-        "hex": "D3BCFF",
-        "copy": "primary",
-        "contrast": "AAA 12.4",
-        "primary": "no"
-      },
-      {
-        "stop": "300",
-        "hex": "AB7EFF",
-        "copy": "primary",
-        "contrast": "AAA 7.15",
-        "primary": "no"
-      },
-      {
-        "stop": "400",
-        "hex": "7C52FF",
-        "copy": "white",
-        "contrast": "AA 4.65",
-        "darkContrast": "AA 4.5",
-        "primary": "yes"
-      },
-      {
-        "stop": "500",
-        "hex": "3A1D95",
-        "copy": "white",
-        "contrast": "AAA 11.73",
-        "primary": "no"
-      },
-      {
-        "stop": "600",
-        "hex": "10022C",
-        "copy": "white",
-        "contrast": "AAA 19.67",
-        "primary": "no"
-      }
-    ]
-  },
-  {
     "color": "black",
     "stops": [
       {
@@ -116,18 +68,66 @@
     ]
   },
   {
+    "color": "purple",
+    "stops": [
+      {
+        "stop": "100",
+        "hex": "F5F0FF",
+        "copy": "primary",
+        "contrast": "AAA 17.28",
+        "primary": "no"
+      },
+      {
+        "stop": "200",
+        "hex": "DAC7FF",
+        "copy": "primary",
+        "contrast": "AAA 12.4",
+        "primary": "no"
+      },
+      {
+        "stop": "300",
+        "hex": "AB7EFF",
+        "copy": "primary",
+        "contrast": "AAA 7.15",
+        "primary": "no"
+      },
+      {
+        "stop": "400",
+        "hex": "7C52FF",
+        "copy": "white",
+        "contrast": "AA 4.65",
+        "darkContrast": "AA 4.5",
+        "primary": "yes"
+      },
+      {
+        "stop": "500",
+        "hex": "3A1D95",
+        "copy": "white",
+        "contrast": "AAA 11.73",
+        "primary": "no"
+      },
+      {
+        "stop": "600",
+        "hex": "10022C",
+        "copy": "white",
+        "contrast": "AAA 19.67",
+        "primary": "no"
+      }
+    ]
+  },
+  {
     "color": "magenta",
     "stops": [
       {
         "stop": "100",
-        "hex": "FF97D2",
+        "hex": "FFE0F2",
         "copy": "primary",
         "contrast": "AAA 10.6",
         "primary": "no"
       },
       {
         "stop": "200",
-        "hex": "F756B1",
+        "hex": "F985C7",
         "copy": "primary",
         "contrast": "AA 6.92",
         "primary": "no"
@@ -160,14 +160,14 @@
     "stops": [
       {
         "stop": "100",
-        "hex": "FFE793",
+        "hex": "FFF4CC",
         "copy": "primary",
         "contrast": "AAA 17.1",
         "primary": "no"
       },
       {
         "stop": "200",
-        "hex": "FFD362",
+        "hex": "FFDB80",
         "copy": "primary",
         "contrast": "AAA 14.74",
         "primary": "no"
@@ -200,14 +200,14 @@
     "stops": [
       {
         "stop": "100",
-        "hex": "FFDCDC",
+        "hex": "FFE5E6",
         "copy": "primary",
         "contrast": "AAA 16.52",
         "primary": "no"
       },
       {
         "stop": "200",
-        "hex": "FF7474",
+        "hex": "FF8585",
         "copy": "primary",
         "contrast": "AAA 8",
         "primary": "no"
@@ -240,14 +240,14 @@
     "stops": [
       {
         "stop": "100",
-        "hex": "DDF4D9",
+        "hex": "EDF9EB",
         "copy": "primary",
         "contrast": "AAA 18.01",
         "primary": "no"
       },
       {
         "stop": "200",
-        "hex": "9FFF90",
+        "hex": "B0FFA3",
         "copy": "primary",
         "contrast": "AAA 17.18",
         "primary": "no"
@@ -280,14 +280,14 @@
     "stops": [
       {
         "stop": "100",
-        "hex": "E3EDF9",
+        "hex": "EAF2FA",
         "copy": "primary",
         "contrast": "AAA 17.74",
         "primary": "no"
       },
       {
         "stop": "200",
-        "hex": "84BDFF",
+        "hex": "99C8FF",
         "copy": "primary",
         "contrast": "AAA 10.7",
         "primary": "no"

--- a/docs/_data/colors.json
+++ b/docs/_data/colors.json
@@ -116,53 +116,6 @@
     ]
   },
   {
-    "color": "orange",
-    "stops": [
-      {
-        "stop": "100",
-        "hex": "FFF035",
-        "copy": "primary",
-        "contrast": "AAA 18.84",
-        "primary": "no"
-      },
-      {
-        "stop": "200",
-        "hex": "FFCCA7",
-        "copy": "primary",
-        "contrast": "AAA 14.44",
-        "primary": "no"
-      },
-      {
-        "stop": "300",
-        "hex": "FFA360",
-        "copy": "primary",
-        "contrast": "AAA 10.65",
-        "primary": "no"
-      },
-      {
-        "stop": "400",
-        "hex": "FF7F23",
-        "copy": "primary",
-        "contrast": "AAA 8.31",
-        "primary": "yes"
-      },
-      {
-        "stop": "500",
-        "hex": "E05E00",
-        "copy": "primary",
-        "contrast": "AA 5.77",
-        "primary": "no"
-      },
-      {
-        "stop": "600",
-        "hex": "43220A",
-        "copy": "white",
-        "contrast": "AAA 14.26",
-        "primary": "no"
-      }
-    ]
-  },
-  {
     "color": "magenta",
     "stops": [
       {

--- a/docs/assets/less/overrides.less
+++ b/docs/assets/less/overrides.less
@@ -116,20 +116,20 @@ samp {
 p.sidebar-item:not(.sidebar-heading) {
   // TODO hack until we have a custom method for tagging planned or otherwise inactive nav items
   display: flex;
-  align-items: center;
+  align-items: baseline;
+  justify-content: space-between;
   color: var(--fc-disabled);
   cursor: text;
   gap: var(--su4);
 
   &:after {
-    content: 'planned';
+    content: 'Planned';
+    color: var(--fc-secondary);
     background: var(--black-200);
     border-radius: var(--su4);
-    color: var(--fc-secondary);
-    font-size: 1.1rem;
-    font-weight: var(--n-font-weight-heading);
-    text-transform: uppercase;
-    padding: var(--su2) var(--su4);
+    font-size: var(--fs-100);
+    font-weight: var(--fw-semibold);
+    padding: var(--su4) var(--su8);
     line-height: 1;
   }
 }

--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -80,7 +80,7 @@ figma_url: https://www.figma.com/file/zz40wi0uW9MvaJ5RuhcRZR/DT-Core%3A-Icons-7?
         <inbox-icon :class="className" />
       </td>
       <td class="d-ta-right">
-        <span v-if="deviceOnly" class="d-badge d-mr8 d-mb8 d-badge">Device only</span>
+        <span v-if="deviceOnly" class="d-badge d-badge--warning">Device only</span>
       </td>
     </tr>
   </tbody>

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -20,12 +20,11 @@ prev:
     <div class="dialtone-wall__details">
       <div class="dialtone-wall__title">
         <span class="dialtone-wall__title-text">{frontmatter.title}</span>
-        <span class="d-badge d-badge d-bgc-green-100">{frontmatter.status}</span>
+        <span class="d-badge d-badge--{ALIGN_VARIANT_TO_TYPE}">{frontmatter.status}</span>
       </div>
       <div class="dialtone-wall__description">{frontmatter.desc}</div>
     </div>
   </router-link>
-
 -->
 
 <div class="dialtone-wall">
@@ -34,8 +33,8 @@ prev:
     <div class="dialtone-wall__details">
       <div class="dialtone-wall__title">
         <span class="dialtone-wall__title-text">Avatar</span>
-        <!-- <span class="d-badge d-badge d-bgc-green-100">Ready</span> -->
-        <!-- <span class="d-badge d-badge--purple-500">New</span> -->
+        <!-- <span class="d-badge">Ready</span> -->
+        <!-- <span class="d-badge">New</span> -->
       </div>
       <div class="dialtone-wall__description">An avatar is a visual representation of a user or object.</div>
     </div>

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -16,7 +16,7 @@ desc: The visual foundation that supports and unites Dialpad products.
     <div class="dialtone-wall__details">
       <div class="dialtone-wall__title">
         <span class="dialtone-wall__title-text">Typography</span>
-        <span class="d-badge d-badge d-badge--purple-500">Planned</span>
+        <span class="d-badge">Planned</span>
       </div>
       <div class="dialtone-wall__description">Guidance for clear, legible, and easy-to-read text.</div>
     </div>
@@ -49,7 +49,7 @@ desc: The visual foundation that supports and unites Dialpad products.
     <div class="dialtone-wall__details">
       <div class="dialtone-wall__title">
         <span class="dialtone-wall__title-text">Elevation</span>
-        <span class="d-badge d-badge d-badge--purple-500">Planned</span>
+        <span class="d-badge">Planned</span>
       </div>
       <div class="dialtone-wall__description">A layering system to give content blocks visual depth and prominence.</div>
     </div>
@@ -58,7 +58,7 @@ desc: The visual foundation that supports and unites Dialpad products.
     <div class="dialtone-wall__details">
       <div class="dialtone-wall__title">
         <span class="dialtone-wall__title-text">Motion</span>
-        <span class="d-badge d-badge d-badge--purple-500">Planned</span>
+        <span class="d-badge">Planned</span>
       </div>
       <div class="dialtone-wall__description">Expressive transitions to guide users through complex experiences.</div>
     </div>

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -20,7 +20,7 @@ prev:
     <div class="dialtone-wall__details">
       <div class="dialtone-wall__title">
         <span class="dialtone-wall__title-text">Design principles</span>
-        <span class="d-badge d-badge d-badge--purple-500">Planned</span>
+        <span class="d-badge">Planned</span>
       </div>
       <div class="dialtone-wall__description">The core values behind Dialpad's experiences.</div>
     </div>
@@ -45,7 +45,7 @@ prev:
     <div class="dialtone-wall__details">
       <div class="dialtone-wall__title">
         <span class="dialtone-wall__title-text">Brand</span>
-        <span class="d-badge d-badge d-badge--purple-500">Planned</span>
+        <span class="d-badge">Planned</span>
       </div>
       <div class="dialtone-wall__description">Details on Dialpad's identity and who we are as a company.</div>
     </div>
@@ -54,7 +54,7 @@ prev:
     <div class="dialtone-wall__details">
       <div class="dialtone-wall__title">
         <span class="dialtone-wall__title-text">Design assets</span>
-        <span class="d-badge d-badge d-badge--purple-500">Planned</span>
+        <span class="d-badge">Planned</span>
       </div>
       <div class="dialtone-wall__description">Figma toolkit of building blocks for exploration and collaboration.</div>
     </div>

--- a/docs/utilities/backgrounds/size.md
+++ b/docs/utilities/backgrounds/size.md
@@ -7,10 +7,10 @@ desc: Utilities for controlling an element's background size.
 
 Use `d-bgs-{n}` to control the size of element's background image.
 
-<code-well-header class="d-fl-col4 d-fw-wrap d-flg12 d-p12 d-bgc-orange-100 d-bgo50" custom>
+<code-well-header class="d-fl-col4 d-fw-wrap d-flg12 d-p12 d-bgc-black-200 d-bgo50" custom>
   <div class="d-d-flex d-fd-column d-ai-center d-stack4" v-for="i in sizes">
       <div
-        class="d-fl-center d-w128 d-h128 d-bgc-orange-300 d-bar8 d-bc-purple-200 d-of-hidden d-bgr-none"
+        class="d-fl-center d-w128 d-h128 d-bgc-magenta-200 d-bar8 d-bc-purple-200 d-of-hidden d-bgr-none"
         style="background-image: url('https://4.bp.blogspot.com/-EVbXg5iW6qY/ULcKZEC-bnI/AAAAAAAACCI/kZDtjeKwQlo/s1600/puffin1.jpg');"
         :style="i === 'var' ? '--bgg-size: 65% 65%;' : ''"
         :class="[{'d-bgp-center': i === 'auto'}, `d-bgs-${i}`]"

--- a/docs/utilities/borders/color.md
+++ b/docs/utilities/borders/color.md
@@ -25,29 +25,28 @@ Use `d-bco{n}` to change the border color opacity value. You can also change the
 , `:focus`, `:focus-visible`, or in dark mode by using the respective `h:d-bco{n}`, `f:d-bco{n}`, `fv:d-bco{n}`,
 or `d:d-bco{n}` prefixes.
 
-<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-orange-100 d-bgo50 d-w100p d-hmn102 d-stack8" custom>
-  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-orange-500 d-fs-200 d-fw-bold d-ff-mono">100%</div>
-  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-orange-500 d-bco99 d-fs-200 d-fw-bold">99%</div>
-  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-orange-500 d-bco95 d-fs-200 d-fw-bold">95%</div>
-  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-orange-500 d-bco90 d-fs-200 d-fw-bold">90%</div>
-  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-orange-500 d-bco75 d-fs-200 d-fw-bold">75%</div>
-  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-orange-500 d-bco50 d-fs-200 d-fw-bold">50%</div>
-  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-orange-500 d-bco25 d-fs-200 d-fw-bold">25%</div>
-  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-orange-500 d-bco10 d-fs-200 d-fw-bold">10%</div>
-  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-orange-500 d-bco0 d-fs-200 d-fw-bold">0%</div>
+<code-well-header class="d-d-flex d-jc-center d-fd-column d-p24 d-bgc-magenta-100 d-bgo50 d-w100p d-hmn102 d-stack8" custom>
+  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-magenta-300 d-fs-200 d-fw-bold d-ff-mono">100%</div>
+  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-magenta-300 d-bco99 d-fs-200 d-fw-bold">99%</div>
+  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-magenta-300 d-bco95 d-fs-200 d-fw-bold">95%</div>
+  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-magenta-300 d-bco90 d-fs-200 d-fw-bold">90%</div>
+  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-magenta-300 d-bco75 d-fs-200 d-fw-bold">75%</div>
+  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-magenta-300 d-bco50 d-fs-200 d-fw-bold">50%</div>
+  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-magenta-300 d-bco25 d-fs-200 d-fw-bold">25%</div>
+  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-magenta-300 d-bco10 d-fs-200 d-fw-bold">10%</div>
+  <div class="d-w100p d-p4 d-bb d-bbw2 d-bc-magenta-300 d-bco0 d-fs-200 d-fw-bold">0%</div>
 </code-well-header>
 
 ```html
-
-<div class="d-bb d-bbw2 d-bc-orange-500">...</div>
-<div class="d-bb d-bbw2 d-bc-orange-500 d-bco99">...</div>
-<div class="d-bb d-bbw2 d-bc-orange-500 d-bco95">...</div>
-<div class="d-bb d-bbw2 d-bc-orange-500 d-bco90">...</div>
-<div class="d-bb d-bbw2 d-bc-orange-500 d-bco75">...</div>
-<div class="d-bb d-bbw2 d-bc-orange-500 d-bco50">...</div>
-<div class="d-bb d-bbw2 d-bc-orange-500 d-bco25">...</div>
-<div class="d-bb d-bbw2 d-bc-orange-500 d-bco10">...</div>
-<div class="d-bb d-bbw2 d-bc-orange-500 d-bco0">...</div>
+<div class="d-bb d-bbw2 d-bc-magenta-300">...</div>
+<div class="d-bb d-bbw2 d-bc-magenta-300 d-bco99">...</div>
+<div class="d-bb d-bbw2 d-bc-magenta-300 d-bco95">...</div>
+<div class="d-bb d-bbw2 d-bc-magenta-300 d-bco90">...</div>
+<div class="d-bb d-bbw2 d-bc-magenta-300 d-bco75">...</div>
+<div class="d-bb d-bbw2 d-bc-magenta-300 d-bco50">...</div>
+<div class="d-bb d-bbw2 d-bc-magenta-300 d-bco25">...</div>
+<div class="d-bb d-bbw2 d-bc-magenta-300 d-bco10">...</div>
+<div class="d-bb d-bbw2 d-bc-magenta-300 d-bco0">...</div>
 ```
 
 ## Hover

--- a/docs/utilities/flex/align-content.md
+++ b/docs/utilities/flex/align-content.md
@@ -130,16 +130,16 @@ Use `d-ac-space-between` to distribute rows along the element's cross axis so th
 
 Use `d-ac-space-evenly` to distribute rows along the element's cross axis so that there is an equal amount of space on each side of the rows, but unlike `d-ac-space-around` the space visually looks evenly distributed between objects.
 
-<code-well-header bgclass="d-bgc-orange-100" >
-  <div class="d-fl-col3 d-fw-wrap d-flg16 d-ac-space-evenly d-p8 d-w100p d-hmn3 d-bar8 d-bgc-orange-100">
-    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-orange-300 d-bar4 d-fs-300 d-fw-bold">1</div>
-    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-orange-300 d-bar4 d-fs-300 d-fw-bold">2</div>
-    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-orange-300 d-bar4 d-fs-300 d-fw-bold">3</div>
-    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-orange-300 d-bar4 d-fs-300 d-fw-bold">4</div>
-    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-orange-300 d-bar4 d-fs-300 d-fw-bold">5</div>
-    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-orange-300 d-bar4 d-fs-300 d-fw-bold">6</div>
-    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-orange-300 d-bar4 d-fs-300 d-fw-bold">7</div>
-    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-orange-300 d-bar4 d-fs-300 d-fw-bold">8</div>
+<code-well-header bgclass="d-bgc-blue-100" >
+  <div class="d-fl-col3 d-fw-wrap d-flg16 d-ac-space-evenly d-p8 d-w100p d-hmn3 d-bar8 d-bgc-blue-100">
+    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-blue-300 d-bar4 d-fs-300 d-fw-bold">1</div>
+    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-blue-300 d-bar4 d-fs-300 d-fw-bold">2</div>
+    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-blue-300 d-bar4 d-fs-300 d-fw-bold">3</div>
+    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-blue-300 d-bar4 d-fs-300 d-fw-bold">4</div>
+    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-blue-300 d-bar4 d-fs-300 d-fw-bold">5</div>
+    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-blue-300 d-bar4 d-fs-300 d-fw-bold">6</div>
+    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-blue-300 d-bar4 d-fs-300 d-fw-bold">7</div>
+    <div class="d-fl-center d-m8 d-p16 d-h64 d-bgc-blue-300 d-bar4 d-fs-300 d-fw-bold">8</div>
   </div>
 </code-well-header>
 

--- a/docs/utilities/flex/direction-wrap-flow.md
+++ b/docs/utilities/flex/direction-wrap-flow.md
@@ -108,11 +108,11 @@ The `flex-flow` property is a shorthand property that sets allows you to quickly
   </tbody>
 </table>
 
-<code-well-header class="d-fl-center d-fd-column d-p24 d-bgc-orange-100 d-bgo50 d-w100p d-hmn216">
-  <div class="d-d-flex d-ff-row-reverse-wrap d-w100p d-bar8 d-bgc-orange-100">
-    <div class="d-fl-center d-m8 d-p16 d-w25p d-h64 d-bgc-orange-400 d-bar4 d-fs-300 d-fw-bold">1</div>
-    <div class="d-fl-center d-m8 d-p16 d-w50p d-h64 d-bgc-orange-400 d-bar4 d-fs-300 d-fw-bold">2</div>
-    <div class="d-fl-center d-m8 d-p16 d-w75p d-h64 d-bgc-orange-400 d-bar4 d-fs-300 d-fw-bold">3</div>
+<code-well-header class="d-fl-center d-fd-column d-p24 d-bgc-blue-100 d-bgo50 d-w100p d-hmn216">
+  <div class="d-d-flex d-ff-row-reverse-wrap d-w100p d-bar8 d-bgc-blue-200">
+    <div class="d-fl-center d-m8 d-p16 d-w25p d-h64 d-bgc-blue-400 d-bar4 d-fs-300 d-fw-bold">1</div>
+    <div class="d-fl-center d-m8 d-p16 d-w50p d-h64 d-bgc-blue-400 d-bar4 d-fs-300 d-fw-bold">2</div>
+    <div class="d-fl-center d-m8 d-p16 d-w75p d-h64 d-bgc-blue-400 d-bar4 d-fs-300 d-fw-bold">3</div>
   </div>
 </code-well-header>
 

--- a/docs/utilities/flex/justify.md
+++ b/docs/utilities/flex/justify.md
@@ -120,11 +120,11 @@ Use `d-jc-space-between` to justify items along the element's main axis so that 
 
 Use `d-jc-space-evenly` to justify items along the element's main axis so that there is an equal amount of space on each side of the item, but unlike `d-jc-space-around` visually evenly spaces objects.
 
-<code-well-header class="d-fl-center d-fd-column d-p24 d-bgc-orange-100 d-bgo50 d-w100p d-hmn102" custom>
-  <div class="d-d-flex d-jc-space-evenly d-w100p d-bar8 d-bgc-orange-100">
-    <div class="d-fl-center d-m8 d-p16 d-w64 d-h64 d-bgc-orange-300 d-bar4 d-fs-300 d-fw-bold">1</div>
-    <div class="d-fl-center d-m8 d-p16 d-w64 d-h64 d-bgc-orange-300 d-bar4 d-fs-300 d-fw-bold">2</div>
-    <div class="d-fl-center d-m8 d-p16 d-w64 d-h64 d-bgc-orange-300 d-bar4 d-fs-300 d-fw-bold">3</div>
+<code-well-header class="d-fl-center d-fd-column d-p24 d-bgc-blue-100 d-bgo50 d-w100p d-hmn102" custom>
+  <div class="d-d-flex d-jc-space-evenly d-w100p d-bar8 d-bgc-blue-200">
+    <div class="d-fl-center d-m8 d-p16 d-w64 d-h64 d-bgc-blue-300 d-bar4 d-fs-300 d-fw-bold">1</div>
+    <div class="d-fl-center d-m8 d-p16 d-w64 d-h64 d-bgc-blue-300 d-bar4 d-fs-300 d-fw-bold">2</div>
+    <div class="d-fl-center d-m8 d-p16 d-w64 d-h64 d-bgc-blue-300 d-bar4 d-fs-300 d-fw-bold">3</div>
   </div>
 </code-well-header>
 

--- a/docs/utilities/sizing/height.md
+++ b/docs/utilities/sizing/height.md
@@ -101,8 +101,8 @@ Use `d-h100vh` to have an element cover the user's viewport.
 
 Use `d-h-auto` have the browser calculate and select a height.
 
-<code-well-header class="d-ps-relative d-d-flex d-jc-center d-p24 d-bgc-orange-100 d-bgo50 d-w100p d-hmn216 d-flow16" custom>
-  <div class="d-fl-center d-py16 d-px8 d-w100p d-h-auto d-bgc-orange-300 d-bar4 d-fs-300 d-fw-bold d-ta-center">Auto</div>
+<code-well-header class="d-ps-relative d-d-flex d-jc-center d-p24 d-bgc-blue-100 d-bgo50 d-w100p d-hmn216 d-flow16" custom>
+  <div class="d-fl-center d-py16 d-px8 d-w100p d-h-auto d-bgc-blue-200 d-bar4 d-fs-300 d-fw-bold d-ta-center">Auto</div>
 </code-well-header>
 
 ```html

--- a/docs/utilities/sizing/width.md
+++ b/docs/utilities/sizing/width.md
@@ -94,8 +94,8 @@ Use `d-w100vh` to have an element cover the user's viewport.
 
 Use `d-w-auto` have the browser calculate and select a width.
 
-<code-well-header class="d-ps-relative d-d-flex d-jc-center d-p24 d-bgc-orange-100 d-bgo50 d-w100p d-hmn102 d-stack16" custom>
-  <div class="d-fl-center d-py16 d-px8 d-h72 d-w-auto d-bgc-orange-400 d-bar4 d-fs-300 d-fw-bold d-ta-center">Auto</div>
+<code-well-header class="d-ps-relative d-d-flex d-jc-center d-p24 d-bgc-blue-100 d-bgo50 d-w100p d-hmn102 d-stack16" custom>
+  <div class="d-fl-center d-py16 d-px8 d-h72 d-w-auto d-bgc-blue-200 d-bar4 d-fs-300 d-fw-bold d-ta-center">Auto</div>
 </code-well-header>
 
 ```html

--- a/docs/utilities/typography/whitespace.md
+++ b/docs/utilities/typography/whitespace.md
@@ -35,8 +35,8 @@ Use `d-ws-nowrap` to collapse an element's text whitespaces sequences, but line 
 
 Use `d-ws-pre` to preserve an element's whitespaces sequences. Lines are only broken at new line characters and `<br/>` elements.
 
-<code-well-header class="d-fl-center d-p24 d-bgc-orange-100 d-bgo50 d-w100p d-hmn102" custom>
-  <div class="d-bgc-orange-200 d-py8 d-px16 d-bar8 d-w216">
+<code-well-header class="d-fl-center d-p24 d-bgc-blue-100 d-bgo50 d-w100p d-hmn102" custom>
+  <div class="d-bgc-blue-200 d-py8 d-px16 d-bar8 d-w216">
     <p class="lg:d-fs-200 d-fs-200 d-ws-pre d-of-hidden">Lorem ipsum dolor sit amet, consectetur adipisicing elit.<br/>       Blanditiisitaquequodpraesentiumexplicaboincidunt?       Dolores beatae nam at sed dolorum ratione dolorem nisi velit dolor.</p>
   </div>
 </code-well-header>

--- a/docs/utilities/typography/whitespace.md
+++ b/docs/utilities/typography/whitespace.md
@@ -8,7 +8,7 @@ desc: Utilities for controlling an element's whitespace.
 Use `d-ws-normal` to collapse an element's text whitespaces sequences and newline characters are treated like whitespace. Lines are broken as needed to fill boxes.
 
 <code-well-header class="d-fl-center d-p24 d-bgc-green-100 d-bgo50 d-w100p d-hmn102" custom>
-  <div class="d-bgc-green-100 d-py8 d-px16 d-bar8 d-w216">
+  <div class="d-bgc-green-200 d-py8 d-px16 d-bar8 d-w216">
     <p class="lg:d-fs-200 d-fs-200 d-ws-normal">Lorem ipsum dolor sit amet, consectetur adipisicing elit.<br/>Blanditiisitaquequodpraesentium Dolores beatae nam at sed dolorum ratione dolorem nisi velit dolor.</p>
   </div>
 </code-well-header>

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -66,11 +66,11 @@
     theme-sidebar-active-row-color-hsl:               var(--black-900-h) var(--black-900-s) var(--black-900-l); // Use with d-fco[##] Opacity utility
     theme-sidebar-active-row-color-background:        #e9e9e9; // DT7 TBD, possibly black-100?
 
-    theme-presence-color-background-available:        var(--green-500);
-    theme-presence-color-background-busy-unavailable: var(--red-500);
+    theme-presence-color-background-available:        var(--green-400);
+    theme-presence-color-background-busy-unavailable: var(--red-300);
     theme-presence-color-background-busy:             var(--gold-300);
 
-    theme-mention-color-background:                   var(--purple-500);
+    theme-mention-color-background:                   var(--purple-400);
 }
 
 //  ============================================================================

--- a/lib/build/less/variables/colors.less
+++ b/lib/build/less/variables/colors.less
@@ -24,8 +24,8 @@
 @black-800:                     #222222;
 @black-900:                     #000000;
 
-@purple-100:                    #EEE5FF;
-@purple-200:                    #D3BCFF;
+@purple-100:                    #F5F0FF;
+@purple-200:                    #DAC7FF;
 @purple-300:                    #AB7EFF;
 @purple-400:                    #7C52FF;
 @purple-500:                    #3A1D95;
@@ -38,32 +38,32 @@
 @orange-500:                    #E05E00;
 @orange-600:                    #43220A;
 
-@magenta-100:                   #FF97D2;
-@magenta-200:                   #F756B1;
+@magenta-100:                   #FFE0F2;
+@magenta-200:                   #F985C7;
 @magenta-300:                   #F9008E;
 @magenta-400:                   #8C0E56;
 @magenta-500:                   #541A3B;
 
-@gold-100:                      #FFE793;
-@gold-200:                      #FFD362;
+@gold-100:                      #FFF4CC;
+@gold-200:                      #FFDB80;
 @gold-300:                      #F6AB3C;
 @gold-400:                      #D28F2B;
 @gold-500:                      #815008;
 
-@green-100:                     #DDF4D9;
-@green-200:                     #9FFF90;
+@green-100:                     #EDF9EB;
+@green-200:                     #B0FFA3;
 @green-300:                     #45F777;
 @green-400:                     #1AA340;
 @green-500:                     #124620;
 
-@red-100:                       #FFDCDC;
-@red-200:                       #FF7474;
+@red-100:                       #FFE5E6;
+@red-200:                       #FF8585;
 @red-300:                       #FF2E2E;
 @red-400:                       #A41111;
 @red-500:                       #540000;
 
-@blue-100:                      #E3EDF9;
-@blue-200:                      #84BDFF;
+@blue-100:                      #EAF2FA;
+@blue-200:                      #99C8FF;
 @blue-300:                      #51A0FE;
 @blue-400:                      #1768C6;
 @blue-500:                      #01326D;


### PR DESCRIPTION
## Description

* `100` and `200` stops updated for base colors Purple, Magenta, Gold, Green, Red, Blue.
* Warning, Error, Success surface colors updated with new `100` and `200` base colors.
* Removed Orange colors used in doc site.
* Corrected theme mention and presence colors.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

![image](https://user-images.githubusercontent.com/1165933/205970340-9c290f5e-ea5d-4461-a702-e28f8ae4ad76.png)

