### PR TITLE
fix(modal): fix misalignment of modal banner

### DIFF
--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -73,6 +73,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-500); //
+  box-sizing: border-box;
   width: 100%;
   max-width: calc(var(--size-300) * 157); // 628
   max-height: 100%;


### PR DESCRIPTION
## Description
Modal dialog was just missing border-box so the changes to padding and such were causing it to expand.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/U2fGWsobLVjV7Siw5k/giphy.gif)
