### PR TITLE
feat(button): uniform padding for icon-only button

### DIFF
--- a/docs/.vuepress/exampleComponents/ExampleBanner.vue
+++ b/docs/.vuepress/exampleComponents/ExampleBanner.vue
@@ -114,29 +114,29 @@
     >
       <div class="d-notice__icon">
         <dt-icon
+          v-show="kind === 'base'"
           name="bell"
           size="400"
-          v-show="kind === 'base'"
         />
         <dt-icon
+          v-show="kind === 'error'"
           name="alert-circle"
           size="400"
-          v-show="kind === 'error'"
         />
         <dt-icon
+          v-show="kind === 'info'"
           name="info"
           size="400"
-          v-show="kind === 'info'"
         />
         <dt-icon
+          v-show="kind === 'success'"
           name="check-circle"
           size="400"
-          v-show="kind === 'success'"
         />
         <dt-icon
+          v-show="kind === 'warning'"
           name="alert-triangle"
           size="400"
-          v-show="kind === 'warning'"
         />
       </div>
       <div class="d-notice__content">

--- a/docs/.vuepress/exampleComponents/ExampleNotice.vue
+++ b/docs/.vuepress/exampleComponents/ExampleNotice.vue
@@ -11,29 +11,29 @@
     >
       <div class="d-notice__icon">
         <dt-icon
+          v-show="kind === 'base'"
           name="bell"
           size="400"
-          v-show="kind === 'base'"
         />
         <dt-icon
+          v-show="kind === 'error'"
           name="alert-circle"
           size="400"
-          v-show="kind === 'error'"
         />
         <dt-icon
+          v-show="kind === 'info'"
           name="info"
           size="400"
-          v-show="kind === 'info'"
         />
         <dt-icon
+          v-show="kind === 'success'"
           name="check-circle"
           size="400"
-          v-show="kind === 'success'"
         />
         <dt-icon
+          v-show="kind === 'warning'"
           name="alert-triangle"
           size="400"
-          v-show="kind === 'warning'"
         />
       </div>
       <div class="d-notice__content">

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -421,10 +421,37 @@
 //  $$  ICON ONLY
 //  ----------------------------------------------------------------------------
 .d-btn--icon-only {
-    // --button-padding: ;
+    --button-padding-x: var(--button-padding-y-md);
+    --button-padding-y: var(--button-padding-y-md);
 
     .d-btn__icon {
         margin: unset;
+    }
+
+    //  Adjust padding based on sizes
+    &.d-btn--xs {
+        --button-padding-y: var(--button-padding-y-xs);
+        --button-padding-x: var(--button-padding-y-xs);
+    }
+
+    &.d-btn--sm {
+        --button-padding-y: var(--button-padding-y-sm);
+        --button-padding-x: var(--button-padding-y-sm);
+    }
+
+    &.d-btn--md {
+        --button-padding-x: var(--button-padding-y-md);
+        --button-padding-y: var(--button-padding-y-md);
+    }
+
+    &.d-btn--lg {
+        --button-padding-x: calc(var(--button-padding-y-lg) + var(--space-100));
+        --button-padding-y: calc(var(--button-padding-y-lg) + var(--space-100));
+    }
+
+    &.d-btn--xl {
+        --button-padding-x: calc(var(--button-padding-y-xl) + var(--space-300));
+        --button-padding-y: calc(var(--button-padding-y-xl) + var(--space-300));
     }
 }
 


### PR DESCRIPTION
## Description

The non-circle Icon-only button had more x-padding than y-padding. 

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

<img width="214" alt="image" src="https://user-images.githubusercontent.com/1165933/211410053-8b0a399c-c2bc-4903-9d63-0c4beebe4a2a.png">

