### PR TITLE
docs(toc): add level 3 heading linkability

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -105,7 +105,7 @@ export default defineUserConfig({
       lineNumbers: false,
     },
     headers: {
-      level: [2], // Generated data header levels (used for toc)
+      level: [2, 3], // Generated data header levels (used for toc)
     },
   },
 

--- a/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -195,6 +195,12 @@ a.header-anchor {
   grid-area: toc !important;
 }
 
+.toc-item {
+  > .toc-list {
+    padding-left: var(--space-500);
+  }
+}
+
 .d-gl-docsite {
   grid-template-areas: 'content';
   grid-template-columns: [content] minmax(32rem, 99rem);


### PR DESCRIPTION
## Description
Add `h3` headings into the toc.
- Added indentation for h3 headings.
- The left border of the active link was maintained.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [ ] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![2023-01-31 at 11 52 10](https://user-images.githubusercontent.com/83774467/215796097-fb188997-a803-4e1a-9060-7ea6d8da6523.gif)