### PR TITLE
feat(textarea): scroll padding

### DIFF
--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -178,6 +178,7 @@
     vertical-align: top;
     border-bottom-right-radius: var(--size-300);
     resize: vertical;
+    scroll-padding-block: var(--input-padding-y);
 }
 
 //  $$  SIZES


### PR DESCRIPTION
## Description

Add comfy space at end of `textarea` when typing. hattip: @tedgoas-dialpad 

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

<img width="1310" alt="image" src="https://user-images.githubusercontent.com/1165933/221889969-073a5d3d-b0df-4ab7-b6d4-c871f761b380.png">
