### PR TITLE
docs: set fixed: false on root-layout on docsite

### DIFF
--- a/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -51,11 +51,6 @@ html {
   scroll-padding-top: 6.4rem;
 }
 
-// @TODO: Move this class into root-layout component on dialtone-vue
-.root-layout {
-  min-height: 100vh;
-}
-
 //  ============================================================================
 //  $   SEARCH BUTTON
 //      Override search button with dialtone styles

--- a/docs/.vuepress/theme/layouts/Layout.vue
+++ b/docs/.vuepress/theme/layouts/Layout.vue
@@ -3,6 +3,7 @@
     class="d-h-auto"
     header-class="dialtone-header d-d-flex d-ai-center d-p16 d-pl8 d-h64 d-jc-space-between d-zi-navigation"
     :header-sticky="true"
+    :fixed="false"
     footer-class="d-text-right"
     sidebar-class="dialtone-sidebar lg:d-d-none"
   >


### PR DESCRIPTION
## Description
Set fixed = false on root-layout on our docsite to make it like it was before. The header was disappearing when scrolling about half way down the page after the recent fixed = true change. We don't want to use fixed = true because vuepress handles the scrolling and it needs to manage the scrollbar.
