### PR TITLE
docs(badge): add badge to migration guide, and blog post

### DIFF
--- a/docs/about/whats_new/posts/2022-12-9.md
+++ b/docs/about/whats_new/posts/2022-12-9.md
@@ -1,0 +1,187 @@
+---
+heading: Badge update - breaking change
+author: Brad Paugh
+posted: '2022-12-9'
+---
+<!-- Note the date must be in this format YYYY-M-D and wrapped in single quotes -->
+
+<BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">
+
+Hello and happy Friday to you all as we approach the holiday season! :christmas_tree: :menorah:
+
+We'll be performing a number of redesigns to existing Dialtone components over the coming months. Some of these updates may involve breaking changes to existing Vue components and Dialtone classes. Today's update involves badge which we have just reworked for better styling, functionality and convenience.
+
+- [Badge](https://dialpad.design/components/badge.html)
+- [Badge Vue Component](https://vue.dialpad.design/?path=/story/components-badge--default)
+
+## Badge
+
+The recent updates to badge cause breaking changes in Dialtone v7.9.0 and Dialtone Vue v2.43.0 and Dialtone Vue 3 v3.29.0
+
+The migration has been performed for all existing `DtBadge` components and `d-badge` classes in Dialpad and Dialpad Meetings. However if you have an existing feature branch or are in a project outside of Dialpad / Dialpad Meetings that involves badge, the changes will not have been made there so you'll have to make the updates yourself. If you need to do this, please follow the badge section of the [migration guide](https://github.com/dialpad/dialtone/blob/staging/migration_guide/MIGRATION_GUIDE.md#badge).
+
+### Label
+
+<code-well-header>
+  <div>
+    <div class="d-d-flex d-gg8 d-ai-center">
+      <span class="d-badge">Co-host</span>
+      <span class="d-badge">Customer</span>
+      <span class="d-badge">
+        <span class="d-badge__icon-left">
+          <dt-icon name="lock" size="200"/>
+        </span>
+        <span class="d-badge__label">Locked</span>
+        </span>
+      <span class="d-badge">
+        <span class="d-badge__icon-left">
+          <dt-icon name="message" size="200"/>
+        </span>
+        <span class="d-badge__label">Chat log</span>
+      </span>
+    </div>
+  </div>
+  <div>
+    <div class="d-d-flex d-gg8 d-ai-center">
+      <span class="d-badge d-badge--info"><span class="d-badge__label">In progress</span></span>
+      <span class="d-badge d-badge--info"><span class="d-badge__label">Beta</span></span>
+      <span class="d-badge d-badge--info"><span class="d-badge__label">Draft</span></span>
+    </div>
+  </div>
+  <div>
+    <div class="d-d-flex d-gg8 d-ai-center">
+      <span class="d-badge d-badge--warning"><span class="d-badge__label">Overdue</span></span>
+    </div>
+  </div>
+  <div>
+    <div class="d-d-flex d-gg8 d-ai-center">
+      <span class="d-badge d-badge--success"><span class="d-badge__label">Resolved</span></span>
+    </div>
+  </div>
+  <div>
+    <div class="d-d-flex d-gg8 d-ai-center">
+      <span class="d-badge d-badge--critical">
+        <span class="d-badge__icon-left">
+          <dt-icon name="record-filled" size="200"/>
+        </span>
+        <span class="d-badge__label">Recording</span>
+      </span>
+    </div>
+  </div>
+  <div>
+    <div class="d-d-flex d-gg8 d-ai-center">
+      <span class="d-badge d-badge--bulletin"><span class="d-badge__label">Live</span></span>
+      <span class="d-badge d-badge--bulletin"><span class="d-badge__label">Presenter</span></span>
+    </div>
+  </div>
+  <div>
+    <div class="d-d-flex d-gg8 d-ai-center">
+      <span class="d-badge d-badge--ai">
+        <span class="d-badge__icon-left">
+          <dt-icon name="dialpad-ai" size="200"/>
+        </span>
+        <span class="d-vi-visible-sr">Ai</span>
+        <span class="d-badge__label">Notes</span>
+      </span>
+      <span class="d-badge d-badge--ai">
+        <span class="d-badge__icon-left">
+          <dt-icon name="dialpad-ai" size="200"/>
+        </span>
+        <span class="d-vi-visible-sr">Ai</span>
+        <span class="d-badge__label">Suggestion</span>
+      </span>
+      <span class="d-badge d-badge--ai">
+        <span class="d-badge__icon-left">
+          <dt-icon name="dialpad-ai" size="200"/>
+        </span>
+        <span class="d-vi-visible-sr">Ai</span>
+        <span class="d-badge__label">enabled</span>
+      </span>
+      <span class="d-badge d-badge--ai">
+        <span class="d-badge__icon-left">
+          <dt-icon name="dialpad-ai" size="200"/>
+        </span>
+        <span class="d-vi-visible-sr">Ai</span>
+        <span class="d-badge__label">Transcript</span>
+      </span>
+    </div>
+  </div>
+</code-well-header>
+
+### Count
+
+<code-well-header>
+  <div>
+    <div class="d-d-flex d-gg8 d-ai-center">
+      <span class="d-badge d-badge--count d-badge--success">
+        <span class="d-badge__icon-left">
+          <dt-icon name="arrow-up" size="200"/>
+        </span>
+        <span class="d-badge__label">5%</span>
+      </span>
+    </div>
+  </div>
+  <div>
+    <div class="d-d-flex d-gg8 d-ai-center">
+      <span class="d-badge d-badge--count d-badge--critical">
+        <span class="d-badge__icon-left">
+          <dt-icon name="arrow-down" size="200"/>
+        </span>
+        <span class="d-badge__label">-12%</span>
+      </span>
+    </div>
+  </div>
+  <div>
+    <div class="d-d-flex d-gg8 d-ai-center">
+      <span class="d-badge d-badge--count d-badge--bulletin"><span class="d-badge__label">1</span></span>
+      <span class="d-badge d-badge--count d-badge--bulletin"><span class="d-badge__label">18</span></span>
+      <span class="d-badge d-badge--count d-badge--bulletin"><span class="d-badge__label">99+</span></span>
+    </div>
+  </div>
+</code-well-header>
+
+### Styling & documentation changes
+
+- Visual styling updates.
+- You no longer set a badge to a specific color, you set it to a "type" with a specific semantic intent. See [badge documenatation](https://dialpad.design/components/badge.html#type) for all the possible types.
+- Two different kinds of badge "label" which is meant for alphanumeric text and "count" which makes the badge circular and is intended for numerical text only.
+- Improved documentation for badge usage and best practices.
+- Support for icons on either side of the badge.
+
+### Vue component changes
+
+- New iconLeft and iconRight prop on the vue component. pass in any icon name from the [icon catalog](https://dialpad.design/components/icon.html) to set the icon.
+- New prop "kind", set to "label" or "count".
+- New prop "type", replaces "color".
+- Special case: setting the type to 'ai' will automatically display the AI icon on the left. This can be overridden if desired by setting the iconLeft prop.
+
+## Avatar
+
+We have also made some updates to the avatar component. You'll notice that when you use the component in initials or icon mode it will now display a randomly generated gradient for the background using multiple colors:
+
+<code-well-header>
+  <dt-avatar>BP</dt-avatar>
+</code-well-header>
+
+Very fancy!! :monocle_face: Thanks to Francis and Jose for this one.
+
+The new presence component has also been released and is integrated into the Avatar. You'll notice there is a new prop on the [Vue component](https://vue.dialpad.design/?path=/story/components-avatar--default) called presence in which you can set the presence state for the avatar.
+
+<code-well-header>
+  <dt-avatar presence="away">BP</dt-avatar>
+</code-well-header>
+
+# Combobox
+
+You may have noticed that while our input component had a label on it, none of our combobox components which use input had labels, or had any way of setting the label.
+
+All combobox components now have a required label prop. You do not have to set a label that shows up visually, but if you don't then you still have to label it for screenreaders. You can do so by setting the label prop and then setting the labelVisible prop to `false` in which case the aria-label will still be set even if it is not shown visually.
+
+That's all for today have a great weekend all!
+
+</BlogPost>
+
+<script setup>
+import BlogPost from '@baseComponents/BlogPost.vue';
+import { parse } from 'date-fns';
+</script>

--- a/docs/about/whats_new/posts/2022-12-9.md
+++ b/docs/about/whats_new/posts/2022-12-9.md
@@ -20,7 +20,27 @@ The recent updates to badge cause breaking changes in Dialtone v7.9.0 and Dialto
 
 The migration has been performed for all existing `DtBadge` components and `d-badge` classes in Dialpad and Dialpad Meetings. However if you have an existing feature branch or are in a project outside of Dialpad / Dialpad Meetings that involves badge, the changes will not have been made there so you'll have to make the updates yourself. If you need to do this, please follow the badge section of the [migration guide](https://github.com/dialpad/dialtone/blob/staging/migration_guide/MIGRATION_GUIDE.md#badge).
 
-### Label
+### Variants
+
+<code-well-header>
+<div class="d-d-flex d-gg8 d-ai-center">
+  <dt-badge text="Default" />
+  <dt-badge type="info" text="Info" />
+  <dt-badge type="success" text="Success" />
+  <dt-badge type="warning" text="Warning" />
+  <dt-badge type="critical" text="Critical" />
+  <dt-badge type="bulletin" text="Bulletin" />
+  <dt-badge type="ai" text="Ai" />
+  <dt-badge kind="count" text="1" />
+  <dt-badge kind="count" type="info" text="1" />
+  <dt-badge kind="count" type="success" text="1" />
+  <dt-badge kind="count" type="warning" text="1" />
+  <dt-badge kind="count" type="critical" text="1" />
+  <dt-badge kind="count" type="bulletin" text="1" />
+</div>
+</code-well-header>
+
+### Label Badge Examples
 
 <code-well-header>
   <div>
@@ -108,7 +128,7 @@ The migration has been performed for all existing `DtBadge` components and `d-ba
   </div>
 </code-well-header>
 
-### Count
+### Count Badge Examples
 
 <code-well-header>
   <div>

--- a/migration_guide/MIGRATION_GUIDE.md
+++ b/migration_guide/MIGRATION_GUIDE.md
@@ -545,7 +545,7 @@ The "color" prop has been removed from the DtBadge component and replaced with "
 
 ##### Styling
 
-All `d-badge` color classes are no longer valid and will have to be replaced with a "type" class. There is no direct mapping for this so you'll have to decided which works best on a case by case basis. Speak with your designer if you are unsure.
+The previous d-badge color classes are no longer valid and will have to be replaced with a "type" class. There is no direct mapping guide, as the previous use of badge colors may not imply which updated type to use. Use your judgment on a case-by-case basis and validate with your Product Designer.
 
 Classes removed:
 

--- a/migration_guide/MIGRATION_GUIDE.md
+++ b/migration_guide/MIGRATION_GUIDE.md
@@ -490,28 +490,28 @@ Search for | Replace with
 #### Replace icons
 
 Do a search in [Icon docs][icon-docs] to find an icon that matches your needs.
-For icon component documentation on props (naming and sizing), check 
+For icon component documentation on props (naming and sizing), check
 [Dialtone Vue - Icon component](https://vue.dialpad.design/?path=/story/components-icon--default)
 
 *Check with your designer or ask in #dialtone if you are having trouble finding a replacement for an existing icon*
 
-**If you can use vue components**: 
+**If you can use vue components**:
 
 Replace any custom usage of icon component with `<dt-icon name="icon-name" size="icon-size" />`
 
 **If you can't use vue component e.g. in backbone**:
 
-Replace the current `img` or `svg` with the RAW svg file content from `@dialpad/dialtone-icons/dist/svg/icon-name.svg`. 
+Replace the current `img` or `svg` with the RAW svg file content from `@dialpad/dialtone-icons/dist/svg/icon-name.svg`.
 e.g. replace `<img src="@dialpad/dialtone/lib/build/svg/user.svg">`
 with `<svg>...</svg>`
 
 #### Update Icon contextual sizing with fixed
 
 Some `svgs` are sized with `d-svg--sizeX` this are direct mappings that work in most of the cases.
-After replacing make sure the updated icon includes `d-icon` class too and that it looks correct. 
+After replacing make sure the updated icon includes `d-icon` class too and that it looks correct.
 
-e.g. replace `d-svg--size14` with `d-icon d-icon--size-100` 
-and `d-svg d-svg--size14` with `d-icon d-icon--size-100`.  
+e.g. replace `d-svg--size14` with `d-icon d-icon--size-100`
+and `d-svg d-svg--size14` with `d-icon d-icon--size-100`.
 
 Search for | Replace with
 :-:|:-:
@@ -531,7 +531,48 @@ Remove any usage of `d-svg` and `d-svg--*`.
 
 #### Product custom CSS
 
-Remove any custom icon sizing e.g. `.foo .icon { width: xxx; height: yyy; }.` 
+Remove any custom icon sizing e.g. `.foo .icon { width: xxx; height: yyy; }.`
 and replace with the correct sizing class in [icon documentation][icon-docs].
 
 [icon-docs]: https://dialpad.design/components/icon.html
+
+
+#### Badge
+
+##### DtBadge Vue Component
+
+The "color" prop has been removed from the DtBadge component and replaced with "type".
+
+##### Styling
+
+All `d-badge` color classes are no longer valid and will have to be replaced with a "type" class. There is no direct mapping for this so you'll have to decided which works best on a case by case basis. Speak with your designer if you are unsure.
+
+Classes removed:
+
+```
+d-badge--white
+d-badge--black-700
+d-badge--purple-100
+d-badge--purple-300
+d-badge--purple-400
+d-badge--purple-500
+d-badge--orange-400
+d-badge--magenta-100
+d-badge--magenta-300
+d-badge--magenta-400
+d-badge--magenta-500
+d-badge--gold-200
+d-badge--green-400
+d-badge--red-300
+```
+
+Replaced with:
+
+```
+d-badge--info
+d-badge--success
+d-badge--warning
+d-badge--critical
+d-badge--bulletin
+d-badge--ai
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@dialpad/conventional-changelog-angular": "^1.0.0",
         "@dialpad/dialtone-combinator": "^0.3.1",
         "@dialpad/dialtone-icons": "^0.0.14-vue3",
-        "@dialpad/dialtone-vue": "^3.27.0",
+        "@dialpad/dialtone-vue": "^3.29.0",
         "@dialpad/postcss-responsive-variations": "^1.1.3",
         "@docsearch/js": "^3.3.0",
         "@semantic-release/changelog": "^6.0.1",
@@ -988,15 +988,12 @@
       }
     },
     "node_modules/@dialpad/dialtone": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.8.1.tgz",
-      "integrity": "sha512-IqEYcdMD2YXqQ/ZJ//0i5kkpXJyFw5TAqdD9twRjaQHlv1wtPmCNbgVmcap5IerLXMWn4mec6TctUAdYrAm6gg==",
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.10.2.tgz",
+      "integrity": "sha512-OmcHzDT85wLATBM3NBm0C2vDZMWvzVUqoq5pqjqgfLUvcNmYb/ikx6+WdqXm/VnU5TWzdvDTIa4DZefJLTXhvw==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@dialpad/dialtone-icons": "0.0.7-vue3",
-        "@docsearch/js": "^3.2.1",
-        "date-fns": "^2.29.3",
         "docopt": "^0.6.2",
         "precss": "^4.0.0"
       },
@@ -1024,12 +1021,12 @@
       }
     },
     "node_modules/@dialpad/dialtone-vue": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.27.0.tgz",
-      "integrity": "sha512-KxN+ZfRoq+XunDDFqLoK9HiMVJLpyM5ZvorNm5P4xTmDJdja+Qf3BtB14Y5qsbRKSEp/4d1rln0C55l15KFb6Q==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.29.0.tgz",
+      "integrity": "sha512-58BewFTbY/JsIVPpvLAnqqq1JUbev0ornCJKQT6x26BMAPq1DDLYzWyAMX1f9Bxel5Rq2gSdRRjOWy4igtaQuQ==",
       "dev": true,
       "dependencies": {
-        "@dialpad/dialtone-icons": "^0.0.14-vue3",
+        "@dialpad/dialtone-icons": "0.0.14-vue3",
         "emoji-regex": "^10.1.0",
         "emoji-toolkit": "^6.6.0",
         "tippy.js": "^6.3.7"
@@ -1038,21 +1035,7 @@
         "node": ">= 16"
       },
       "peerDependencies": {
-        "@dialpad/dialtone": ">=7.8",
-        "vue": ">=3.2"
-      }
-    },
-    "node_modules/@dialpad/dialtone/node_modules/@dialpad/dialtone-icons": {
-      "version": "0.0.7-vue3",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.7-vue3.tgz",
-      "integrity": "sha512-vvBG1XzRXpoxtTwZyrjGGAqBAGERHfZUu9vP38aZcWPxNbsSjKXJgwC7wbvnhX6j+y6/ltxeykjuygohbGBe+w==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "core-js": "^3.8.3",
-        "vue": "^3.2.41"
-      },
-      "peerDependencies": {
+        "@dialpad/dialtone": ">=7.10",
         "vue": ">=3.2"
       }
     },
@@ -29752,30 +29735,14 @@
       }
     },
     "@dialpad/dialtone": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.8.1.tgz",
-      "integrity": "sha512-IqEYcdMD2YXqQ/ZJ//0i5kkpXJyFw5TAqdD9twRjaQHlv1wtPmCNbgVmcap5IerLXMWn4mec6TctUAdYrAm6gg==",
+      "version": "7.10.2",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone/-/dialtone-7.10.2.tgz",
+      "integrity": "sha512-OmcHzDT85wLATBM3NBm0C2vDZMWvzVUqoq5pqjqgfLUvcNmYb/ikx6+WdqXm/VnU5TWzdvDTIa4DZefJLTXhvw==",
       "dev": true,
       "peer": true,
       "requires": {
-        "@dialpad/dialtone-icons": "0.0.7-vue3",
-        "@docsearch/js": "^3.2.1",
-        "date-fns": "^2.29.3",
         "docopt": "^0.6.2",
         "precss": "^4.0.0"
-      },
-      "dependencies": {
-        "@dialpad/dialtone-icons": {
-          "version": "0.0.7-vue3",
-          "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-0.0.7-vue3.tgz",
-          "integrity": "sha512-vvBG1XzRXpoxtTwZyrjGGAqBAGERHfZUu9vP38aZcWPxNbsSjKXJgwC7wbvnhX6j+y6/ltxeykjuygohbGBe+w==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "core-js": "^3.8.3",
-            "vue": "^3.2.41"
-          }
-        }
       }
     },
     "@dialpad/dialtone-combinator": {
@@ -29795,12 +29762,12 @@
       }
     },
     "@dialpad/dialtone-vue": {
-      "version": "3.27.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.27.0.tgz",
-      "integrity": "sha512-KxN+ZfRoq+XunDDFqLoK9HiMVJLpyM5ZvorNm5P4xTmDJdja+Qf3BtB14Y5qsbRKSEp/4d1rln0C55l15KFb6Q==",
+      "version": "3.29.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.29.0.tgz",
+      "integrity": "sha512-58BewFTbY/JsIVPpvLAnqqq1JUbev0ornCJKQT6x26BMAPq1DDLYzWyAMX1f9Bxel5Rq2gSdRRjOWy4igtaQuQ==",
       "dev": true,
       "requires": {
-        "@dialpad/dialtone-icons": "^0.0.14-vue3",
+        "@dialpad/dialtone-icons": "0.0.14-vue3",
         "emoji-regex": "^10.1.0",
         "emoji-toolkit": "^6.6.0",
         "tippy.js": "^6.3.7"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@dialpad/conventional-changelog-angular": "^1.0.0",
     "@dialpad/dialtone-combinator": "^0.3.1",
     "@dialpad/dialtone-icons": "^0.0.14-vue3",
-    "@dialpad/dialtone-vue": "^3.27.0",
+    "@dialpad/dialtone-vue": "^3.29.0",
     "@dialpad/postcss-responsive-variations": "^1.1.3",
     "@docsearch/js": "^3.3.0",
     "@semantic-release/changelog": "^6.0.1",


### PR DESCRIPTION
Adding the recent badge breaking changes to the migration guide and wrote a blog post on some of our new updates.