### PR TITLE
fix(theme): missing theme variable for icon color

### DIFF
--- a/docs/design/colors/index.md
+++ b/docs/design/colors/index.md
@@ -524,7 +524,7 @@ Define the edge of key content area, components, or surfaces.
     </tr>
     <tr>
       <td class="d-pl0">
-        <div class="d-theme-sidebar-fc d-p6 d-fco8-circle h:d-fco100 d-ta-center"> <dt-icon name="info"></dt-icon> </div>
+        <div class="d-theme-sidebar-icon-fc d-p6 d-fco8-circle h:d-fco100 d-ta-center"> <dt-icon name="info"></dt-icon> </div>
       </td>
       <th scope="row">
         Sidebar
@@ -536,11 +536,11 @@ Define the edge of key content area, components, or surfaces.
         color
       </td>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">
-        var(--theme-sidebar-color)
+        var(--theme-sidebar-icon-color)
       </td>
       <td>
         <div class="d-ff-mono d-fs-100 d-fc-purple-400">
-          class="<strong>d-theme-sidebar-fc</strong>"
+          class="<strong>d-theme-sidebar-icon-fc</strong>"
         </div>
       </td>
     </tr>

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -59,6 +59,8 @@
     theme-sidebar-color:                              var(--fc-primary);
     theme-sidebar-color-hsl:                          var(--black-900-h) var(--black-900-s) var(--black-900-l);
     theme-sidebar-color-background:                   var(--bgc-secondary);
+
+    theme-sidebar-icon-color:                         var(--fc-secondary);
     theme-sidebar-status-color:                       var(--fc-tertiary);
 
 //  theme-sidebar-row-color-background:               {UNUSED}
@@ -91,6 +93,7 @@
 .d-theme-topbar-bgc { background-color: var(--theme-topbar-color-background) !important; }
 .d-theme-sidebar-fc { color: var(--theme-sidebar-color) !important; }
 .d-theme-sidebar-status-fc { color: var(--theme-sidebar-status-color) !important; }
+.d-theme-sidebar-icon-fc { color: var(--theme-sidebar-icon-color) !important; }
 .d-theme-sidebar-bgc { background-color: var(--theme-sidebar-color-background) !important; }
 .d-theme-sidebar-row-bgc:hover { background-color: var(--theme-sidebar-row-color-background-hover) !important; }
 .d-theme-sidebar-row-active-fc { color: var(--theme-sidebar-active-row-color) !important; }


### PR DESCRIPTION
## Description

Added missing sidebar theme variable icon color. Not the worst thing for the moment, and fallback is acceptable.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).