### PR TITLE
docs: fix empty landing pages

### DIFF
--- a/docs/.vuepress/theme/components/PageHeader.vue
+++ b/docs/.vuepress/theme/components/PageHeader.vue
@@ -30,7 +30,7 @@
       </h2>
       <span>
         <a
-          v-if="$frontmatter.storybook"
+          v-if="$frontmatter.storybook && $frontmatter.storybook !== 'planned'"
           class="d-btn d-btn--muted d-btn--muted"
           :href="$frontmatter.storybook"
           target="_blank"

--- a/docs/.vuepress/theme/components/SidebarItem.vue
+++ b/docs/.vuepress/theme/components/SidebarItem.vue
@@ -10,7 +10,7 @@
         :key="subItem.text"
       >
         <router-link
-          v-if="subItem.link && !subItem.planned"
+          v-if="!subItem.planned"
           v-slot="{ href, navigate, isActive, isExactActive }"
           :to="subItem.link"
           custom

--- a/docs/.vuepress/theme/index.js
+++ b/docs/.vuepress/theme/index.js
@@ -37,13 +37,15 @@ function _blogPostsFrontmatter (app) {
     }));
 }
 
-function _extractFrontmatter (app, path, options) {
+function _extractFrontmatter (app, path, options, exceptions = []) {
   const sortingArr = options?.sidebar[path][0].children.map(child => child.text.toLowerCase().replaceAll(' ', '-'));
   const indexPage = app.pages.find(page => page.path === path);
+  const regExpPath = new RegExp(`${path}.+`);
 
   indexPage.data.enhancedFrontmatter = app.pages
-    .filter(page => page.path.startsWith(path) && page.path.endsWith('.html'))
-    .filter(page => page.frontmatter && (page.frontmatter.title || page.frontmatter.shortTitle))
+    .filter(page => regExpPath.test(page.path))
+    .filter(page => page.frontmatter?.title || page.frontmatter?.shortTitle)
+    .filter(page => !exceptions.includes(page.path))
     .map(page => {
       const fileName = page.frontmatter.title.toLowerCase().replaceAll(' ', '-');
       return {
@@ -125,7 +127,7 @@ export const dialtoneVuepressTheme = (options) => {
     onInitialized (app) {
       _blogPostsFrontmatter(app);
       _extractFrontmatter(app, '/guides/', options);
-      _extractFrontmatter(app, '/components/', options);
+      _extractFrontmatter(app, '/components/', options, ['/components/status/']);
       _extractFrontmatter(app, '/design/', options);
       _extractComponentStatus(app);
     },

--- a/docs/.vuepress/views/Overview.vue
+++ b/docs/.vuepress/views/Overview.vue
@@ -4,7 +4,8 @@
       v-for="page in pages"
       :key="page.title"
     >
-      <router-link
+      <component
+        :is="cardElType(page)"
         :to="`/${basePath}/${page.link}/`"
         class="dialtone-wall__item"
       >
@@ -33,7 +34,7 @@
             {{ page.description }}
           </div>
         </div>
-      </router-link>
+      </component>
     </template>
   </div>
 </template>
@@ -63,5 +64,9 @@ const badgeKindClass = (status) => {
 const pageTitle = (page) => {
   const shortTitle = page.shortTitle ? page.shortTitle[0].toUpperCase() + page.shortTitle.slice(1) : undefined;
   return shortTitle || page.title;
+};
+const cardElType = (page) => {
+  if (page.status !== 'planned' || (page.storybook && page.storybook !== 'planned')) return 'router-link';
+  return 'div';
 };
 </script>

--- a/docs/_data/site-nav.json
+++ b/docs/_data/site-nav.json
@@ -32,7 +32,7 @@
         },
         {
           "text": "Design principles",
-          "link": "",
+          "link": "/guides/design-principles/",
           "planned": true
         },
         {
@@ -45,12 +45,12 @@
         },
         {
           "text": "Brand",
-          "link": "",
+          "link": "/guides/brand/",
           "planned": true
         },
         {
           "text": "Design assets",
-          "link": "",
+          "link": "/guides/design-assets/",
           "planned": true
         }
       ]
@@ -522,7 +522,8 @@
         },
         {
           "text": "Emoji picker",
-          "link": "/components/emoji-picker.html"
+          "link": "/components/emoji-picker.html",
+          "planned": true
         },
         {
           "text": "Emoji text wrapper",
@@ -534,7 +535,8 @@
         },
         {
           "text": "Infinite scroll",
-          "link": "/components/infinite-scroll.html"
+          "link": "/components/infinite-scroll.html",
+          "planned": true
         },
         {
           "text": "Input",

--- a/docs/components/emoji-picker.md
+++ b/docs/components/emoji-picker.md
@@ -1,5 +1,5 @@
 ---
-title: Emoji Picker
+title: Emoji picker
 thumb: true
 image: assets/images/components/emoji-picker.png
 status: planned

--- a/docs/components/infinite-scroll.md
+++ b/docs/components/infinite-scroll.md
@@ -1,5 +1,5 @@
 ---
-title: Infinite Scroll
+title: Infinite scroll
 thumb: true
 image: assets/images/components/infinite-scroll.png
 status: planned

--- a/docs/components/list-item.md
+++ b/docs/components/list-item.md
@@ -1,5 +1,5 @@
 ---
-title: List Item
+title: List item
 description: A list item is an element that can be used to represent individual items in a list.
 status: planned
 thumb: true


### PR DESCRIPTION
## Description

- Changed a validation that was incorrectly filtering the pages on `Design` and `Guides`
- Changed the case of some component names
- Added a validation to display `storybook` link only when prop in frontmatter is not 'planned'.
- Added `exceptions` parameter to `_extractFrontmatter` function to filter unwanted pages in a easier way.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/JpMO5kSNpHa1Bq0qa9/giphy.gif)
