### PR TITLE
fix(popover): min content on header and footer grid items

### DIFF
--- a/lib/build/less/components/popover.less
+++ b/lib/build/less/components/popover.less
@@ -38,7 +38,7 @@
     }
 
     display: grid;
-    grid-template-rows: 1fr;
+    grid-template-rows: min-content 1fr min-content;
     overflow: auto;
     background-color: var(--popover-color-background);
     background-clip: padding-box;

--- a/lib/build/less/components/popover.less
+++ b/lib/build/less/components/popover.less
@@ -55,6 +55,7 @@
   //  $$  DIALOG CONTENT
   //  ----------------------------------------------------------------------------
   &__content {
+    grid-row: 2;
     overflow: auto;
   }
 
@@ -76,10 +77,12 @@
   }
 
   &__header {
+    grid-row: 1;
     border-bottom: var(--popover-border-width) solid var(--popover-color-border);
   }
 
   &__footer {
+    grid-row: 3;
     border-top: var(--popover-border-width) solid var(--popover-color-border);
   }
 }


### PR DESCRIPTION
## Description
Fix for https://dialpad.atlassian.net/browse/DT-986

When setting the popover dialog to to an explicit height, the header was expanding rather than the main content. This change will make it so the main content expands.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/Q6Hp5A7gUS8plLMOHb/giphy.gif)
