### PR TITLE
feat(modal): style variants of banner

### DIFF
--- a/docs/_data/modal.json
+++ b/docs/_data/modal.json
@@ -11,6 +11,36 @@
       "description": "Base dialog container for modal content."
     },
     {
+      "class": "d-modal__banner",
+      "applies": "Child of .d-modal__dialog",
+      "description": "Optional banner docked above d-modal__dialog."
+    },
+    {
+      "class": "d-modal_banner--warning",
+      "applies": "d-modal__banner",
+      "description": "Styles d-modal__banner for Warning messaging."
+    },
+    {
+      "class": "d-modal_banner--info",
+      "applies": "d-modal__banner",
+      "description": "Styles d-modal__banner for Info messaging."
+    },
+    {
+      "class": "d-modal_banner--critical",
+      "applies": "d-modal__banner",
+      "description": "Styles d-modal__banner for Critical messaging."
+    },
+    {
+      "class": "d-modal_banner--success",
+      "applies": "d-modal__banner",
+      "description": "Styles d-modal__banner for Success messaging."
+    },
+    {
+      "class": "d-modal_banner--general",
+      "applies": "d-modal__banner",
+      "description": "Styles d-modal__banner for General messaging."
+    },
+    {
       "class": "d-modal__header",
       "applies": "Child of .d-modal__dialog",
       "description": "Adds proper styling for the modal's header."

--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -171,6 +171,26 @@
   border-radius: var(--size-500) var(--size-500) 0 0;
   box-shadow: var(--modal-dialog-shadow);
 
+  &--warning {
+    --modal-banner-color-background: var(--bgc-warning);
+  }
+
+  &--info {
+    --modal-banner-color-background: var(--bgc-info);
+  }
+
+  &--critical {
+    --modal-banner-color-background: var(--bgc-critical);
+  }
+
+  &--success {
+    --modal-banner-color-background: var(--bgc-success);
+  }
+
+  &--general {
+    --modal-banner-color-background: var(--bgc-secondary);
+  }
+
   &::before {
     // 🤦 don't ask. or do, i'm not even sorry.
     position: absolute;


### PR DESCRIPTION
## Description

Currently Modal's optional docked Banner only had one variant, "Warning" (Gold 100 (`bgc-warning`)), forcing some to override with utility classes.

This enhancement restricts it to be inline with surfaces used in other Notification-like components (Banner, Toast, Notice).

[Updated Figma component](https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8923%3A20396&t=BJwfOztc5UCkla5A-11).

<img width="2431" alt="image" src="https://user-images.githubusercontent.com/1165933/214113202-d1e6a351-4a57-47f5-9a31-68946440f231.png">


## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

