### PR TITLE
docs: fix link in release versions

### DIFF
--- a/docs/.vuepress/common/constants.js
+++ b/docs/.vuepress/common/constants.js
@@ -2,8 +2,14 @@ import dialtoneChangelog from '@projectRoot/CHANGELOG.json';
 import dialtoneVueChangelog from '@projectRoot/node_modules/@dialpad/dialtone-vue/CHANGELOG.json';
 
 export const DIALTONE_CHANGELOGS = {
-  Dialtone: dialtoneChangelog,
-  DialtoneVue: dialtoneVueChangelog,
+  Dialtone: {
+    json_file: dialtoneChangelog,
+    url_handler: 'dialtone',
+  },
+  DialtoneVue: {
+    json_file: dialtoneVueChangelog,
+    url_handler: 'dialtone-vue',
+  },
 };
 
 export default {

--- a/docs/.vuepress/common/utilities.js
+++ b/docs/.vuepress/common/utilities.js
@@ -16,6 +16,7 @@ export function debounce (func, timeout = 300) {
 * */
 export const ReleaseNoteFormatter = {
   note: '',
+  project_url_handler: '',
 
   format () {
     this.note = this._withoutExtraAsterisks();
@@ -31,7 +32,7 @@ export const ReleaseNoteFormatter = {
 
   _withCommitLink () {
     return this.note.replace(/\(([^)]+)\)$/, (match, text) => {
-      const link = `<a href="https://github.com/dialpad/dialtone/commit/${text}">${text}</a>`;
+      const link = `<a href="https://github.com/dialpad/${this.project_url_handler}/commit/${text}">${text}</a>`;
       return `(${link})`;
     });
   },
@@ -40,7 +41,8 @@ export const ReleaseNoteFormatter = {
     return this.note.replace(/(\([^)]+\))(?!.*\1)/, (match, text) => {
       const content = text.slice(1, -1);
       if (content[0] === '#') {
-        const link = `<a href="https://github.com/dialpad/dialtone/pull/${content.slice(1)}">${text}</a>`;
+        const link =
+          `<a href="https://github.com/dialpad/${this.project_url_handler}/pull/${content.slice(1)}">${text}</a>`;
         return `${link}`;
       }
       return text;

--- a/docs/.vuepress/views/DialtoneChangelog.vue
+++ b/docs/.vuepress/views/DialtoneChangelog.vue
@@ -35,15 +35,18 @@ const props = defineProps({
   },
 });
 
-const changelogJson = computed(() => DIALTONE_CHANGELOGS[props.project]);
+const changelogJson = computed(() => DIALTONE_CHANGELOGS[props.project].json_file);
 
 const getVersion = (item) => changelogJson.value.versions[item].version;
 
-const getGithubReleaseUrl = (item) => `https://github.com/dialpad/dialtone/releases/tag/v${getVersion(item)}`;
+const getUrlHandler = () => DIALTONE_CHANGELOGS[props.project].url_handler;
+
+const getGithubReleaseUrl = (item) => `https://github.com/dialpad/${getUrlHandler()}/releases/tag/v${getVersion(item)}`;
 
 const formatReleaseNote = (note) => {
   const formatter = Object.create(ReleaseNoteFormatter);
   formatter.note = note;
+  formatter.project_url_handler = getUrlHandler();
   return formatter.format();
 };
 </script>


### PR DESCRIPTION
## Description
The links of the dialtone-vue releases were pointing to dialtone repo in the About page. Fixed to show the correct link to the dialtone-vue repo.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://i.giphy.com/media/xuXzcHMkuwvf2/giphy.webp)
