### PR TITLE
fix(banner): move border color to correct element

### DIFF
--- a/lib/build/less/components/banner.less
+++ b/lib/build/less/components/banner.less
@@ -18,7 +18,7 @@
     --banner-color-background: var(--bgc-secondary);
     --banner-color-text: var(--fc-primary);
     --notice-color-icon: var(--toast-color-text);
-    --banner-color-border: 1px solid hsla(var(--black-900-hsl) ~' / ' 10%);
+    --banner-color-border: hsla(var(--black-900-hsl) / 0.1);
     --banner-font-size: var(--fs-200);
     --banner-line-height: var(--lh-200);
     --banner-dialog-padding-y: var(--space-400);
@@ -37,6 +37,7 @@
     font-size: var(--banner-font-size);
     line-height: var(--banner-line-height);
     background-color: var(--banner-color-background);
+    border-bottom: 1px solid var(--banner-color-border);
     border-radius: 0;
     box-shadow: none;
 
@@ -76,7 +77,6 @@
     min-height: 100%;
     margin: 0 auto;
     padding: var(--banner-dialog-padding-y) var(--banner-dialog-padding-x);
-    border-bottom: var(--banner-color-border);
 
     .d-notice__content {
         flex-direction: row;


### PR DESCRIPTION
## Description

Bottom border wasn't spanning full width. Moved to correct element.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).