### PR TITLE
refactor(popover, modal): 1px `box-shadow` moved to `border` with `background-clip`

### DIFF
--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -27,13 +27,13 @@
 .d-modal {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
-    --modal-backdrop-color-background: hsla(var(--bgc-contrast-hsl) / 0.7);
+    --modal-backdrop-color-background: transparent; // hsla(var(--bgc-contrast-hsl) / 0.7)
     --modal-dialog-padding: var(--space-600);
     --modal-dialog-color-background: var(--bgc-primary);
+    --modal-dialog-color-border: hsla(var(--black-900-hsl) / 0.1);
     --modal-dialog-color-text: var(--fc-tertiary);
     --modal-header-color-text: var(--fc-secondary);
-    --modal-dialog-color-shadow: hsla(var(--black-900-hsl) / 0.1);
-    --modal-dialog-shadow: 0 0 0 var(--size-100) var(--modal-dialog-color-shadow), var(--bs-card);
+    --modal-dialog-shadow: var(--bs-card);
 
     position: fixed;
     top: 0;
@@ -83,6 +83,8 @@
   font-size: var(--fs-200);
   line-height: var(--lh-400);
   background-color: var(--modal-dialog-color-background);
+  background-clip: padding-box;
+  border: var(--size-100) solid var(--modal-dialog-color-border);
   border-radius: var(--size-500);
   box-shadow: var(--modal-dialog-shadow);
   transform: translate3d(0, 30%, 0) scale3d(0.75, 0.75, 0.75);
@@ -168,6 +170,9 @@
   font-size: var(--fs-200);
   line-height: var(--lh-300);
   background-color: var(--modal-banner-color-background);
+  background-clip: padding-box;
+  border: var(--size-100) solid var(--modal-dialog-color-border);
+  border-bottom-width: 0;
   border-radius: var(--size-500) var(--size-500) 0 0;
   box-shadow: var(--modal-dialog-shadow);
 
@@ -204,6 +209,7 @@
   }
 
   &:not(.d-d-none) + .d-modal__dialog {
+    border-top-width: 0;
     border-top-left-radius: 0;
     border-top-right-radius: 0;
   }

--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -27,7 +27,7 @@
 .d-modal {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
-    --modal-backdrop-color-background: transparent; // hsla(var(--bgc-contrast-hsl) / 0.7)
+    --modal-backdrop-color-background: hsla(var(--bgc-contrast-hsl) / 0.7);
     --modal-dialog-padding: var(--space-600);
     --modal-dialog-color-background: var(--bgc-primary);
     --modal-dialog-color-border: hsla(var(--black-900-hsl) / 0.1);

--- a/lib/build/less/components/popover.less
+++ b/lib/build/less/components/popover.less
@@ -8,31 +8,28 @@
 //
 //  TABLE OF CONTENTS
 //  • POPOVER
+//  • POPOVER DIALOG
 //  • CSS CUSTOM PROPERTIES
 //  • POPOVER DIALOG
 //    - Base dialog style
 //    - Content
 //    - Header / Footer
 
-//  $  CSS CUSTOM PROPERTIES
-//  ----------------------------------------------------------------------------
-body {
-  --popover-color-background: var(--black-100);
-  --popover-border-width: var(--size-100); // 8
-  --popover-border-radius: var(--size-400);
-  --popover-color-shadow: hsla(var(--black-900-hsl) ~' / ' 10%);
-  --popover-color-border: var(--popover-color-shadow);
-  --popover-shadow: 0 0 0 1px var(--popover-color-shadow), var(--bs-card);
-}
-
 //  $  POPOVER
 //  ----------------------------------------------------------------------------
 .d-popover {
-
-
   //  $  POPOVER DIALOG
   //  ----------------------------------------------------------------------------
+
   &__dialog {
+    //  $$  CSS CUSTOM PROPERTIES
+    //  ----------------------------------------------------------------------------
+    --popover-color-background: var(--bgc-secondary);
+    --popover-border-width: var(--size-100); // 8
+    --popover-border-radius: var(--size-400);
+    --popover-color-border: hsla(var(--black-900-hsl) / 0.1);
+    --popover-shadow: var(--bs-card);
+
     &,
     *,
     *::before,
@@ -44,6 +41,8 @@ body {
     grid-template-rows: 1fr;
     overflow: auto;
     background-color: var(--popover-color-background);
+    background-clip: padding-box;
+    border: var(--popover-border-width) solid var(--popover-color-border);
     border-radius: var(--popover-border-radius);
     box-shadow: var(--popover-shadow);
 


### PR DESCRIPTION
## Description

The `1px` border of Modal and Popover were a `box-shadow` (effectively a workaround). Now that [browser support for `background-clip`](https://caniuse.com/?search=background-clip) is solid, I refactored it to more accurately be an _outside_ border, distinct from shadow.

This also sets the stage for border Design Tokens.

<img width="886" alt="image" src="https://user-images.githubusercontent.com/1165933/219261435-015da0c7-64cb-4331-b6a7-697d02fce709.png">

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
