### PR TITLE
fix(toggle): fix toggle shrinking with large text

### DIFF
--- a/lib/build/less/components/toggle.less
+++ b/lib/build/less/components/toggle.less
@@ -36,6 +36,7 @@
   display: inline-block;
   box-sizing: border-box;
   width: var(--toggle-size-width);
+  min-width: var(--toggle-size-width);
   height: var(--toggle-size-height);
   padding: 0;
   line-height: var(--lh4);


### PR DESCRIPTION
## Description
The toggle will shrink if there's not enough space, as shown on the settings page https://dialpad.atlassian.net/browse/UC-16723.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://i.giphy.com/media/u4z9yvLepgiqJ3T0nP/giphy-downsized.gif)
