### PR TITLE
docs: add Open Graph metadata to support rich link preview

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -294,7 +294,7 @@ Here's an overview of important properties and the values they need/can have:
 
 - title `(required)`: Used as the page title, and also as the component name for [Components overview page].
 - shortTitle `(optional)`: This property is used to fix linking issues on [Components overview page] when the title is different from the component name.
-- desc `(optional)`: Used as the page subtitle.
+- description `(optional)`: Used as the page subtitle and in the page metadata.
 - status `(optional)`: CSS Component status, used to display a badge on [Components overview page] and
 also to define the component status on [Components status page], 
   - Status options available: `['wip', 'planned', 'new', 'ready', null]` 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -7,6 +7,7 @@ import anchor from 'markdown-it-anchor';
 
 const sidebar = require('../_data/site-nav.json');
 const { dialtoneVuepressTheme } = require('./theme');
+const siteURL = 'https://dialpad.design/';
 const baseURL = (process.env.VUEPRESS_BASE_URL ?? '/');
 
 const themeConfig = {
@@ -109,7 +110,11 @@ export default defineUserConfig({
       id: 'G-0YV8QJ44LF',
     }),
     seoPlugin({
-      // your options
+      hostname: siteURL,
+      ogp: (ogp, page) => ({
+        ...ogp,
+        'og:image': siteURL + baseURL + page.frontmatter.image || ogp['og:image'],
+      }),
     }),
   ],
 });

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,6 +2,7 @@ import { defineUserConfig } from 'vuepress';
 import { getDirname, path } from '@vuepress/utils';
 import { viteBundler } from '@vuepress/bundler-vite';
 import { googleAnalyticsPlugin } from '@vuepress/plugin-google-analytics';
+import { seoPlugin } from 'vuepress-plugin-seo2';
 import anchor from 'markdown-it-anchor';
 
 const sidebar = require('../_data/site-nav.json');
@@ -124,6 +125,9 @@ export default defineUserConfig({
   plugins: [
     googleAnalyticsPlugin({
       id: 'G-0YV8QJ44LF',
+    }),
+    seoPlugin({
+      // your options
     }),
   ],
 });

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -74,24 +74,6 @@ export default defineUserConfig({
     ['link', { rel: 'mask-icon', href: baseURL + 'assets/images/favicons/safari-pinned-tab.svg', color: '#7C52FF' }],
     ['meta', { name: 'msapplication-TileColor', content: '#7C52FF' }],
     ['meta', { name: 'theme-color', content: '#ffffff' }],
-
-    // Social
-    ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:url', content: 'https://dialpad.design/' }],
-    ['meta', {
-      property: 'og:image',
-      itemprop: 'image primaryImageOfPage',
-      content: baseURL + 'assets/images/favicons/apple-touch-icon-180x180.png',
-    }],
-    ['meta', { name: 'twitter:card', content: 'summary' }],
-    ['meta', { name: 'twitter:domain', content: 'dialpad.design' }],
-    ['meta', { name: 'twitter:title', property: 'og:title', itemprop: 'title name', content: 'Dialtone' }],
-    ['meta', {
-      name: 'twitter:description',
-      property: 'og:description',
-      itemprop: 'description',
-      content: 'Dialtone is the design system and resources for the Dialpad team.',
-    }],
   ],
 
   // markdown config

--- a/docs/.vuepress/theme/components/PageHeader.vue
+++ b/docs/.vuepress/theme/components/PageHeader.vue
@@ -14,9 +14,9 @@
         >New</span>
       </div>
       <p
-        v-if="$frontmatter.desc"
+        v-if="$frontmatter.description"
         class="dialtone-intro"
-        v-html="$frontmatter.desc"
+        v-html="$frontmatter.description"
       />
     </header>
     <slot name="content-bottom" />

--- a/docs/.vuepress/views/Overview.vue
+++ b/docs/.vuepress/views/Overview.vue
@@ -30,7 +30,7 @@
             </span>
           </div>
           <div class="dialtone-wall__description">
-            {{ page.desc }}
+            {{ page.description }}
           </div>
         </div>
       </router-link>

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-desc: Help Dialtone be even better.
+description: Help Dialtone be even better.
 ---
 
 ## Component contribution

--- a/docs/about/dialtone.md
+++ b/docs/about/dialtone.md
@@ -1,6 +1,6 @@
 ---
 title: About Dialtone
-desc: Dialtone is Dialpad's Design System that unites product teams around a common visual language.
+description: Dialtone is Dialpad's Design System that unites product teams around a common visual language.
 ---
 
 ## Release notes

--- a/docs/about/whats-new/index.md
+++ b/docs/about/whats-new/index.md
@@ -1,6 +1,6 @@
 ---
 title: What's New
-desc: Updates, progress and planning for all things Dialtone.
+description: Updates, progress and planning for all things Dialtone.
 ---
 
 <BlogPostPreview v-for="post in $page.blogPosts.sort(sortHandler)" :key="post.posted" :author="post.author" :heading="post.heading" :posted="parse(post.posted, 'y-M-d', new Date())">

--- a/docs/components/avatar.md
+++ b/docs/components/avatar.md
@@ -3,6 +3,7 @@ title: Avatar
 description: An avatar is a visual representation of a user or object.
 status: new
 thumb: true
+image: assets/images/components/avatar.png
 storybook: https://vue.dialpad.design/?path=/story/components-avatar--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8918%3A21289&viewport=137%2C605%2C0.46&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/avatar.md
+++ b/docs/components/avatar.md
@@ -1,6 +1,6 @@
 ---
 title: Avatar
-desc: An avatar is a visual representation of a user or object.
+description: An avatar is a visual representation of a user or object.
 status: new
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-avatar--default

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -3,6 +3,7 @@ title: Badge
 description: A badge is a compact UI element providing brief, descriptive information about an element and its surrounding context. It is terse, ideally one word.
 status: ready
 thumb: true
+image: assets/images/components/badge.png
 storybook: https://vue.dialpad.design/?path=/story/components-badge--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8914%3A21227&viewport=656%2C314%2C0.55&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/badge.md
+++ b/docs/components/badge.md
@@ -1,6 +1,6 @@
 ---
 title: Badge
-desc: A badge is a compact UI element providing brief, descriptive information about an element and its surrounding context. It is terse, ideally one word.
+description: A badge is a compact UI element providing brief, descriptive information about an element and its surrounding context. It is terse, ideally one word.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-badge--default

--- a/docs/components/banner.md
+++ b/docs/components/banner.md
@@ -1,6 +1,6 @@
 ---
 title: Banner
-desc: A banner is a type of Notice, delivering system and engagement messaging. It is highly intrusive and should be used sparingly and appropriately.
+description: A banner is a type of Notice, delivering system and engagement messaging. It is highly intrusive and should be used sparingly and appropriately.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-banner--default

--- a/docs/components/banner.md
+++ b/docs/components/banner.md
@@ -3,6 +3,7 @@ title: Banner
 description: A banner is a type of Notice, delivering system and engagement messaging. It is highly intrusive and should be used sparingly and appropriately.
 status: ready
 thumb: true
+image: assets/images/components/banner.png
 storybook: https://vue.dialpad.design/?path=/story/components-banner--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8922%3A20410&viewport=-178%2C151%2C0.23&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -1,6 +1,6 @@
 ---
 title: Breadcrumbs
-desc: Breadcrumbs are links used to provide context for the currently-viewed page and where it is located within the overall site structure.
+description: Breadcrumbs are links used to provide context for the currently-viewed page and where it is located within the overall site structure.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-breadcrumbs--default

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -3,6 +3,7 @@ title: Breadcrumbs
 description: Breadcrumbs are links used to provide context for the currently-viewed page and where it is located within the overall site structure.
 status: ready
 thumb: true
+image: assets/images/components/breadcrumbs.png
 storybook: https://vue.dialpad.design/?path=/story/components-breadcrumbs--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8918%3A21306&viewport=-61%2C443%2C1.12&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/button-group.md
+++ b/docs/components/button-group.md
@@ -2,6 +2,7 @@
 title: Button group
 description: Button groups are used to group buttons that have a relationship or similar actions.
 thumb: true
+image: assets/images/components/button-group.png
 storybook: https://vue.dialpad.design/?path=/story/components-button-group--default
 ---
 

--- a/docs/components/button-group.md
+++ b/docs/components/button-group.md
@@ -1,6 +1,6 @@
 ---
 title: Button group
-desc: Button groups are used to group buttons that have a relationship or similar actions.
+description: Button groups are used to group buttons that have a relationship or similar actions.
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-button-group--default
 ---

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -1,6 +1,6 @@
 ---
 title: Button
-desc: A button is an UI element which signals key actions to take an action throughout an app. It is important a button is identifiable, consistent, communicates its actions clearly, and is appropriately sized to its action.
+description: A button is an UI element which signals key actions to take an action throughout an app. It is important a button is identifiable, consistent, communicates its actions clearly, and is appropriately sized to its action.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-button--default

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -3,6 +3,7 @@ title: Button
 description: A button is an UI element which signals key actions to take an action throughout an app. It is important a button is identifiable, consistent, communicates its actions clearly, and is appropriately sized to its action.
 status: ready
 thumb: true
+image: assets/images/components/button.png
 storybook: https://vue.dialpad.design/?path=/story/components-button--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8923%3A20208&viewport=-1695%2C219%2C0.19&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -3,6 +3,7 @@ title: Card
 description: A card contains summary content and actions about a single subject. It can be used by itself or within a list, and is generally interactive.
 status: ready
 thumb: true
+image: assets/images/components/card.png
 figma: planned
 storybook: https://vue.dialpad.design/?path=/story/components-card--default
 ---

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -1,6 +1,6 @@
 ---
 title: Card
-desc: A card contains summary content and actions about a single subject. It can be used by itself or within a list, and is generally interactive.
+description: A card contains summary content and actions about a single subject. It can be used by itself or within a list, and is generally interactive.
 status: ready
 thumb: true
 figma: planned

--- a/docs/components/checkbox-group.md
+++ b/docs/components/checkbox-group.md
@@ -1,6 +1,6 @@
 ---
 title: Checkbox group
-desc: Checkbox groups are convenient components for a grouping of related Checkboxes.
+description: Checkbox groups are convenient components for a grouping of related Checkboxes.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--default

--- a/docs/components/checkbox-group.md
+++ b/docs/components/checkbox-group.md
@@ -3,6 +3,7 @@ title: Checkbox group
 description: Checkbox groups are convenient components for a grouping of related Checkboxes.
 status: ready
 thumb: true
+image: assets/images/components/checkbox-group.png
 storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--default
 ---
 

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -3,6 +3,7 @@ title: Checkbox
 description: A checkbox is an input control that allows users to select zero, one, or more options from a number of choices.
 status: ready
 thumb: true
+image: assets/images/components/checkbox.png
 storybook: https://vue.dialpad.design/?path=/story/components-checkbox--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8921%3A21160&viewport=-351%2C484%2C0.54&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -1,6 +1,6 @@
 ---
 title: Checkbox
-desc: A checkbox is an input control that allows users to select zero, one, or more options from a number of choices.
+description: A checkbox is an input control that allows users to select zero, one, or more options from a number of choices.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-checkbox--default

--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -3,6 +3,7 @@ title: Chip
 description: A Chip is a compact UI element that provides brief, descriptive information about an element. It is terse, ideally one word.
 status: ready
 thumb: true
+image: assets/images/components/chip.png
 storybook: https://vue.dialpad.design/?path=/story/components-chip--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=9937%3A64802
 ---

--- a/docs/components/chip.md
+++ b/docs/components/chip.md
@@ -1,6 +1,6 @@
 ---
 title: Chip
-desc: A Chip is a compact UI element that provides brief, descriptive information about an element. It is terse, ideally one word.
+description: A Chip is a compact UI element that provides brief, descriptive information about an element. It is terse, ideally one word.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-chip--default

--- a/docs/components/collapsible.md
+++ b/docs/components/collapsible.md
@@ -3,6 +3,7 @@ title: Collapsible
 description: A collapsible is a component consisting of an interactive anchor that toggled the expandable/collapsible element.
 status: ready
 thumb: true
+image: assets/images/components/collapsible.png
 figma: planned
 storybook: https://vue.dialpad.design/?path=/story/components-collapsible--default
 ---

--- a/docs/components/collapsible.md
+++ b/docs/components/collapsible.md
@@ -1,6 +1,6 @@
 ---
 title: Collapsible
-desc: A collapsible is a component consisting of an interactive anchor that toggled the expandable/collapsible element.
+description: A collapsible is a component consisting of an interactive anchor that toggled the expandable/collapsible element.
 status: ready
 thumb: true
 figma: planned

--- a/docs/components/combobox.md
+++ b/docs/components/combobox.md
@@ -3,6 +3,7 @@ title: Combobox
 description: A combobox is a semantic component that displays an input element combined with a listbox, which enables the user to select items from the list.
 status: ready
 thumb: true
+image: assets/images/components/combobox.png
 figma: planned
 storybook: https://vue.dialpad.design/?path=/story/components-combobox--default
 ---

--- a/docs/components/combobox.md
+++ b/docs/components/combobox.md
@@ -1,6 +1,6 @@
 ---
 title: Combobox
-desc: A combobox is a semantic component that displays an input element combined with a listbox, which enables the user to select items from the list.
+description: A combobox is a semantic component that displays an input element combined with a listbox, which enables the user to select items from the list.
 status: ready
 thumb: true
 figma: planned

--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -3,6 +3,7 @@ title: Dropdown
 description: A Dropdown presents a list of options or actions.
 status: planned
 thumb: true
+image: assets/images/components/dropdown.png
 storybook: https://vue.dialpad.design/?path=/story/components-dropdown--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=10732%3A69099
 ---

--- a/docs/components/dropdown.md
+++ b/docs/components/dropdown.md
@@ -1,6 +1,6 @@
 ---
 title: Dropdown
-desc: A Dropdown presents a list of options or actions.
+description: A Dropdown presents a list of options or actions.
 status: planned
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-dropdown--default

--- a/docs/components/emoji-picker.md
+++ b/docs/components/emoji-picker.md
@@ -1,6 +1,7 @@
 ---
 title: Emoji Picker
 thumb: true
+image: assets/images/components/emoji-picker.png
 status: planned
 storybook: planned
 figma: planned

--- a/docs/components/emoji-text-wrapper.md
+++ b/docs/components/emoji-text-wrapper.md
@@ -3,6 +3,7 @@ title: Emoji text wrapper
 description: "Wrapper to find and replace shortcodes like :smile: or unicode chars such as 😄 with our custom Emojis implementation."
 status: ready
 thumb: true
+image: assets/images/components/emoji-text-wrapper.png
 storybook: https://vue.dialpad.design/?path=/story/components-emoji-text-wrapper--default
 ---
 

--- a/docs/components/emoji-text-wrapper.md
+++ b/docs/components/emoji-text-wrapper.md
@@ -1,6 +1,6 @@
 ---
 title: Emoji text wrapper
-desc: "Wrapper to find and replace shortcodes like :smile: or unicode chars such as 😄 with our custom Emojis implementation."
+description: "Wrapper to find and replace shortcodes like :smile: or unicode chars such as 😄 with our custom Emojis implementation."
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-emoji-text-wrapper--default

--- a/docs/components/emoji.md
+++ b/docs/components/emoji.md
@@ -1,6 +1,6 @@
 ---
 title: Emoji
-desc: "Renders an emoji from a shortcode such as :smile: or unicode character such as 😄."
+description: "Renders an emoji from a shortcode such as :smile: or unicode character such as 😄."
 status: ready
 thumb: true
 figma: planned

--- a/docs/components/emoji.md
+++ b/docs/components/emoji.md
@@ -3,6 +3,7 @@ title: Emoji
 description: "Renders an emoji from a shortcode such as :smile: or unicode character such as 😄."
 status: ready
 thumb: true
+image: assets/images/components/emoji.png
 figma: planned
 storybook: https://vue.dialpad.design/?path=/story/components-emoji--default
 ---

--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -3,6 +3,7 @@ title: Icon
 description: An icon is used to visually communicate commands, meaning, status, feedback, or common actions.
 status: new
 thumb: true
+image: assets/images/components/icon.png
 storybook: https://vue.dialpad.design/?path=/docs/components-icon--default
 figma_url: https://www.figma.com/file/zz40wi0uW9MvaJ5RuhcRZR/DT-Core%3A-Icons-7?node-id=1473%3A3757&viewport=-168%2C479%2C1&t=OhX4ilCDvb7Tqkx4-11
 ---

--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -1,6 +1,6 @@
 ---
 title: Icon
-desc: An icon is used to visually communicate commands, meaning, status, feedback, or common actions.
+description: An icon is used to visually communicate commands, meaning, status, feedback, or common actions.
 status: new
 thumb: true
 storybook: https://vue.dialpad.design/?path=/docs/components-icon--default

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -1,6 +1,6 @@
 ---
 title: Components
-desc: Reusable components solving common UI needs, designed and built to be assembled in countless combinations.
+description: Reusable components solving common UI needs, designed and built to be assembled in countless combinations.
 no_preview: true
 ---
 

--- a/docs/components/infinite-scroll.md
+++ b/docs/components/infinite-scroll.md
@@ -1,6 +1,7 @@
 ---
 title: Infinite Scroll
 thumb: true
+image: assets/images/components/infinite-scroll.png
 status: planned
 storybook: planned
 figma: planned

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -1,6 +1,6 @@
 ---
 title: Input
-desc: An input field is an input control that allows users to enter alphanumeric information. It can have a range of options and supports single line and multi-line lengths, as well as varying formats, including numbers, masked passwords, etc.
+description: An input field is an input control that allows users to enter alphanumeric information. It can have a range of options and supports single line and multi-line lengths, as well as varying formats, including numbers, masked passwords, etc.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-input--default

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -3,6 +3,7 @@ title: Input
 description: An input field is an input control that allows users to enter alphanumeric information. It can have a range of options and supports single line and multi-line lengths, as well as varying formats, including numbers, masked passwords, etc.
 status: ready
 thumb: true
+image: assets/images/components/input.png
 storybook: https://vue.dialpad.design/?path=/story/components-input--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8923%3A21866&viewport=-983%2C83%2C0.16&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/keyboard-shortcut.md
+++ b/docs/components/keyboard-shortcut.md
@@ -3,6 +3,7 @@ title: Keyboard shortcut
 description: This component displays a visual representation of a keyboard shortcut to the user.
 status: ready
 thumb: true
+image: assets/images/components/keyboard-shortcut.png
 storybook: https://vue.dialpad.design/?path=/story/components-keyboard-shortcut--default
 ---
 

--- a/docs/components/keyboard-shortcut.md
+++ b/docs/components/keyboard-shortcut.md
@@ -1,6 +1,6 @@
 ---
 title: Keyboard shortcut
-desc: This component displays a visual representation of a keyboard shortcut to the user.
+description: This component displays a visual representation of a keyboard shortcut to the user.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-keyboard-shortcut--default

--- a/docs/components/lazy-show.md
+++ b/docs/components/lazy-show.md
@@ -1,6 +1,6 @@
 ---
 title: Lazy show
-desc: Lazy show is a utility component that prevents its children from being rendered until the first time it is shown.
+description: Lazy show is a utility component that prevents its children from being rendered until the first time it is shown.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/utilities-lazy-show--default

--- a/docs/components/lazy-show.md
+++ b/docs/components/lazy-show.md
@@ -3,6 +3,7 @@ title: Lazy show
 description: Lazy show is a utility component that prevents its children from being rendered until the first time it is shown.
 status: ready
 thumb: true
+image: assets/images/components/lazy-show.png
 storybook: https://vue.dialpad.design/?path=/story/utilities-lazy-show--default
 ---
 

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -3,6 +3,7 @@ title: Link
 description: A link is a navigational element that can be found on its own, within other text, or directly following content.
 status: ready
 thumb: true
+image: assets/images/components/link.png
 storybook: https://vue.dialpad.design/?path=/story/components-link--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21226&viewport=-746%2C-197%2C1.41&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/link.md
+++ b/docs/components/link.md
@@ -1,6 +1,6 @@
 ---
 title: Link
-desc: A link is a navigational element that can be found on its own, within other text, or directly following content.
+description: A link is a navigational element that can be found on its own, within other text, or directly following content.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-link--default

--- a/docs/components/list-item.md
+++ b/docs/components/list-item.md
@@ -3,6 +3,7 @@ title: List Item
 description: A list item is an element that can be used to represent individual items in a list.
 status: planned
 thumb: true
+image: assets/images/components/list-item.png
 storybook: https://vue.dialpad.design/?path=/story/components-list-item--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=10732%3A69390
 ---

--- a/docs/components/list-item.md
+++ b/docs/components/list-item.md
@@ -1,6 +1,6 @@
 ---
 title: List Item
-desc: A list item is an element that can be used to represent individual items in a list.
+description: A list item is an element that can be used to represent individual items in a list.
 status: planned
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-list-item--default

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -3,6 +3,7 @@ title: Modal
 description: A modal focuses the user’s attention on a single task or message.
 status: ready
 thumb: true
+image: assets/images/components/modal.png
 storybook: https://vue.dialpad.design/?path=/story/components-modal--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8923%3A20396&viewport=-724%2C-52%2C0.38&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -1,6 +1,6 @@
 ---
 title: Modal
-desc: A modal focuses the user’s attention on a single task or message.
+description: A modal focuses the user’s attention on a single task or message.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-modal--default

--- a/docs/components/notice.md
+++ b/docs/components/notice.md
@@ -3,6 +3,7 @@ title: Notice
 description: A notice is an informational and assistive message that appears inline with content.
 status: ready
 thumb: true
+image: assets/images/components/notice.png
 storybook: https://vue.dialpad.design/?path=/story/components-notice--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8921%3A23341&viewport=145%2C-209%2C0.31&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/notice.md
+++ b/docs/components/notice.md
@@ -1,6 +1,6 @@
 ---
 title: Notice
-desc: A notice is an informational and assistive message that appears inline with content.
+description: A notice is an informational and assistive message that appears inline with content.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-notice--default

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -1,6 +1,6 @@
 ---
 title: Pagination
-desc: Pagination allows you to divide large amounts of content into smaller chunks across multiple pages.
+description: Pagination allows you to divide large amounts of content into smaller chunks across multiple pages.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-pagination--default

--- a/docs/components/pagination.md
+++ b/docs/components/pagination.md
@@ -3,6 +3,7 @@ title: Pagination
 description: Pagination allows you to divide large amounts of content into smaller chunks across multiple pages.
 status: ready
 thumb: true
+image: assets/images/components/pagination.png
 storybook: https://vue.dialpad.design/?path=/story/components-pagination--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=10984%3A76640
 ---

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -3,6 +3,7 @@ title: Popover
 description: A Popover displays a content overlay when its anchor element is activated.
 status: ready
 thumb: true
+image: assets/images/components/popover.png
 storybook: https://vue.dialpad.design/?path=/story/components-popover--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8921%3A22411&viewport=831%2C-269%2C0.43&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/popover.md
+++ b/docs/components/popover.md
@@ -1,6 +1,6 @@
 ---
 title: Popover
-desc: A Popover displays a content overlay when its anchor element is activated.
+description: A Popover displays a content overlay when its anchor element is activated.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-popover--default

--- a/docs/components/presence.md
+++ b/docs/components/presence.md
@@ -1,6 +1,6 @@
 ---
 title: Presence
-desc: A visual control element indicating the current status of a user.
+description: A visual control element indicating the current status of a user.
 status: new
 thumb: true
 storybook: https://vue.dialpad.design/?path=/docs/components-presence--default

--- a/docs/components/presence.md
+++ b/docs/components/presence.md
@@ -3,6 +3,7 @@ title: Presence
 description: A visual control element indicating the current status of a user.
 status: new
 thumb: true
+image: assets/images/components/presence.png
 storybook: https://vue.dialpad.design/?path=/docs/components-presence--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=9628%3A59018&viewport=-1353%2C1919%2C1.91&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/radio-group.md
+++ b/docs/components/radio-group.md
@@ -1,6 +1,6 @@
 ---
 title: Radio group
-desc: Radio groups are control elements that allow the user to make a single selection from a list of options.
+description: Radio groups are control elements that allow the user to make a single selection from a list of options.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-radio-group--default

--- a/docs/components/radio-group.md
+++ b/docs/components/radio-group.md
@@ -3,6 +3,7 @@ title: Radio group
 description: Radio groups are control elements that allow the user to make a single selection from a list of options.
 status: ready
 thumb: true
+image: assets/images/components/radio-group.png
 storybook: https://vue.dialpad.design/?path=/story/components-radio-group--default
 ---
 

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -1,6 +1,6 @@
 ---
 title: Radio
-desc: A radio is an input control that allows users to select only one option from a number of choices.
+description: A radio is an input control that allows users to select only one option from a number of choices.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-radio--default

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -3,6 +3,7 @@ title: Radio
 description: A radio is an input control that allows users to select only one option from a number of choices.
 status: ready
 thumb: true
+image: assets/images/components/radio.png
 storybook: https://vue.dialpad.design/?path=/story/components-radio--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A22042&viewport=-451%2C205%2C0.6&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/root-layout.md
+++ b/docs/components/root-layout.md
@@ -1,6 +1,6 @@
 ---
 title: Root layout
-desc: A root layout provides a standardized group of containers to display content at the root level.
+description: A root layout provides a standardized group of containers to display content at the root level.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-root-layout--default

--- a/docs/components/root-layout.md
+++ b/docs/components/root-layout.md
@@ -3,6 +3,7 @@ title: Root layout
 description: A root layout provides a standardized group of containers to display content at the root level.
 status: ready
 thumb: true
+image: assets/images/components/root-layout.png
 storybook: https://vue.dialpad.design/?path=/story/components-root-layout--default
 ---
 

--- a/docs/components/select-menu.md
+++ b/docs/components/select-menu.md
@@ -1,6 +1,6 @@
 ---
 title: Select menu
-desc: A select menu is an input control that allows users to choose one option from a list.
+description: A select menu is an input control that allows users to choose one option from a list.
 status: ready
 thumb: true
 storybook: https://vue.dialpad.design/?path=/story/components-select-menu--default

--- a/docs/components/select-menu.md
+++ b/docs/components/select-menu.md
@@ -3,6 +3,7 @@ title: Select menu
 description: A select menu is an input control that allows users to choose one option from a list.
 status: ready
 thumb: true
+image: assets/images/components/select-menu.png
 storybook: https://vue.dialpad.design/?path=/story/components-select-menu--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21569&viewport=-1857%2C206%2C0.37&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -2,7 +2,7 @@
 title: Skeleton
 status: ready
 thumb: true
-desc: Skeleton loader is a non-interactive placeholder that displays a preview of the UI to visually communicate that content is in the process of loading. Skeleton is used to provide a low fidelity representation of the user interface (UI) before content appears on the page.
+description: Skeleton loader is a non-interactive placeholder that displays a preview of the UI to visually communicate that content is in the process of loading. Skeleton is used to provide a low fidelity representation of the user interface (UI) before content appears on the page.
 storybook: https://vue.dialpad.design/?path=/story/components-skeleton--default
 figma: planned
 ---

--- a/docs/components/skeleton.md
+++ b/docs/components/skeleton.md
@@ -2,6 +2,7 @@
 title: Skeleton
 status: ready
 thumb: true
+image: assets/images/components/skeleton.png
 description: Skeleton loader is a non-interactive placeholder that displays a preview of the UI to visually communicate that content is in the process of loading. Skeleton is used to provide a low fidelity representation of the user interface (UI) before content appears on the page.
 storybook: https://vue.dialpad.design/?path=/story/components-skeleton--default
 figma: planned

--- a/docs/components/status/index.md
+++ b/docs/components/status/index.md
@@ -1,6 +1,6 @@
 ---
 title: Component status
-desc: Overview of the components health status
+description: Overview of the components health status
 no_preview: true
 ---
 

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -2,6 +2,7 @@
 title: Table
 status: ready
 thumb: true
+image: assets/images/components/table.png
 description: A table is a pattern for organizing data sets. While data visualization helps quickly summarize a data set, a table allows users to compare and analyze individual data rows.
 figma: wip
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8921%3A20948&viewport=-788%2C209%2C0.86&t=xHutRjwo1o5zMTgT-11

--- a/docs/components/table.md
+++ b/docs/components/table.md
@@ -2,7 +2,7 @@
 title: Table
 status: ready
 thumb: true
-desc: A table is a pattern for organizing data sets. While data visualization helps quickly summarize a data set, a table allows users to compare and analyze individual data rows.
+description: A table is a pattern for organizing data sets. While data visualization helps quickly summarize a data set, a table allows users to compare and analyze individual data rows.
 figma: wip
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8921%3A20948&viewport=-788%2C209%2C0.86&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -2,7 +2,7 @@
 title: Tabs
 status: ready
 thumb: true
-desc: Tabs allow users to navigation between grouped content in different views while within the same page context.
+description: Tabs allow users to navigation between grouped content in different views while within the same page context.
 storybook: https://vue.dialpad.design/?path=/story/components-tabs--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21321&viewport=306%2C-547%2C1.01&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/toast.md
+++ b/docs/components/toast.md
@@ -2,6 +2,7 @@
 title: Toast
 status: ready
 thumb: true
+image: assets/images/components/toast.png
 description: A toast notice, sometimes called a snackbar, is a time-based message that appears based on users' actions. It contains at-a-glance information about outcomes and can be paired with actions.
 storybook: https://vue.dialpad.design/?path=/story/components-toast--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21834&viewport=-496%2C632%2C0.48&t=xHutRjwo1o5zMTgT-11

--- a/docs/components/toast.md
+++ b/docs/components/toast.md
@@ -2,7 +2,7 @@
 title: Toast
 status: ready
 thumb: true
-desc: A toast notice, sometimes called a snackbar, is a time-based message that appears based on users' actions. It contains at-a-glance information about outcomes and can be paired with actions.
+description: A toast notice, sometimes called a snackbar, is a time-based message that appears based on users' actions. It contains at-a-glance information about outcomes and can be paired with actions.
 storybook: https://vue.dialpad.design/?path=/story/components-toast--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21834&viewport=-496%2C632%2C0.48&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/toggle.md
+++ b/docs/components/toggle.md
@@ -2,7 +2,7 @@
 title: Toggle
 status: ready
 thumb: true
-desc: A toggle, or "switch", is a button control element that allows the user to make a binary selection.
+description: A toggle, or "switch", is a button control element that allows the user to make a binary selection.
 storybook: https://vue.dialpad.design/?path=/story/components-toggle--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21460&viewport=-359%2C250%2C0.49&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/toggle.md
+++ b/docs/components/toggle.md
@@ -2,6 +2,7 @@
 title: Toggle
 status: ready
 thumb: true
+image: assets/images/components/toggle.png
 description: A toggle, or "switch", is a button control element that allows the user to make a binary selection.
 storybook: https://vue.dialpad.design/?path=/story/components-toggle--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21460&viewport=-359%2C250%2C0.49&t=xHutRjwo1o5zMTgT-11

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -2,7 +2,7 @@
 title: Tooltip
 status: ready
 thumb: true
-desc: A tooltip is a floating label that briefly explains an action, function, or an element. Its content is exclusively text and shouldn't be vital information for users. If richer media is desired, consider using a popover instead.
+description: A tooltip is a floating label that briefly explains an action, function, or an element. Its content is exclusively text and shouldn't be vital information for users. If richer media is desired, consider using a popover instead.
 storybook: https://vue.dialpad.design/?path=/story/components-tooltip--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21626&viewport=-614%2C359%2C0.86&t=xHutRjwo1o5zMTgT-11
 ---

--- a/docs/components/tooltip.md
+++ b/docs/components/tooltip.md
@@ -2,6 +2,7 @@
 title: Tooltip
 status: ready
 thumb: true
+image: assets/images/components/tooltip.png
 description: A tooltip is a floating label that briefly explains an action, function, or an element. Its content is exclusively text and shouldn't be vital information for users. If richer media is desired, consider using a popover instead.
 storybook: https://vue.dialpad.design/?path=/story/components-tooltip--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21626&viewport=-614%2C359%2C0.86&t=xHutRjwo1o5zMTgT-11

--- a/docs/components/validation-messages.md
+++ b/docs/components/validation-messages.md
@@ -2,6 +2,7 @@
 title: Validation messages
 status: ready
 thumb: true
+image: assets/images/components/validation-messages.png
 description: Validation messages are used to convey information to the user about the current state of the input element. These messages can have an error, warning or success type.
 storybook: https://vue.dialpad.design/?path=/story/components-validation-messages--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=11399%3A76354&t=LqzEvQfr3DMHh7Og-11

--- a/docs/components/validation-messages.md
+++ b/docs/components/validation-messages.md
@@ -2,7 +2,7 @@
 title: Validation messages
 status: ready
 thumb: true
-desc: Validation messages are used to convey information to the user about the current state of the input element. These messages can have an error, warning or success type.
+description: Validation messages are used to convey information to the user about the current state of the input element. These messages can have an error, warning or success type.
 storybook: https://vue.dialpad.design/?path=/story/components-validation-messages--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=11399%3A76354&t=LqzEvQfr3DMHh7Og-11
 ---

--- a/docs/design/colors/index.md
+++ b/docs/design/colors/index.md
@@ -1,6 +1,6 @@
 ---
 title: Colors
-desc: A functional, personal, and accessible color palette.
+description: A functional, personal, and accessible color palette.
 ---
 
 ## Text

--- a/docs/design/elevation/index.md
+++ b/docs/design/elevation/index.md
@@ -1,5 +1,5 @@
 ---
 title: Elevation
 status: planned
-desc: A layering system to give content blocks visual depth and prominence.
+description: A layering system to give content blocks visual depth and prominence.
 ---

--- a/docs/design/icons/index.md
+++ b/docs/design/icons/index.md
@@ -1,7 +1,7 @@
 ---
 title: Iconography
 shortTitle: icons
-desc: An icon style for visually communicating commands, status, and more.
+description: An icon style for visually communicating commands, status, and more.
 ---
 
 <aside class="d-notice d-notice--info d-mt24 d-wmx100p" role="status" aria-hidden="false">

--- a/docs/design/illustrations/index.md
+++ b/docs/design/illustrations/index.md
@@ -1,6 +1,6 @@
 ---
 title: Illustrations
-desc: A system for consistent visual rhythms and proportions.
+description: A system for consistent visual rhythms and proportions.
 ---
 
 ## Spot illustrations

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -1,6 +1,6 @@
 ---
 title: Design language
-desc: The visual foundation that supports and unites Dialpad products.
+description: The visual foundation that supports and unites Dialpad products.
 ---
 
 <overview :pages="$page.enhancedFrontmatter" base-path="design" />

--- a/docs/design/motion/index.md
+++ b/docs/design/motion/index.md
@@ -1,5 +1,5 @@
 ---
 title: Motion
 status: planned
-desc: Expressive transitions to guide users through complex experiences.
+description: Expressive transitions to guide users through complex experiences.
 ---

--- a/docs/design/size-and-spacing/index.md
+++ b/docs/design/size-and-spacing/index.md
@@ -1,6 +1,6 @@
 ---
 title: Size and spacing
-desc: A system to maintain consistent size, space, and scale.
+description: A system to maintain consistent size, space, and scale.
 ---
 
 Consistently using this system makes it easier for customers to scan, browse, and use Dialpad product interfaces with a predictable visual rhythm.

--- a/docs/design/typography/index.md
+++ b/docs/design/typography/index.md
@@ -1,7 +1,7 @@
 ---
 title: Typography
 status: planned
-desc: Guidance for clear, legible, and easy-to-read text.
+description: Guidance for clear, legible, and easy-to-read text.
 ---
 
 Dialtone provides a set of purposeful typographic styles to present user interface and content as clearly and efficiently as possible.

--- a/docs/guides/accessibility/index.md
+++ b/docs/guides/accessibility/index.md
@@ -1,7 +1,7 @@
 ---
 title: Accessibility and inclusive design
 shortTitle: accessibility
-desc: Guidance on building products for everyone.
+description: Guidance on building products for everyone.
 ---
 
 We are committed to usable experiences and products for everyone. Because “everyone” is a lot of people reflecting a variety of backgrounds, abilities, and circumstances, we believe in applying thoughtful and inclusive design and development practices.

--- a/docs/guides/brand/index.md
+++ b/docs/guides/brand/index.md
@@ -1,5 +1,5 @@
 ---
 title: Brand
-desc: Details on Dialpad's identity and who we are as a company.
+description: Details on Dialpad's identity and who we are as a company.
 status: planned
 ---

--- a/docs/guides/design-assets/index.md
+++ b/docs/guides/design-assets/index.md
@@ -1,5 +1,5 @@
 ---
 title: Design assets 
-desc: Figma toolkit of building blocks for exploration and collaboration.
+description: Figma toolkit of building blocks for exploration and collaboration.
 status: planned
 ---

--- a/docs/guides/design-principles/index.md
+++ b/docs/guides/design-principles/index.md
@@ -1,5 +1,5 @@
 ---
 title: Design principles
-desc: The core values behind Dialpad's experiences.
+description: The core values behind Dialpad's experiences.
 status: planned
 ---

--- a/docs/guides/getting-started/index.md
+++ b/docs/guides/getting-started/index.md
@@ -1,6 +1,6 @@
 ---
 title: Getting started
-desc: A quick start guide to add Dialtone to your project.
+description: A quick start guide to add Dialtone to your project.
 ---
 
 ## Adding Dialtone to your project

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,6 +1,6 @@
 ---
 title: Guides
-desc: In-depth guidance to support consistent, high-quality product design.
+description: In-depth guidance to support consistent, high-quality product design.
 no_preview: true
 ---
 

--- a/docs/guides/writing-guidelines/index.md
+++ b/docs/guides/writing-guidelines/index.md
@@ -1,6 +1,6 @@
 ---
 title: Writing guidelines
-desc: Guidance on voice and tone, terms, grammar, and more.
+description: Guidance on voice and tone, terms, grammar, and more.
 ---
 
 ## Principles

--- a/docs/utilities/backgrounds/attachment.md
+++ b/docs/utilities/backgrounds/attachment.md
@@ -1,6 +1,6 @@
 ---
 title: Background attachment
-desc: Utilities for controlling the way an element's background image position is fixed within the viewport or scrolls with its containing block.
+description: Utilities for controlling the way an element's background image position is fixed within the viewport or scrolls with its containing block.
 ---
 
 ## Scroll

--- a/docs/utilities/backgrounds/clip.md
+++ b/docs/utilities/backgrounds/clip.md
@@ -1,6 +1,6 @@
 ---
 title: Background clip
-desc: Utilities for controlling whether an element's background extends underneath its border, padding, or content box.
+description: Utilities for controlling whether an element's background extends underneath its border, padding, or content box.
 ---
 
 ## Usage

--- a/docs/utilities/backgrounds/color.md
+++ b/docs/utilities/backgrounds/color.md
@@ -1,6 +1,6 @@
 ---
 title: Background colors
-desc: Utilities for setting background colors.
+description: Utilities for setting background colors.
 ---
 
 <aside class="d-notice d-notice--warning d-mt24 d-wmx100p" role="status" aria-hidden="false">

--- a/docs/utilities/backgrounds/gradients.md
+++ b/docs/utilities/backgrounds/gradients.md
@@ -1,6 +1,6 @@
 ---
 title: Gradients
-desc: Utilities for creating an background gradient and controlling its stops.
+description: Utilities for creating an background gradient and controlling its stops.
 ---
 
 ## Starting color

--- a/docs/utilities/backgrounds/patterns.md
+++ b/docs/utilities/backgrounds/patterns.md
@@ -1,6 +1,6 @@
 ---
 title: Background Patterns
-desc: Utilities for adding distinctive background patterns for Department and Call Centers.
+description: Utilities for adding distinctive background patterns for Department and Call Centers.
 ---
 
 ## Usage

--- a/docs/utilities/backgrounds/position.md
+++ b/docs/utilities/backgrounds/position.md
@@ -1,6 +1,6 @@
 ---
 title: Background position
-desc: Utilities for controlling the position of an element's background image.
+description: Utilities for controlling the position of an element's background image.
 ---
 
 ## Usage

--- a/docs/utilities/backgrounds/repeat.md
+++ b/docs/utilities/backgrounds/repeat.md
@@ -1,6 +1,6 @@
 ---
 title: Background repeat
-desc: Utilities for controlling if or how an element's background image repeats.
+description: Utilities for controlling if or how an element's background image repeats.
 ---
 
 ## Usage

--- a/docs/utilities/backgrounds/size.md
+++ b/docs/utilities/backgrounds/size.md
@@ -1,6 +1,6 @@
 ---
 title: Background size
-desc: Utilities for controlling an element's background size.
+description: Utilities for controlling an element's background size.
 ---
 
 ## Usage

--- a/docs/utilities/borders/color.md
+++ b/docs/utilities/borders/color.md
@@ -1,6 +1,6 @@
 ---
 title: Border colors
-desc: Utilities for controlling an element's border color.
+description: Utilities for controlling an element's border color.
 ---
 
 <aside class="d-notice d-notice--warning d-mt24 d-wmx100p" role="status" aria-hidden="false">

--- a/docs/utilities/borders/direction.md
+++ b/docs/utilities/borders/direction.md
@@ -1,6 +1,6 @@
 ---
 title: Border directions
-desc: Utilities for controlling an element's border.
+description: Utilities for controlling an element's border.
 ---
 
 ## All sides

--- a/docs/utilities/borders/divide-color.md
+++ b/docs/utilities/borders/divide-color.md
@@ -1,6 +1,6 @@
 ---
 title: Divide color
-desc: Utilities for controlling the border color between an element's child items.
+description: Utilities for controlling the border color between an element's child items.
 ---
 
 ## Vertical dividers

--- a/docs/utilities/borders/divide-width.md
+++ b/docs/utilities/borders/divide-width.md
@@ -1,6 +1,6 @@
 ---
 title: Divide width
-desc: Utilities for controlling the divider width between an element's child items.
+description: Utilities for controlling the divider width between an element's child items.
 ---
 
 ## Default width

--- a/docs/utilities/borders/radius.md
+++ b/docs/utilities/borders/radius.md
@@ -1,6 +1,6 @@
 ---
 title: Border radius
-desc: Utilities for controlling an element's border radius.
+description: Utilities for controlling an element's border radius.
 ---
 
 ## All corners

--- a/docs/utilities/borders/style.md
+++ b/docs/utilities/borders/style.md
@@ -1,6 +1,6 @@
 ---
 title: Border style.
-desc: Utilities for controlling an element's border style.
+description: Utilities for controlling an element's border style.
 ---
 
 ## Dashed borders

--- a/docs/utilities/borders/width.md
+++ b/docs/utilities/borders/width.md
@@ -1,6 +1,6 @@
 ---
 title: Border widths
-desc: Utilities for controlling an element's border width.
+description: Utilities for controlling an element's border width.
 ---
 
 ## All sides

--- a/docs/utilities/effects/box-shadow.md
+++ b/docs/utilities/effects/box-shadow.md
@@ -1,6 +1,6 @@
 ---
 title: Box shadows
-desc: Utilities for controlling an element's box shadows.
+description: Utilities for controlling an element's box shadows.
 ---
 
 ## Outer shadow

--- a/docs/utilities/effects/opacity.md
+++ b/docs/utilities/effects/opacity.md
@@ -1,6 +1,6 @@
 ---
 title: Opacity
-desc: Utility classes for changing an element's opacity.
+description: Utility classes for changing an element's opacity.
 ---
 
 ## Usage

--- a/docs/utilities/effects/transition.md
+++ b/docs/utilities/effects/transition.md
@@ -1,6 +1,6 @@
 ---
 title: Transition
-desc: Utilities for controlling how an element transitions in and out of states.
+description: Utilities for controlling how an element transitions in and out of states.
 ---
 
 ## Adding a transition

--- a/docs/utilities/flex/align-content.md
+++ b/docs/utilities/flex/align-content.md
@@ -1,6 +1,6 @@
 ---
 title: Align content
-desc: Utilities for setting how rows are distributed along it's cross axis. This property only works when a parent container has more than one line.
+description: Utilities for setting how rows are distributed along it's cross axis. This property only works when a parent container has more than one line.
 ---
 
 ## Flex start

--- a/docs/utilities/flex/align-items.md
+++ b/docs/utilities/flex/align-items.md
@@ -1,6 +1,6 @@
 ---
 title: Align items
-desc: Utilities for setting how an element's is aligned along an element's cross axis.
+description: Utilities for setting how an element's is aligned along an element's cross axis.
 ---
 
 ## Stretch

--- a/docs/utilities/flex/align-self.md
+++ b/docs/utilities/flex/align-self.md
@@ -1,6 +1,6 @@
 ---
 title: Align self
-desc: Utilities for setting how an element's is aligned along a parent's cross axis.
+description: Utilities for setting how an element's is aligned along a parent's cross axis.
 ---
 
 ## Stretch

--- a/docs/utilities/flex/columns-layouts.md
+++ b/docs/utilities/flex/columns-layouts.md
@@ -1,6 +1,6 @@
 ---
 title: Columns & layouts
-desc: Utilities for flex columns and common flex layouts.
+description: Utilities for flex columns and common flex layouts.
 ---
 
 ## Creating flex columns

--- a/docs/utilities/flex/direction-wrap-flow.md
+++ b/docs/utilities/flex/direction-wrap-flow.md
@@ -1,6 +1,6 @@
 ---
 title: Direction, Wrap, & Flow
-desc: Utilities for setting an object's flex direction, wrap, and flow directions.
+description: Utilities for setting an object's flex direction, wrap, and flow directions.
 ---
 
 ## Flex direction

--- a/docs/utilities/flex/flex-grow-shrink.md
+++ b/docs/utilities/flex/flex-grow-shrink.md
@@ -1,6 +1,6 @@
 ---
 title: Flex, Grow, & Shrink
-desc: Utilities for setting an object's flex, grow, and shrink flex properties.
+description: Utilities for setting an object's flex, grow, and shrink flex properties.
 ---
 
 ## Flex

--- a/docs/utilities/flex/justify.md
+++ b/docs/utilities/flex/justify.md
@@ -1,6 +1,6 @@
 ---
 title: Justify content
-desc: Utilities for setting how an element's space around and between content is distributed along it's main axis.
+description: Utilities for setting how an element's space around and between content is distributed along it's main axis.
 ---
 
 ## Classes

--- a/docs/utilities/flex/order.md
+++ b/docs/utilities/flex/order.md
@@ -1,6 +1,6 @@
 ---
 title: Order
-desc: Utilities for controlling an element's order within a parent container.
+description: Utilities for controlling an element's order within a parent container.
 ---
 
 ## Example

--- a/docs/utilities/grid/column-start-end-span.md
+++ b/docs/utilities/grid/column-start-end-span.md
@@ -1,6 +1,6 @@
 ---
 title: Column Start / End / Span
-desc: Utilities for controlling how elements are placed across grid columns.
+description: Utilities for controlling how elements are placed across grid columns.
 ---
 
 ## Spanning columns

--- a/docs/utilities/grid/gap.md
+++ b/docs/utilities/grid/gap.md
@@ -1,6 +1,6 @@
 ---
 title: Gap
-desc: Utilities to control the spacing between columns, rows, or both in grids.
+description: Utilities to control the spacing between columns, rows, or both in grids.
 ---
 
 ## Adding universal row and column gaps

--- a/docs/utilities/grid/justify-items.md
+++ b/docs/utilities/grid/justify-items.md
@@ -1,6 +1,6 @@
 ---
 title: Justify items
-desc: Utilities for controlling how grid items align along their inline axis.
+description: Utilities for controlling how grid items align along their inline axis.
 ---
 
 ## Auto

--- a/docs/utilities/grid/justify-self.md
+++ b/docs/utilities/grid/justify-self.md
@@ -1,6 +1,6 @@
 ---
 title: Justify self
-desc: Utilities for controlling how a grid item is aligned along its inline axis.
+description: Utilities for controlling how a grid item is aligned along its inline axis.
 ---
 
 ## Auto

--- a/docs/utilities/grid/layouts.md
+++ b/docs/utilities/grid/layouts.md
@@ -1,6 +1,6 @@
 ---
 title: Layouts
-desc: Common grid layout patterns used throughout Dialpad and UberConference.
+description: Common grid layout patterns used throughout Dialpad and UberConference.
 ---
 
 ## Sidebar

--- a/docs/utilities/grid/place-content.md
+++ b/docs/utilities/grid/place-content.md
@@ -1,6 +1,6 @@
 ---
 title: Place content
-desc: Utilities for controlling how grid items are aligned along both the block and inline axis directions.
+description: Utilities for controlling how grid items are aligned along both the block and inline axis directions.
 ---
 
 ## Stretch

--- a/docs/utilities/grid/place-items.md
+++ b/docs/utilities/grid/place-items.md
@@ -1,6 +1,6 @@
 ---
 title: Place items
-desc: Utilities for controlling how grid items are aligned along their block and inline axis directions.
+description: Utilities for controlling how grid items are aligned along their block and inline axis directions.
 ---
 
 ## Stretch

--- a/docs/utilities/grid/place-self.md
+++ b/docs/utilities/grid/place-self.md
@@ -1,6 +1,6 @@
 ---
 title: Place self
-desc: Utilities for controlling a grid item's alignment along their block and inline axis directions.
+description: Utilities for controlling a grid item's alignment along their block and inline axis directions.
 ---
 
 ## Stretch

--- a/docs/utilities/grid/row-start-end-span.md
+++ b/docs/utilities/grid/row-start-end-span.md
@@ -1,6 +1,6 @@
 ---
 title: Row Start / End / Span
-desc: Utilities for controlling how elements are placed across grid rows.
+description: Utilities for controlling how elements are placed across grid rows.
 ---
 
 ## Spanning rows

--- a/docs/utilities/grid/understanding.md
+++ b/docs/utilities/grid/understanding.md
@@ -1,6 +1,6 @@
 ---
 title: Understanding Grids
-desc: CSS grids are a two-dimensional layout tool that allow you to place items within columns and rows simulateously unlike Flexbox which is a one-dimensional layout tool and requires complex nesting at times.
+description: CSS grids are a two-dimensional layout tool that allow you to place items within columns and rows simulateously unlike Flexbox which is a one-dimensional layout tool and requires complex nesting at times.
 ---
 
 In the past CSS grid systems based on Flexbox required a number of CSS classes to achieve two-dimensional layouts. With the introduction of CSS grids, that is no longer needed. Most grid layouts can be generated quickly using CSS within your Less. Also CSS grids are highly specific to the content placed within it. That said, there are a few common layouts and grid helpers that Dialtone provides to help you as you're laying out content.

--- a/docs/utilities/index.md
+++ b/docs/utilities/index.md
@@ -1,6 +1,6 @@
 ---
 title: CSS utilities
-desc: A utility-first CSS framework for building user interfaces.
+description: A utility-first CSS framework for building user interfaces.
 ---
 
 ## Introduction

--- a/docs/utilities/interactivity/cursor.md
+++ b/docs/utilities/interactivity/cursor.md
@@ -1,6 +1,6 @@
 ---
 title: Cursor
-desc: Utilities for setting the type of mouse cursor, if any, to show when the mouse pointer is over an element.
+description: Utilities for setting the type of mouse cursor, if any, to show when the mouse pointer is over an element.
 ---
 ## Usage
 

--- a/docs/utilities/interactivity/outline.md
+++ b/docs/utilities/interactivity/outline.md
@@ -1,6 +1,6 @@
 ---
 title: Outline
-desc: Utilities for controlling an element's outline.
+description: Utilities for controlling an element's outline.
 ---
 
 ## Usage

--- a/docs/utilities/interactivity/pointer-events.md
+++ b/docs/utilities/interactivity/pointer-events.md
@@ -1,6 +1,6 @@
 ---
 title: Pointer events
-desc: Utilities for controlling how an element responds to mouse/touch events.
+description: Utilities for controlling how an element responds to mouse/touch events.
 ---
 
 ## Pointer event classes

--- a/docs/utilities/interactivity/resize.md
+++ b/docs/utilities/interactivity/resize.md
@@ -1,6 +1,6 @@
 ---
 title: Resize
-desc: Utilities for controlling the resize of an element.
+description: Utilities for controlling the resize of an element.
 ---
 
 ## Usage

--- a/docs/utilities/layout/box-sizing.md
+++ b/docs/utilities/layout/box-sizing.md
@@ -1,6 +1,6 @@
 ---
 title: Box sizing
-desc: Utilities for controlling how the browser should calculate an element's total size.
+description: Utilities for controlling how the browser should calculate an element's total size.
 ---
 
 ## Examples

--- a/docs/utilities/layout/coordinates.md
+++ b/docs/utilities/layout/coordinates.md
@@ -1,6 +1,6 @@
 ---
 title: Coordinates
-desc: Utility classes to assign an element’s top, right, bottom, or left position.
+description: Utility classes to assign an element’s top, right, bottom, or left position.
 ---
 
 ## Positive coordinates

--- a/docs/utilities/layout/display.md
+++ b/docs/utilities/layout/display.md
@@ -1,6 +1,6 @@
 ---
 title: Display
-desc: Utilities for controlling the display box type of an element.
+description: Utilities for controlling the display box type of an element.
 ---
 
 ## Examples

--- a/docs/utilities/layout/overflow.md
+++ b/docs/utilities/layout/overflow.md
@@ -1,6 +1,6 @@
 ---
 title: Overflow
-desc: Utilities for controlling how an element handles content that is too large for the container.
+description: Utilities for controlling how an element handles content that is too large for the container.
 ---
 
 ## Examples

--- a/docs/utilities/layout/position.md
+++ b/docs/utilities/layout/position.md
@@ -1,6 +1,6 @@
 ---
 title: Position
-desc: Utility classes to change an element’s position type.
+description: Utility classes to change an element’s position type.
 ---
 
 ## Examples

--- a/docs/utilities/layout/visibility.md
+++ b/docs/utilities/layout/visibility.md
@@ -1,6 +1,6 @@
 ---
 title: Visibility
-desc: Utilities for showing or hiding an element without changing the layout of a document.
+description: Utilities for showing or hiding an element without changing the layout of a document.
 ---
 
 ## Usage

--- a/docs/utilities/layout/z-index.md
+++ b/docs/utilities/layout/z-index.md
@@ -1,6 +1,6 @@
 ---
 title: Z-Index
-desc: Utility classes for setting an element's z-index level.
+description: Utility classes for setting an element's z-index level.
 ---
 
 ## Classes

--- a/docs/utilities/responsive/breakpoints.md
+++ b/docs/utilities/responsive/breakpoints.md
@@ -1,6 +1,6 @@
 ---
 title: Breakpoints
-desc: All classes can have responsive variations. Using our plugin @dialpad/postcss-responsive-variations and configuring the breakpoint constants, you can create media queries represented in conditional prefixes. These prefixed classes allow you to apply a style or property within a specific breakpoint.
+description: All classes can have responsive variations. Using our plugin @dialpad/postcss-responsive-variations and configuring the breakpoint constants, you can create media queries represented in conditional prefixes. These prefixed classes allow you to apply a style or property within a specific breakpoint.
 ---
 
 ## PostCSS

--- a/docs/utilities/sizing/height.md
+++ b/docs/utilities/sizing/height.md
@@ -1,6 +1,6 @@
 ---
 title: Height
-desc: Utilities to control an element's height.
+description: Utilities to control an element's height.
 ---
 
 ## Percentages

--- a/docs/utilities/sizing/max-height.md
+++ b/docs/utilities/sizing/max-height.md
@@ -1,6 +1,6 @@
 ---
 title: Max-height
-desc: Utilities to control an element's maximum height.
+description: Utilities to control an element's maximum height.
 ---
 
 ## Example

--- a/docs/utilities/sizing/max-width.md
+++ b/docs/utilities/sizing/max-width.md
@@ -1,6 +1,6 @@
 ---
 title: Max-width
-desc: Utilities to control an element's maximum width.
+description: Utilities to control an element's maximum width.
 ---
 
 ## Percentages

--- a/docs/utilities/sizing/min-height.md
+++ b/docs/utilities/sizing/min-height.md
@@ -1,6 +1,6 @@
 ---
 title: Min-height
-desc: Utilities to control an element's minimum height.
+description: Utilities to control an element's minimum height.
 ---
 
 ## Percentages

--- a/docs/utilities/sizing/min-width.md
+++ b/docs/utilities/sizing/min-width.md
@@ -1,6 +1,6 @@
 ---
 title: Min-width
-desc: Utilities to control an element's minimum width.
+description: Utilities to control an element's minimum width.
 ---
 
 ## Percentages

--- a/docs/utilities/sizing/width.md
+++ b/docs/utilities/sizing/width.md
@@ -1,6 +1,6 @@
 ---
 title: Width
-desc: Utilities to control an element's width.
+description: Utilities to control an element's width.
 ---
 
 ## Percentages

--- a/docs/utilities/spacing/auto-spacing.md
+++ b/docs/utilities/spacing/auto-spacing.md
@@ -1,6 +1,6 @@
 ---
 title: Auto spacing
-desc: Utilities for controlling the space between child elements.
+description: Utilities for controlling the space between child elements.
 ---
 
 ## Adding space vertically

--- a/docs/utilities/spacing/margin.md
+++ b/docs/utilities/spacing/margin.md
@@ -1,6 +1,6 @@
 ---
 title: Margins
-desc: Utilities to adjust an element's exterior spacing between other objects.
+description: Utilities to adjust an element's exterior spacing between other objects.
 ---
 
 ## Add margin to all sides

--- a/docs/utilities/spacing/padding.md
+++ b/docs/utilities/spacing/padding.md
@@ -1,6 +1,6 @@
 ---
 title: Padding
-desc: Utilities for setting an element's interior spacing between child elements and the element's box edge.
+description: Utilities for setting an element's interior spacing between child elements and the element's box edge.
 ---
 
 ## Add padding to all sides

--- a/docs/utilities/typography/color.md
+++ b/docs/utilities/typography/color.md
@@ -1,6 +1,6 @@
 ---
 title: Colors
-desc: Utilities to change an element's font-color.
+description: Utilities to change an element's font-color.
 ---
 
 All font colors pass the WCAG 2.1 Level AA contrast ratio requirements (ratio >= 4.5:1) and most pass WCAG 2.1 Level AAA requirements (ratio >= 7:1).

--- a/docs/utilities/typography/font-family.md
+++ b/docs/utilities/typography/font-family.md
@@ -1,6 +1,6 @@
 ---
 title: Font family
-desc: Utilities to change an element's font-family.
+description: Utilities to change an element's font-family.
 ---
 
 ## Custom

--- a/docs/utilities/typography/font-size.md
+++ b/docs/utilities/typography/font-size.md
@@ -1,6 +1,6 @@
 ---
 title: Font size
-desc: Utilities to change an element's font-size.
+description: Utilities to change an element's font-size.
 ---
 
 ## Usage

--- a/docs/utilities/typography/font-style.md
+++ b/docs/utilities/typography/font-style.md
@@ -1,6 +1,6 @@
 ---
 title: Font style
-desc: Utilities to change an element's font styles.
+description: Utilities to change an element's font styles.
 ---
 
 ## Italics

--- a/docs/utilities/typography/font-weight.md
+++ b/docs/utilities/typography/font-weight.md
@@ -1,6 +1,6 @@
 ---
 title: Font weight
-desc: Utilities to change an element's font-weight.
+description: Utilities to change an element's font-weight.
 ---
 
 ## Classes

--- a/docs/utilities/typography/line-height.md
+++ b/docs/utilities/typography/line-height.md
@@ -1,6 +1,6 @@
 ---
 title: Line height
-desc: Utilities to change an element's line-height.
+description: Utilities to change an element's line-height.
 ---
 
 ## Relative line-heights

--- a/docs/utilities/typography/lists.md
+++ b/docs/utilities/typography/lists.md
@@ -1,6 +1,6 @@
 ---
 title: Lists
-desc: Utilities for controlling list styling.
+description: Utilities for controlling list styling.
 ---
 
 ## Resetting a list

--- a/docs/utilities/typography/styles.md
+++ b/docs/utilities/typography/styles.md
@@ -1,6 +1,6 @@
 ---
 title: Typography Styles
-desc: Core typographic styles for body text and headlines.
+description: Core typographic styles for body text and headlines.
 ---
 
 ## Headlines

--- a/docs/utilities/typography/text-align.md
+++ b/docs/utilities/typography/text-align.md
@@ -1,6 +1,6 @@
 ---
 title: Text align
-desc: Utilities for controlling an element's text alignment.
+description: Utilities for controlling an element's text alignment.
 ---
 
 ## Usage

--- a/docs/utilities/typography/text-decoration.md
+++ b/docs/utilities/typography/text-decoration.md
@@ -1,6 +1,6 @@
 ---
 title: Text decoration
-desc: Utilities to change an element's text decoration styles.
+description: Utilities to change an element's text decoration styles.
 ---
 
 ## Underline

--- a/docs/utilities/typography/text-opacity.md
+++ b/docs/utilities/typography/text-opacity.md
@@ -1,6 +1,6 @@
 ---
 title: Text opacity
-desc: Utilities for controlling an element's font-color opacity.
+description: Utilities for controlling an element's font-color opacity.
 ---
 The ability to control an element's color is <em>only</em> provided as a class. We do not provide variables to control this. The text opacity class resets the font color's alpha channel CSS variable value.
 

--- a/docs/utilities/typography/text-overflow.md
+++ b/docs/utilities/typography/text-overflow.md
@@ -1,6 +1,6 @@
 ---
 title: Text overflow
-desc: Utilities for controlling an element's text overflow.
+description: Utilities for controlling an element's text overflow.
 ---
 
 ## Truncate

--- a/docs/utilities/typography/text-transform.md
+++ b/docs/utilities/typography/text-transform.md
@@ -1,6 +1,6 @@
 ---
 title: Text transform
-desc: Utilities for controlling an element's text transform.
+description: Utilities for controlling an element's text transform.
 ---
 
 ## Uppercase

--- a/docs/utilities/typography/vertical-align.md
+++ b/docs/utilities/typography/vertical-align.md
@@ -1,6 +1,6 @@
 ---
 title: Vertical align
-desc: Utilities for controlling an element's text transform.
+description: Utilities for controlling an element's text transform.
 ---
 
 ## Baseline

--- a/docs/utilities/typography/whitespace.md
+++ b/docs/utilities/typography/whitespace.md
@@ -1,6 +1,6 @@
 ---
 title: Whitespace
-desc: Utilities for controlling an element's whitespace.
+description: Utilities for controlling an element's whitespace.
 ---
 
 ## Normal

--- a/docs/utilities/typography/word-break.md
+++ b/docs/utilities/typography/word-break.md
@@ -1,6 +1,6 @@
 ---
 title: Word break
-desc: Utilities for controlling the way words break within an element.
+description: Utilities for controlling the way words break within an element.
 ---
 
 ## Normal

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
         "stylelint-no-px": "^1.0.1",
         "through2": "^4.0.2",
         "vuepress": "2.0.0-beta.59",
+        "vuepress-plugin-seo2": "^2.0.0-beta.124",
         "vuepress-plugin-sitemap2": "2.0.0-beta.143",
         "yargs": "^17.6.2"
       }
@@ -28404,6 +28405,449 @@
         "vuepress": "bin/vuepress.js"
       }
     },
+    "node_modules/vuepress-plugin-seo2": {
+      "version": "2.0.0-beta.124",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-seo2/-/vuepress-plugin-seo2-2.0.0-beta.124.tgz",
+      "integrity": "sha512-PTr8VAjtAZ5l4T9HB15UgRGQ2zQVH/FgpI4A9nlZoYSXYhnrdQyTEH+N33UtZX95LkKhSIN9anB2D72ekP+sGQ==",
+      "dev": true,
+      "dependencies": {
+        "@vuepress/shared": "2.0.0-beta.53",
+        "@vuepress/utils": "2.0.0-beta.53",
+        "gray-matter": "^4.0.3",
+        "vuepress-shared": "2.0.0-beta.124"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/@vuepress/client": {
+      "version": "2.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@vuepress/client/-/client-2.0.0-beta.53.tgz",
+      "integrity": "sha512-TDKxlrUvwfWu3QAY4SHeu9mVqBkEoKvuoy0WsKy7x9omEy8+HJG1O9y664bP9SotD52skcKL1iW38nQJR2+AkQ==",
+      "dev": true,
+      "dependencies": {
+        "@vue/devtools-api": "^6.4.5",
+        "@vuepress/shared": "2.0.0-beta.53",
+        "vue": "^3.2.41",
+        "vue-router": "^4.1.6"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/@vuepress/core": {
+      "version": "2.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-beta.53.tgz",
+      "integrity": "sha512-s642hM+PpiNphLm/KZvva45OYKX6hWRh2Y+C92TDGzCMxiONI8ZxGLqXRCw5bKw5NGh91s+P4sf3iaY+JxL1Ig==",
+      "dev": true,
+      "dependencies": {
+        "@vuepress/client": "2.0.0-beta.53",
+        "@vuepress/markdown": "2.0.0-beta.53",
+        "@vuepress/shared": "2.0.0-beta.53",
+        "@vuepress/utils": "2.0.0-beta.53",
+        "vue": "^3.2.41"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/@vuepress/markdown": {
+      "version": "2.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-beta.53.tgz",
+      "integrity": "sha512-ohIujGc0tVSsFTBD5kyB0asxLsDtctzrOOgHvaS2fDWqm0MQisjxnQKNFdbWk9bfddAyty0aKN+m/4l0f5lCDw==",
+      "dev": true,
+      "dependencies": {
+        "@mdit-vue/plugin-component": "^0.11.1",
+        "@mdit-vue/plugin-frontmatter": "^0.11.1",
+        "@mdit-vue/plugin-headers": "^0.11.1",
+        "@mdit-vue/plugin-sfc": "^0.11.1",
+        "@mdit-vue/plugin-title": "^0.11.1",
+        "@mdit-vue/plugin-toc": "^0.11.1",
+        "@mdit-vue/shared": "^0.11.0",
+        "@mdit-vue/types": "^0.11.0",
+        "@types/markdown-it": "^12.2.3",
+        "@types/markdown-it-emoji": "^2.0.2",
+        "@vuepress/shared": "2.0.0-beta.53",
+        "@vuepress/utils": "2.0.0-beta.53",
+        "markdown-it": "^13.0.1",
+        "markdown-it-anchor": "^8.6.5",
+        "markdown-it-emoji": "^2.0.2",
+        "mdurl": "^1.0.1"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/@vuepress/plugin-git": {
+      "version": "2.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-git/-/plugin-git-2.0.0-beta.53.tgz",
+      "integrity": "sha512-hefVEUhxTgvDcrsIutVBBfJvixR/L6iTQZ9eDAj2z71fOgnVNdN8PNZ9XRDm3nhZrye9X44AmJI82Wk9SlwgVw==",
+      "dev": true,
+      "dependencies": {
+        "@vuepress/core": "2.0.0-beta.53",
+        "@vuepress/utils": "2.0.0-beta.53",
+        "execa": "^6.1.0"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/@vuepress/shared": {
+      "version": "2.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@vuepress/shared/-/shared-2.0.0-beta.53.tgz",
+      "integrity": "sha512-B0qWorGxC3ruSHdZcJW24XtEDEU3L3uPr0xzTeKVfHjOM4b9hN83YzBtW4n/WPnmk1RXVE9266Ulh9ZL5okGOw==",
+      "dev": true,
+      "dependencies": {
+        "@mdit-vue/types": "^0.11.0",
+        "@vue/shared": "^3.2.41"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/@vuepress/utils": {
+      "version": "2.0.0-beta.53",
+      "resolved": "https://registry.npmjs.org/@vuepress/utils/-/utils-2.0.0-beta.53.tgz",
+      "integrity": "sha512-cYqAspUJoY1J84kbDbPbrIcfaoID5Wb+BUrcWV7x8EFPXTn/KBLgc4/KBxWkdxk8O9V96/bXBDSLlalqLJCmJw==",
+      "dev": true,
+      "dependencies": {
+        "@types/debug": "^4.1.7",
+        "@types/fs-extra": "^9.0.13",
+        "@types/hash-sum": "^1.0.0",
+        "@vuepress/shared": "2.0.0-beta.53",
+        "chalk": "^5.1.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0",
+        "globby": "^13.1.2",
+        "hash-sum": "^2.0.0",
+        "ora": "^6.1.2",
+        "upath": "^2.0.1"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/bl": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/chalk": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/cli-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/execa": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^3.0.1",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/execa/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/globby": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+      "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/log-symbols": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^5.0.0",
+        "is-unicode-supported": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/ora": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-6.1.2.tgz",
+      "integrity": "sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^5.0.0",
+        "chalk": "^5.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-spinners": "^2.6.1",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^1.1.0",
+        "log-symbols": "^5.1.0",
+        "strip-ansi": "^7.0.1",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/restore-cursor": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/strip-ansi": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+      "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vuepress-plugin-seo2/node_modules/vuepress-shared": {
+      "version": "2.0.0-beta.124",
+      "resolved": "https://registry.npmjs.org/vuepress-shared/-/vuepress-shared-2.0.0-beta.124.tgz",
+      "integrity": "sha512-gMXvmKJtq+RqJnC4j/lDZrKimhQp5j087H0UI3iCQLqsZ/HddXIpqQElZr43jfEIpVEV3M/+usbiTF0fwepFlA==",
+      "dev": true,
+      "dependencies": {
+        "@vuepress/client": "2.0.0-beta.53",
+        "@vuepress/plugin-git": "2.0.0-beta.53",
+        "@vuepress/shared": "2.0.0-beta.53",
+        "@vuepress/utils": "2.0.0-beta.53",
+        "dayjs": "^1.11.6",
+        "execa": "^6.1.0",
+        "fflate": "^0.7.4",
+        "ora": "^6.1.2",
+        "striptags": "3.2.0",
+        "vue": "^3.2.45",
+        "vue-router": "^4.1.6"
+      }
+    },
     "node_modules/vuepress-plugin-sitemap2": {
       "version": "2.0.0-beta.143",
       "resolved": "https://registry.npmjs.org/vuepress-plugin-sitemap2/-/vuepress-plugin-sitemap2-2.0.0-beta.143.tgz",
@@ -50998,6 +51442,325 @@
       "dev": true,
       "requires": {
         "vuepress-vite": "2.0.0-beta.59"
+      }
+    },
+    "vuepress-plugin-seo2": {
+      "version": "2.0.0-beta.124",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-seo2/-/vuepress-plugin-seo2-2.0.0-beta.124.tgz",
+      "integrity": "sha512-PTr8VAjtAZ5l4T9HB15UgRGQ2zQVH/FgpI4A9nlZoYSXYhnrdQyTEH+N33UtZX95LkKhSIN9anB2D72ekP+sGQ==",
+      "dev": true,
+      "requires": {
+        "@vuepress/shared": "2.0.0-beta.53",
+        "@vuepress/utils": "2.0.0-beta.53",
+        "gray-matter": "^4.0.3",
+        "vuepress-shared": "2.0.0-beta.124"
+      },
+      "dependencies": {
+        "@vuepress/client": {
+          "version": "2.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@vuepress/client/-/client-2.0.0-beta.53.tgz",
+          "integrity": "sha512-TDKxlrUvwfWu3QAY4SHeu9mVqBkEoKvuoy0WsKy7x9omEy8+HJG1O9y664bP9SotD52skcKL1iW38nQJR2+AkQ==",
+          "dev": true,
+          "requires": {
+            "@vue/devtools-api": "^6.4.5",
+            "@vuepress/shared": "2.0.0-beta.53",
+            "vue": "^3.2.41",
+            "vue-router": "^4.1.6"
+          }
+        },
+        "@vuepress/core": {
+          "version": "2.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@vuepress/core/-/core-2.0.0-beta.53.tgz",
+          "integrity": "sha512-s642hM+PpiNphLm/KZvva45OYKX6hWRh2Y+C92TDGzCMxiONI8ZxGLqXRCw5bKw5NGh91s+P4sf3iaY+JxL1Ig==",
+          "dev": true,
+          "requires": {
+            "@vuepress/client": "2.0.0-beta.53",
+            "@vuepress/markdown": "2.0.0-beta.53",
+            "@vuepress/shared": "2.0.0-beta.53",
+            "@vuepress/utils": "2.0.0-beta.53",
+            "vue": "^3.2.41"
+          }
+        },
+        "@vuepress/markdown": {
+          "version": "2.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@vuepress/markdown/-/markdown-2.0.0-beta.53.tgz",
+          "integrity": "sha512-ohIujGc0tVSsFTBD5kyB0asxLsDtctzrOOgHvaS2fDWqm0MQisjxnQKNFdbWk9bfddAyty0aKN+m/4l0f5lCDw==",
+          "dev": true,
+          "requires": {
+            "@mdit-vue/plugin-component": "^0.11.1",
+            "@mdit-vue/plugin-frontmatter": "^0.11.1",
+            "@mdit-vue/plugin-headers": "^0.11.1",
+            "@mdit-vue/plugin-sfc": "^0.11.1",
+            "@mdit-vue/plugin-title": "^0.11.1",
+            "@mdit-vue/plugin-toc": "^0.11.1",
+            "@mdit-vue/shared": "^0.11.0",
+            "@mdit-vue/types": "^0.11.0",
+            "@types/markdown-it": "^12.2.3",
+            "@types/markdown-it-emoji": "^2.0.2",
+            "@vuepress/shared": "2.0.0-beta.53",
+            "@vuepress/utils": "2.0.0-beta.53",
+            "markdown-it": "^13.0.1",
+            "markdown-it-anchor": "^8.6.5",
+            "markdown-it-emoji": "^2.0.2",
+            "mdurl": "^1.0.1"
+          }
+        },
+        "@vuepress/plugin-git": {
+          "version": "2.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@vuepress/plugin-git/-/plugin-git-2.0.0-beta.53.tgz",
+          "integrity": "sha512-hefVEUhxTgvDcrsIutVBBfJvixR/L6iTQZ9eDAj2z71fOgnVNdN8PNZ9XRDm3nhZrye9X44AmJI82Wk9SlwgVw==",
+          "dev": true,
+          "requires": {
+            "@vuepress/core": "2.0.0-beta.53",
+            "@vuepress/utils": "2.0.0-beta.53",
+            "execa": "^6.1.0"
+          }
+        },
+        "@vuepress/shared": {
+          "version": "2.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@vuepress/shared/-/shared-2.0.0-beta.53.tgz",
+          "integrity": "sha512-B0qWorGxC3ruSHdZcJW24XtEDEU3L3uPr0xzTeKVfHjOM4b9hN83YzBtW4n/WPnmk1RXVE9266Ulh9ZL5okGOw==",
+          "dev": true,
+          "requires": {
+            "@mdit-vue/types": "^0.11.0",
+            "@vue/shared": "^3.2.41"
+          }
+        },
+        "@vuepress/utils": {
+          "version": "2.0.0-beta.53",
+          "resolved": "https://registry.npmjs.org/@vuepress/utils/-/utils-2.0.0-beta.53.tgz",
+          "integrity": "sha512-cYqAspUJoY1J84kbDbPbrIcfaoID5Wb+BUrcWV7x8EFPXTn/KBLgc4/KBxWkdxk8O9V96/bXBDSLlalqLJCmJw==",
+          "dev": true,
+          "requires": {
+            "@types/debug": "^4.1.7",
+            "@types/fs-extra": "^9.0.13",
+            "@types/hash-sum": "^1.0.0",
+            "@vuepress/shared": "2.0.0-beta.53",
+            "chalk": "^5.1.2",
+            "debug": "^4.3.4",
+            "fs-extra": "^10.1.0",
+            "globby": "^13.1.2",
+            "hash-sum": "^2.0.0",
+            "ora": "^6.1.2",
+            "upath": "^2.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+          "dev": true
+        },
+        "bl": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+          "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^6.0.3",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "chalk": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+          "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
+          "dev": true
+        },
+        "cli-cursor": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
+          "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^4.0.0"
+          }
+        },
+        "execa": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+          "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^3.0.1",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          },
+          "dependencies": {
+            "onetime": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+              "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+              "dev": true,
+              "requires": {
+                "mimic-fn": "^4.0.0"
+              }
+            }
+          }
+        },
+        "globby": {
+          "version": "13.1.3",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+          "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+          "dev": true,
+          "requires": {
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.11",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^4.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+          "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+          "dev": true
+        },
+        "is-interactive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+          "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "is-unicode-supported": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+          "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
+          "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^5.0.0",
+            "is-unicode-supported": "^1.1.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "dev": true,
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "ora": {
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-6.1.2.tgz",
+          "integrity": "sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==",
+          "dev": true,
+          "requires": {
+            "bl": "^5.0.0",
+            "chalk": "^5.0.0",
+            "cli-cursor": "^4.0.0",
+            "cli-spinners": "^2.6.1",
+            "is-interactive": "^2.0.0",
+            "is-unicode-supported": "^1.1.0",
+            "log-symbols": "^5.1.0",
+            "strip-ansi": "^7.0.1",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "restore-cursor": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
+          "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
+          "dev": true,
+          "requires": {
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+          "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "dev": true
+        },
+        "vuepress-shared": {
+          "version": "2.0.0-beta.124",
+          "resolved": "https://registry.npmjs.org/vuepress-shared/-/vuepress-shared-2.0.0-beta.124.tgz",
+          "integrity": "sha512-gMXvmKJtq+RqJnC4j/lDZrKimhQp5j087H0UI3iCQLqsZ/HddXIpqQElZr43jfEIpVEV3M/+usbiTF0fwepFlA==",
+          "dev": true,
+          "requires": {
+            "@vuepress/client": "2.0.0-beta.53",
+            "@vuepress/plugin-git": "2.0.0-beta.53",
+            "@vuepress/shared": "2.0.0-beta.53",
+            "@vuepress/utils": "2.0.0-beta.53",
+            "dayjs": "^1.11.6",
+            "execa": "^6.1.0",
+            "fflate": "^0.7.4",
+            "ora": "^6.1.2",
+            "striptags": "3.2.0",
+            "vue": "^3.2.45",
+            "vue-router": "^4.1.6"
+          }
+        }
       }
     },
     "vuepress-plugin-sitemap2": {

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "stylelint-no-px": "^1.0.1",
     "through2": "^4.0.2",
     "vuepress": "2.0.0-beta.59",
+    "vuepress-plugin-seo2": "^2.0.0-beta.124",
     "vuepress-plugin-sitemap2": "2.0.0-beta.143",
     "yargs": "^17.6.2"
   }


### PR DESCRIPTION
## Description
Added [Open Graph](https://ogp.me/) metadata to the pages through [this plugin](https://vuepress-theme-hope.github.io/v2/seo/guide.html) so that social sites can unfold URLs based on this data.
- Renamed `desc` frontmatter prop to description that way [Vuepress](https://v2.vuepress.vuejs.org/reference/frontmatter.html#description) uses this to the meta description.
- For the component pages, used the thumbnail image for the `og:image` prop.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://i.giphy.com/media/dxyZTfRE610Vg9pkJe/giphy.webp)
