### PR TITLE
fix(presence): border color with selected leftbar state

### DIFF
--- a/docs/design/colors/index.md
+++ b/docs/design/colors/index.md
@@ -546,35 +546,13 @@ Define the edge of key content area, components, or surfaces.
     </tr>
     <tr>
       <td class="d-pl0">
-        <div class="d-w42 d-h42 d-bar-circle d-ba d-bc-black-100 d-theme-sidebar-row-active-bgc"></div>
+        <div class="d-w42 d-h42 d-bar-circle d-ba d-bc-black-300 d-bas-dashed" style="background-color: var(--theme-sidebar-row-color-background-hover)"></div>
       </td>
       <th scope="row">
         Sidebar
       </th>
       <td>
-        Active row
-      </td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">
-        background-color
-      </td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">
-        var(--theme-sidebar-active-row-color-background)
-      </td>
-      <td>
-        <div class="d-ff-mono d-fs-100 d-fc-purple-400">
-          class="<strong>d-theme-sidebar-row-active-bgc</strong>"
-        </div>
-      </td>
-    </tr>
-    <tr>
-      <td class="d-pl0">
-        <div class="d-w42 d-h42 d-bar-circle d-ba d-bc-black-300 d-bas-dashed d-theme-sidebar-row-bgc"></div>
-      </td>
-      <th scope="row">
-        Sidebar
-      </th>
-      <td>
-        Hover row
+        Row&nbsp;<code class="d-fs-100">:hover</code>
       </td>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">
         background-color
@@ -583,30 +561,68 @@ Define the edge of key content area, components, or surfaces.
         var(--theme-sidebar-row-color-background-hover)
       </td>
       <td>
-        <div class="d-ff-mono d-fs-100 d-fc-purple-400">
-          class="<strong>d-theme-sidebar-row-bgc</strong>"
-        </div>
       </td>
     </tr>
     <tr>
       <td class="d-pl0">
-        <div class="d-fs-300 d-p6 d-theme-sidebar-row-active-fc d-ta-center d-fw-medium"> Aa </div>
+        <div class="d-w42 d-h42 d-bar-circle d-ba d-bc-black-300 d-bas-dashed" style="background-color: var(--theme-sidebar-row-color-background-active)"></div>
       </td>
       <th scope="row">
         Sidebar
       </th>
       <td>
-        Active row
+        Row&nbsp;<code class="d-fs-100">:active</code>
+      </td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">
+        background-color
+      </td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">
+        var(--theme-sidebar-row-color-background-hover)
+      </td>
+      <td>
+      </td>
+    </tr>
+    <tr>
+      <td class="d-pl0">
+        <div class="d-w42 d-h42 d-bar-circle d-ba d-bc-black-100 d-theme-sidebar-row-selected-bgc"></div>
+      </td>
+      <th scope="row">
+        Sidebar
+      </th>
+      <td>
+        Row selected
+      </td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">
+        background-color
+      </td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">
+        var(--theme-sidebar-selected-row-color-background)
+      </td>
+      <td>
+        <div class="d-ff-mono d-fs-100 d-fc-purple-400">
+          class="<strong>d-theme-sidebar-row-selected-bgc</strong>"
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td class="d-pl0">
+        <div class="d-fs-300 d-p6 d-theme-sidebar-row-selected-fc d-ta-center d-fw-medium"> Aa </div>
+      </td>
+      <th scope="row">
+        Sidebar
+      </th>
+      <td>
+        Row selected
       </td>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">
         color
       </td>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">
-        var(--theme-sidebar-active-row-color)
+        var(--theme-sidebar-selected-row-color)
       </td>
       <td>
         <div class="d-ff-mono d-fs-100 d-fc-purple-400">
-          class="<strong>d-theme-sidebar-row-active-fc</strong>"
+          class="<strong>d-theme-sidebar-row-selected-fc</strong>"
         </div>
       </td>
     </tr>

--- a/lib/build/less/components/presence.less
+++ b/lib/build/less/components/presence.less
@@ -25,7 +25,10 @@
   border-width: var(--presence-size);
   border-radius: var(--br-circle);
 
-  .dt-leftbar-row--selected &,
+  .dt-leftbar-row--selected & {
+    --presence-color-border-base: var(--theme-sidebar-active-row-color-background);
+  }
+
   .dt-leftbar-row__primary:hover & {
     --presence-color-border-base: var(--theme-sidebar-row-color-background-hover);
   }

--- a/lib/build/less/components/presence.less
+++ b/lib/build/less/components/presence.less
@@ -26,7 +26,7 @@
   border-radius: var(--br-circle);
 
   .dt-leftbar-row--selected & {
-    --presence-color-border-base: var(--theme-sidebar-active-row-color-background);
+    --presence-color-border-base: var(--theme-sidebar-selected-row-color-background);
   }
 
   .dt-leftbar-row__primary:hover & {

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -63,11 +63,12 @@
     theme-sidebar-icon-color:                         var(--fc-secondary);
     theme-sidebar-status-color:                       var(--fc-tertiary);
 
-//  theme-sidebar-row-color-background:               {UNUSED}
-    theme-sidebar-row-color-background-hover:         var(--black-300);
-    theme-sidebar-active-row-color:                   var(--fc-primary);
-    theme-sidebar-active-row-color-hsl:               var(--black-900-h) var(--black-900-s) var(--black-900-l); // Use with d-fco[##] Opacity utility
-    theme-sidebar-active-row-color-background:        var(--black-200);
+    theme-sidebar-row-color-background:               transparent;
+    theme-sidebar-row-color-background-hover:         hsla(var(--black-900-hsl) / 0.1);
+    theme-sidebar-row-color-background-active:        var(--black-300);
+    theme-sidebar-selected-row-color:                 var(--fc-primary);
+    theme-sidebar-selected-row-color-hsl:             var(--black-900-h) var(--black-900-s) var(--black-900-l); // Use with d-fco[##] Opacity utility
+    theme-sidebar-selected-row-color-background:      var(--black-200);
 
     theme-presence-color-background-available:        var(--green-400);
     theme-presence-color-background-busy-unavailable: var(--red-300);
@@ -96,8 +97,9 @@
 .d-theme-sidebar-icon-fc { color: var(--theme-sidebar-icon-color) !important; }
 .d-theme-sidebar-bgc { background-color: var(--theme-sidebar-color-background) !important; }
 .d-theme-sidebar-row-bgc:hover { background-color: var(--theme-sidebar-row-color-background-hover) !important; }
-.d-theme-sidebar-row-active-fc { color: var(--theme-sidebar-active-row-color) !important; }
-.d-theme-sidebar-row-active-bgc { background-color: var(--theme-sidebar-active-row-color-background) !important; }
+.d-theme-sidebar-row-bgc:active { background-color: var(--theme-sidebar-row-color-background-active) !important; }
+.d-theme-sidebar-row-selected-fc { color: var(--theme-sidebar-selected-row-color) !important; }
+.d-theme-sidebar-row-selected-bgc { background-color: var(--theme-sidebar-selected-row-color-background) !important; }
 .d-theme-presence-available { background-color: var(--theme-presence-color-background-available) !important; }
 .d-theme-presence-busy-unavailable { background-color: var(--theme-presence-color-background-busy-unavailable) !important; }
 .d-theme-presence-busy { background-color: var(--theme-presence-color-background-busy) !important; }


### PR DESCRIPTION
## Description

Presence border should match background color in all Leftbar states. This accounts for selected state. 

**Aside:** doesn't feel right that this is in `dialtone` and might be more appropriate to eventually move into [leftbar_row.less](https://github.com/dialpad/dialtone-vue/blob/staging/recipes/leftbar/style/leftbar_row.less).

Origin: https://github.com/dialpad/dialtone-vue/pull/796#issuecomment-1452941178

<img width="746" alt="image" src="https://user-images.githubusercontent.com/1165933/222630714-97a8736c-0579-4ae1-b229-976fb7b3d9e5.png">


## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

