### PR TITLE
fix: missing popover css vars

### DIFF
--- a/lib/build/less/components/popover.less
+++ b/lib/build/less/components/popover.less
@@ -14,23 +14,25 @@
 //    - Content
 //    - Header / Footer
 
+//  $  CSS CUSTOM PROPERTIES
+//  ----------------------------------------------------------------------------
+body {
+  --popover-color-background: var(--black-100);
+  --popover-border-width: var(--size-100); // 8
+  --popover-border-radius: var(--size-400);
+  --popover-color-shadow: hsla(var(--black-900-hsl) ~' / ' 10%);
+  --popover-color-border: var(--popover-color-shadow);
+  --popover-shadow: 0 0 0 1px var(--popover-color-shadow), var(--bs-card);
+}
 
 //  $  POPOVER
 //  ----------------------------------------------------------------------------
 .d-popover {
-  //  $  CSS CUSTOM PROPERTIES
-  //  ----------------------------------------------------------------------------
 
 
   //  $  POPOVER DIALOG
   //  ----------------------------------------------------------------------------
   &__dialog {
-    --popover-color-background: var(--black-100);
-    --popover-border-width: var(--size-100); // 8
-    --popover-border-radius: var(--size-400);
-    --popover-color-shadow: hsla(var(--black-900-hsl) ~' / ' 10%);
-    --popover-shadow: 0 0 0 1px var(--popover-color-shadow), var(--bs-card);
-
     &,
     *,
     *::before,

--- a/lib/build/less/components/popover.less
+++ b/lib/build/less/components/popover.less
@@ -21,15 +21,16 @@
   //  $  CSS CUSTOM PROPERTIES
   //  ----------------------------------------------------------------------------
 
-  --popover-color-background: var(--black-100);
-  --popover-border-width: var(--size-100); // 8
-  --popover-border-radius: var(--size-400);
-  --popover-color-shadow: hsla(var(--black-900-hsl) ~' / ' 10%);
-  --popover-shadow: 0 0 0 1px var(--popover-color-shadow), var(--bs-card);
 
   //  $  POPOVER DIALOG
   //  ----------------------------------------------------------------------------
   &__dialog {
+    --popover-color-background: var(--black-100);
+    --popover-border-width: var(--size-100); // 8
+    --popover-border-radius: var(--size-400);
+    --popover-color-shadow: hsla(var(--black-900-hsl) ~' / ' 10%);
+    --popover-shadow: 0 0 0 1px var(--popover-color-shadow), var(--bs-card);
+
     &,
     *,
     *::before,


### PR DESCRIPTION
## Description
Fixes https://dialpad.atlassian.net/browse/DT-869

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

[DT-869]: https://dialpad.atlassian.net/browse/DT-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ