### PR TITLE
docs(color): correct red values

### DIFF
--- a/docs/_data/colors.json
+++ b/docs/_data/colors.json
@@ -214,21 +214,21 @@
       },
       {
         "stop": "300",
-        "hex": "FF2E2E",
+        "hex": "EC0E0E",
         "copy": "white",
         "contrast": "AA 4.53",
         "primary": "no"
       },
       {
         "stop": "400",
-        "hex": "A41111",
+        "hex": "B70B0B",
         "copy": "white",
         "contrast": "AA 6.84",
         "primary": "yes"
       },
       {
         "stop": "500",
-        "hex": "540000",
+        "hex": "FB0505",
         "copy": "white",
         "contrast": "AAA 14.29",
         "primary": "no"


### PR DESCRIPTION
## Description
Doc'd Red 300, 400, 500 hex values corrected.

<img width="388" alt="image" src="https://user-images.githubusercontent.com/1165933/214117244-3671a25f-4c51-4fe4-9b07-dccb15153e1c.png">

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

<img width="718" alt="image" src="https://user-images.githubusercontent.com/1165933/214117710-861c6e74-bc7c-4d2a-abfa-7acf51c8b75e.png">
