### PR TITLE
fix(button): suppress hover active on disabled buttons

### DIFF
--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -79,14 +79,14 @@
 
     //  --  STATES
     //  ------------------------------------------------------------------------
-    &:hover {
+    &:hover:not([disabled]) {
         --button-color-text: hsl(var(--purple-400-h) var(--purple-400-s) calc(var(--purple-400-l) - 10%));
         --button-color-background: hsla(var(--purple-400-hsl) ~' / ' 4%);
     }
 
-    &:active,
-    &.d-btn--active,
-    &.d-btn--active:active {
+    &:active:not([disabled]),
+    &.d-btn--active:not([disabled]),
+    &.d-btn--active:active:not([disabled]) {
         --button-color-text: hsl(var(--purple-400-h) var(--purple-400-s) calc(var(--purple-400-l) - 10%));
         --button-color-background: hsla(var(--purple-400-hsl) ~' / ' 14%);
     }
@@ -240,14 +240,14 @@
 
     transition-duration: 150ms;
 
-    &:hover {
+    &:hover:not([disabled]) {
         --button-color-text: var(--muted-color-hover);
         --button-color-background: hsla(var(--black-800-hsl) ~' / ' 3%);
     }
 
-    &:active,
-    &.d-btn--active,
-    &.d-btn--active:active {
+    &:active:not([disabled]),
+    &.d-btn--active:not([disabled]),
+    &.d-btn--active:active:not([disabled]) {
         --button-color-text: var(--muted-color-hover);
         --button-color-background: hsla(var(--black-800-hsl) ~' / ' 9%);
     }
@@ -307,14 +307,14 @@
     --button-color-text: var(--white);
     --button-color-background: var(--purple-400);
 
-    &:hover {
+    &:hover:not([disabled]) {
       --button-color-text: var(--white);
       --button-color-background: hsl(var(--purple-400-h), var(--purple-400-s), calc(var(--purple-400-l) - 6%));
     }
 
-    &:active,
-    &.d-btn--active,
-    &.d-btn--active:active {
+    &:active:not([disabled]),
+    &.d-btn--active:not([disabled]),
+    &.d-btn--active:active:not([disabled]) {
       --button-color-text: var(--white);
       --button-color-background: hsl(var(--purple-400-h), var(--purple-400-s), calc(var(--purple-400-l) - 12%));
     }
@@ -325,14 +325,14 @@
 .d-btn--muted {
     --button-color-text: var(--muted-color);
 
-    &:hover {
+    &:hover:not([disabled]) {
         --button-color-text: var(--muted-color-hover);
         --button-color-background: hsla(var(--black-800-hsl) ~' / ' 5%);
     }
 
-    &:active,
-    &.d-btn--active,
-    &.d-btn--active:active {
+    &:active:not([disabled]),
+    &.d-btn--active:not([disabled]),
+    &.d-btn--active:active:not([disabled]) {
         --button-color-text: var(--muted-color-hover);
         --button-color-background: hsla(var(--black-800-hsl) ~' / ' 10%);
     }
@@ -351,14 +351,14 @@
 .d-btn--danger {
     --button-color-text: var(--error-color);
 
-    &:hover {
+    &:hover:not([disabled]) {
         --button-color-text: var(--error-color-hover);
         --button-color-background: hsla(var(--error-color-hsl) ~' / ' 3%);
     }
 
-    &:active,
-    &.d-btn--active,
-    &.d-btn--active:active {
+    &:active:not([disabled]),
+    &.d-btn--active:not([disabled]),
+    &.d-btn--active:active:not([disabled]) {
         --button-color-text: var(--error-color-hover);
         --button-color-background: hsla(var(--error-color-hsl) ~' / ' 9%);
     }
@@ -375,14 +375,14 @@
         --button-color-text: var(--white);
         --button-color-background: var(--error-color);
 
-        &:hover {
+        &:hover:not([disabled]) {
             --button-color-text: var(--white);
             --button-color-background: hsl(var(--red-300-h), var(--red-300-s), calc(var(--red-300-l) - 4%));
         }
 
-        &:active,
-        &.d-btn--active,
-        &.d-btn--active:active {
+        &:active:not([disabled]),
+        &.d-btn--active:not([disabled]),
+        &.d-btn--active:active:not([disabled]) {
             --button-color-text: var(--white);
             --button-color-background: hsl(var(--red-300-h), var(--red-300-s), calc(var(--red-300-l) - 8%));
         }
@@ -396,14 +396,14 @@
     --button-color-text: var(--white);
     --button-color-background: transparent;
 
-    &:hover {
+    &:hover:not([disabled]) {
         --button-color-text: var(--white);
         --button-color-background: hsla(var(--white-hsl) ~' / ' 15%);
     }
 
-    &:active,
-    &.d-btn--active,
-    &.d-btn--active:active {
+    &:active:not([disabled]),
+    &.d-btn--active:not([disabled]),
+    &.d-btn--active:active:not([disabled]) {
         --button-color-text: var(--white);
         --button-color-background: hsla(var(--white-hsl) ~' / ' 30%);
     }
@@ -422,14 +422,14 @@
         --button-color-text: var(--purple-400);
         --button-color-background: hsl(var(--purple-100-h), var(--purple-100-s), 100%);
 
-        &:hover {
+        &:hover:not([disabled]) {
             --button-color-text: hsl(var(--purple-400-h) var(--purple-400-s) calc(var(--purple-400-l) - 10%));
             --button-color-background: hsl(var(--purple-100-h), var(--purple-100-s), 94%);
         }
 
-        &:active,
-        &.d-btn--active,
-        &.d-btn--active:active {
+        &:active:not([disabled]),
+        &.d-btn--active:not([disabled]),
+        &.d-btn--active:active:not([disabled]) {
             --button-color-text: hsl(var(--purple-400-h) var(--purple-400-s) calc(var(--purple-400-l) - 10%));
             --button-color-background: hsl(var(--purple-100-h), var(--purple-100-s), 91%);
         }
@@ -472,8 +472,8 @@
 
     display: flex;
 
-    &:hover,
-    &:active {
+    &:hover:not([disabled]),
+    &:active:not([disabled]) {
         --button-color-text: hsla(var(--white-hsl) ~' / ' 90%);
         --button-color-background: hsl(var(--brand-color-h) calc(var(--brand-color-s) + 2.5%) calc(var(--brand-color-l) - 5%));
     }
@@ -482,7 +482,7 @@
         box-shadow: 0 0 0 var(--space-100) var(--white), 0 0 0 0.25em hsla(var(--brand-color-h) var(--brand-color-s) var(--brand-color-l) ~' / ' 90%);
     }
 
-    &:active {
+    &:active:not([disabled]) {
         --button-color-background: hsl(var(--brand-color-h) calc(var(--brand-color-s) + 5%) calc(var(--brand-color-l) - 10%));
     }
 

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -98,9 +98,9 @@
     }
 
     &[disabled] {
-        --button-color-border: transparent;
-        --button-color-text: var(--fc-disabled);
-        --button-color-background: var(--black-300);
+        --button-color-border: transparent !important;
+        --button-color-text: var(--fc-disabled) !important;
+        --button-color-background: var(--black-300) !important;
 
         cursor: not-allowed;
         transition: none;
@@ -455,9 +455,9 @@
 //  $$  DISABLED STATE
 //  ----------------------------------------------------------------------------
 .d-btn--disabled {
-    --button-color-text: var(--fc-disabled);
-    --button-color-background: var(--black-300);
-    --button-color-border: transparent;
+    --button-color-text: var(--fc-disabled) !important;
+    --button-color-background: var(--black-300) !important;
+    --button-color-border: transparent !important;
 
     cursor: not-allowed;
     transition: none;


### PR DESCRIPTION
## Description

The CSS for disabled buttons works only when just `d-btn`, but not when it has an additional `d-btn--{VARIANT}`. Resolves [DT-871](https://dialpad.atlassian.net/browse/DT-871). 

Given how the cascade is set up, the use of `!important` is intentional and appropriate.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

[DT-871]: https://dialpad.atlassian.net/browse/DT-871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ