### PR TITLE
fix(popover): set default max height to never be larger than viewport

### DIFF
--- a/lib/build/less/components/popover.less
+++ b/lib/build/less/components/popover.less
@@ -55,6 +55,7 @@
   //  $$  DIALOG CONTENT
   //  ----------------------------------------------------------------------------
   &__content {
+    max-height: calc(100vh - var(--space-300));
     overflow: auto;
   }
 


### PR DESCRIPTION
## Description
Set the max height of the popover to never be larger than the viewport. Prior to this change data would be cut off without the ability to scroll.

Recommendation for this fix from popper.js: https://popper.js.org/docs/v2/faq/#my-popper-is-bigger-than-the-viewport-what-do-i-do

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/5jT0jaNDsM6Ik7X9yq/giphy.gif)
