### PR TITLE
feat(tabs, table): update border color styles as translucent

### DIFF
--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -29,7 +29,7 @@
 .d-input__wrapper {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
-    --input-color-border: hsla(var(--black-900-hsl) / 0.09);
+    --input-color-border: hsla(var(--black-900-hsl) / 0.1);
     --input-color-background: hsla(var(--black-900-hsl) / 0.03);
     --input-color-background-disabled: hsla(var(--black-900-hsl) / 0.12);
     --input-color-text: var(--fc-secondary);

--- a/lib/build/less/components/table.less
+++ b/lib/build/less/components/table.less
@@ -17,7 +17,7 @@
 .d-table {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
-    --table-color-border: var(--black-300);
+    --table-color-border: hsla(var(--black-900-hsl) / 0.18);
     --table-th-color-text: var(--fc-secondary);
     --table-td-color-text: var(--fc-tertiary);
     --table-font-size: var(--fs-200);
@@ -99,7 +99,7 @@
 .d-table--inverted {
     --table-th-color-text: var(--fc-secondary-inverted);
     --table-td-color-text: var(--black-400);
-    --table-color-border: var(--black-500);
+    --table-color-border: hsla(var(--white-hsl) / 0.18);
 }
 
 //  ============================================================================

--- a/lib/build/less/components/tabs.less
+++ b/lib/build/less/components/tabs.less
@@ -33,7 +33,7 @@
         left: 0;
         z-index: var(--zi-base1);
         height: var(--size-100);
-        background-color: var(--black-400);
+        background-color: hsla(var(--black-900-hsl) / 0.34);
         content: '';
     }
 
@@ -181,6 +181,10 @@
 
     &::after {
         background-color: hsla(var(--purple-600-hsl) / 0.5);
+    }
+
+    &:not(.d-tablist--no-border)::after {
+        background-color: hsla(var(--white-hsl) / 0.34);
     }
 
     .d-tab {


### PR DESCRIPTION
## Description

Translucent border style for Tabs and Table. This precedes Design Token work as we formalize a set of semantic borders.

You can see these in play [in Figma styles](https://www.figma.com/file/8RbAab7w2rQeg0Ii8jtaAl/DT-Core%3A-Design-Tokens?node-id=3804%3A13428&t=KdELI7m0wq3xjQpn-11).

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).