### PR TITLE
fix: popover background

### DIFF
--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -6,7 +6,8 @@ thumb: true
 storybook_url: https://vue.dialpad.design/?path=/story/components-popover--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8921%3A22411&viewport=831%2C-269%2C0.43&t=xHutRjwo1o5zMTgT-11
 ---
-<code-well-header>
+
+<code-well-header bgclass="d-bgc-white">
   <example-popover modal />
 </code-well-header>
 
@@ -57,7 +58,7 @@ Your popover should be non-modal when:
 
 ### Popover - Modal
 
-<code-well-header>
+<code-well-header bgclass="d-bgc-white">
   <example-popover modal />
 </code-well-header>
 
@@ -76,7 +77,7 @@ Your popover should be non-modal when:
 
 ### Popover - Non Modal
 
-<code-well-header>
+<code-well-header bgclass="d-bgc-white">
   <example-popover />
 </code-well-header>
 
@@ -94,7 +95,7 @@ Your popover should be non-modal when:
 
 ### With Header - Modal
 
-<code-well-header>
+<code-well-header bgclass="d-bgc-white">
   <example-popover modal header>
     <template #content>
       Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae.Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae.<br>
@@ -122,7 +123,7 @@ Your popover should be non-modal when:
 
 ### With Footer - Modal
 
-<code-well-header>
+<code-well-header bgclass="d-bgc-white">
   <example-popover modal footer>
     <template #content>
       Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae.Lorem ipsum dolor sit amet, consectetur adipisicing elit. Consequuntur delectus distinctio id iure labore, maiores mollitia reprehenderit sunt tempore veritatis. Aliquam delectus earum ex, expedita ipsam nobis obcaecati quibusdam repudiandae.<br>

--- a/lib/build/less/components/popover.less
+++ b/lib/build/less/components/popover.less
@@ -40,6 +40,7 @@
     display: grid;
     grid-template-rows: 1fr;
     overflow: auto;
+    background-color: var(--popover-color-background);
     border-radius: var(--popover-border-radius);
     box-shadow: var(--popover-shadow);
 


### PR DESCRIPTION
## Description

Recent restyle for Popover component omitted background color, which thankfully isn't yet in Dialtone Vue.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

<img width="822" alt="image" src="https://user-images.githubusercontent.com/1165933/210657351-e2900415-de1e-476f-acd0-ee8f0c8cf64f.png">

