### PR TITLE
fix(badge): add box-sizing: border-box

### DIFF
--- a/lib/build/less/components/badge.less
+++ b/lib/build/less/components/badge.less
@@ -39,6 +39,7 @@
   gap: var(--badge-gap);
   align-items: center;
   justify-content: center;
+  box-sizing: border-box;
   min-width: calc(var(--size-400) + var(--size-500));
   padding: var(--badge-padding-y) var(--badge-padding-x);
   color: var(--badge-color-text);


### PR DESCRIPTION
## Description
Because the docsite has border-box set universally this problem wasn't noticed on dialpad.design, but rendering a count badge on dialtone-vue storybook caused problems with width like so:

**BEFORE**
![Screenshot 2022-12-06 at 2 26 40 PM](https://user-images.githubusercontent.com/64808812/206037224-3b24f906-be99-4ebd-9409-8b041113d896.png)

**AFTER**
![Screenshot 2022-12-06 at 2 29 33 PM](https://user-images.githubusercontent.com/64808812/206037683-e1f8d2c8-b1c7-4269-a156-ae8c1d87d0f1.png)

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/Op1ngeWGVZtPaj0xrr/giphy.gif)
