### PR TITLE
fix(chip): hover/active background styling

### DIFF
--- a/lib/build/less/components/chip.less
+++ b/lib/build/less/components/chip.less
@@ -103,12 +103,14 @@
     content: '';
   }
 
-  &:hover {
-    --button--bgc: hsla(var(--black-800-hsl) ~' / ' 15%);
+  &:hover:not([disabled]) {
+    --button-color-background: hsla(var(--black-800-hsl) ~' / ' 15%);
   }
 
-  &:active {
-    --button--bgc: hsla(var(--black-800-hsl) ~' / ' 25%);
+  &:active:not([disabled]),
+  &.d-btn--active:not([disabled]),
+  &.d-btn--active:active:not([disabled]) {
+    --button-color-background: hsla(var(--black-800-hsl) ~' / ' 25%);
   }
 
   .d-btn__icon .d-svg {


### PR DESCRIPTION
## Description
Active and hover styling for chip was not only referencing a var that no longer exists (`--button--bgc`), but it also was not being applied because the specificity of the `&:hover:not([disabled])` on `d-btn--circle` was higher than the `&:hover` on chip. This should fix it.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/xT39Dl1AHieEwAobq8/giphy-downsized-large.gif)
