### PR TITLE
feat(semantic-colors): opaque surfaces

### DIFF
--- a/docs/design/colors/index.md
+++ b/docs/design/colors/index.md
@@ -349,12 +349,30 @@ Background colors for default application UI surfaces. Surface colors are contai
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-critical</td>
     </tr>
     <tr>
+      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-critical-opaque"></div></th>
+      <th scope="row" class="d-lh-300">
+        Critical opaque
+        <div class="d-fw-normal d-fs-100">Critical surface as opaque background color.</div>
+      </th>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-critical-opaque)</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-critical-opaque</td>
+    </tr>
+    <tr>
       <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-critical-subtle"></div></th>
       <th scope="row" class="d-lh-300">
         Critical subtle
       </th>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-critical-subtle)</td>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-critical-subtle</td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-critical-subtle-opaque"></div></th>
+      <th scope="row" class="d-lh-300">
+        Critical subtle opaque
+        <div class="d-fw-normal d-fs-100">Critical subtle surface as opaque background color.</div>
+      </th>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-critical-subtle-opaque)</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-critical-subtle-opaque</td>
     </tr>
     <tr>
       <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-critical-strong"></div></th>

--- a/docs/design/colors/index.md
+++ b/docs/design/colors/index.md
@@ -278,7 +278,7 @@ Background colors for default application UI surfaces. Surface colors are contai
       <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-secondary-opaque d-ba d-bc-black-300 d-bas-dashed"></div></th>
       <th scope="row" class="d-lh-300">
         Secondary opaque
-        <div class="d-fw-normal d-fs-100">Secondary surface with opaque background color.</div>
+        <div class="d-fw-normal d-fs-100">Secondary surface as opaque background color.</div>
       </th>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-secondary-opaque)</td>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-secondary-opapue</td>

--- a/docs/design/colors/index.md
+++ b/docs/design/colors/index.md
@@ -448,12 +448,30 @@ Background colors for default application UI surfaces. Surface colors are contai
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-info</td>
     </tr>
     <tr>
+      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-info-opaque"></div></th>
+      <th scope="row" class="d-lh-300">
+        Info opaque
+        <div class="d-fw-normal d-fs-100">Info surface as opaque background color.</div>
+      </th>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-info-opaque)</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-info-opaque</td>
+    </tr>
+    <tr>
       <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-info-subtle"></div></th>
       <th scope="row" class="d-lh-300">
         Info subtle
       </th>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-info-subtle)</td>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-info-subtle</td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-info-subtle-opaque"></div></th>
+      <th scope="row" class="d-lh-300">
+        Info subtle opaque
+        <div class="d-fw-normal d-fs-100">Info surface as opaque background color.</div>
+      </th>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-info-subtle-opaque)</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-info-subtle-opaque</td>
     </tr>
     <tr>
       <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-info-strong"></div></th>

--- a/docs/design/colors/index.md
+++ b/docs/design/colors/index.md
@@ -275,6 +275,15 @@ Background colors for default application UI surfaces. Surface colors are contai
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-secondary</td>
     </tr>
     <tr>
+      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-secondary-opaque d-ba d-bc-black-300 d-bas-dashed"></div></th>
+      <th scope="row" class="d-lh-300">
+        Secondary opaque
+        <div class="d-fw-normal d-fs-100">Secondary surface with opaque background color.</div>
+      </th>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-secondary-opaque)</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-secondary-opapue</td>
+    </tr>
+    <tr>
       <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-moderate"></div></th>
       <th scope="row" class="d-lh-300">
         Moderate
@@ -284,6 +293,15 @@ Background colors for default application UI surfaces. Surface colors are contai
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-moderate</td>
     </tr>
     <tr>
+      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-moderate-opaque"></div></th>
+      <th scope="row" class="d-lh-300">
+        Moderate opaque
+        <div class="d-fw-normal d-fs-100">Moderate surface as opaque background color.</div>
+      </th>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-moderate-opaque)</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-moderate-opaque</td>
+    </tr>
+    <tr>
       <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-bold"></div></th>
       <th scope="row" class="d-lh-300">
         Bold
@@ -291,6 +309,15 @@ Background colors for default application UI surfaces. Surface colors are contai
       </th>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-bold)</td>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-bold</td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-bold-opaque"></div></th>
+      <th scope="row" class="d-lh-300">
+        Bold opaque
+        <div class="d-fw-normal d-fs-100">Bold surface as opaque background color.</div>
+      </th>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-bold-opaque)</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-bold-opaque</td>
     </tr>
     <tr>
       <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-strong"></div></th>

--- a/docs/design/colors/index.md
+++ b/docs/design/colors/index.md
@@ -394,12 +394,30 @@ Background colors for default application UI surfaces. Surface colors are contai
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-success</td>
     </tr>
     <tr>
+      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-success-opaque"></div></th>
+      <th scope="row" class="d-lh-300">
+        Success opaque
+        <div class="d-fw-normal d-fs-100">Success surface as opaque background color.</div>
+      </th>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-success-opaque)</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-success-opaque</td>
+    </tr>
+    <tr>
       <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-success-subtle"></div></th>
       <th scope="row" class="d-lh-300">
         Success subtle
       </th>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-success-subtle)</td>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-success-subtle</td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-success-subtle-opaque"></div></th>
+      <th scope="row" class="d-lh-300">
+        Success subtle opaque
+        <div class="d-fw-normal d-fs-100">Success subtle surface as opaque background color.</div>
+      </th>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-success-subtle-opaque)</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-success-subtle-opaque</td>
     </tr>
     <tr>
       <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-success-strong"></div></th>
@@ -421,12 +439,30 @@ Background colors for default application UI surfaces. Surface colors are contai
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-warning</td>
     </tr>
     <tr>
+      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-warning-opaque"></div></th>
+      <th scope="row" class="d-lh-300">
+        Warning opaque
+        <div class="d-fw-normal d-fs-100">Warning surface as opaque background color</div>
+      </th>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-warning-opaque)</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-warning-opaque</td>
+    </tr>
+    <tr>
       <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-warning-subtle"></div></th>
       <th scope="row" class="d-lh-300">
         Warning subtle
       </th>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-warning-subtle)</td>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-warning-subtle</td>
+    </tr>
+    <tr>
+      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-warning-subtle-opaque"></div></th>
+      <th scope="row" class="d-lh-300">
+        Warning subtle opaque
+        <div class="d-fw-normal d-fs-100">Warning subtle surface as opaque background color</div>
+      </th>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bgc-warning-subtle-opaque)</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-warning-subtle-opaque</td>
     </tr>
     <tr>
       <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-warning-strong"></div></th>

--- a/lib/build/less/components/badge.less
+++ b/lib/build/less/components/badge.less
@@ -21,7 +21,7 @@
   //  COMPONENT CSS VARIABLES
   //  --------------------------------------------------------------------------
   --badge-color-text: var(--fc-primary);
-  --badge-color-background: var(--black-200);
+  --badge-color-background: var(--bgc-moderate-opaque);
   --badge-color-background-ai: linear-gradient(to bottom right, var(--purple-400) 0%, var(--magenta-300) 100%);
   --badge-radius: var(--size-300);
   --badge-line-height: calc(var(--size-500) + var(--size-200));

--- a/lib/build/less/components/chip.less
+++ b/lib/build/less/components/chip.less
@@ -15,17 +15,17 @@
 //  $   BASE STYLE
 //  ----------------------------------------------------------------------------
 .d-chip {
+  //  Component CSS Vars
+  --chip-color-text: var(--fc-primary);
+  --chip-color-background: var(--bgc-moderate-opaque);
+  --chip-border-radius: var(--br-pill);
+
   position: relative;
   display: inline-flex;
   align-items: center;
 }
 
 .d-chip__label {
-  //  Component CSS Vars
-  --chip-color-text: var(--fc-primary);
-  --chip-color-background: var(--black-200);
-  --chip-border-radius: var(--br-pill);
-
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/lib/build/less/components/table.less
+++ b/lib/build/less/components/table.less
@@ -108,7 +108,7 @@
 .d-table--striped {
     // Row Styles
     tr:nth-child(even) {
-        background-color: hsla(var(--bgc-bold-hsl) / 0.1);
+        background-color: var(--bgc-secondary-opaque);
     }
 
     &.d-table--inverted {

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -148,8 +148,14 @@
 #d-internals #generate-hover-focus(d-bgc-error, {.d-bgc-error();});
 #d-internals #generate-hover-focus(d-bgc-danger, {.d-bgc-danger();});
 
+.d-bgc-critical-opaque { background-color: var(--bgc-critical-opaque) !important; }
+#d-internals #generate-hover-focus(d-bgc-critical-opaque, {.d-bgc-critical-opaque();});
+
 .d-bgc-critical-subtle { background-color: var(--bgc-critical-subtle) !important; }
 #d-internals #generate-hover-focus(d-bgc-critical-subtle, {.d-bgc-critical-subtle();});
+
+.d-bgc-critical-subtle-opaque { background-color: var(--bgc-critical-subtle-opaque) !important; }
+#d-internals #generate-hover-focus(d-bgc-critical-subtle-opaque, {.d-bgc-critical-subtle-opaque();});
 
 .d-bgc-critical-strong { background-color: var(--bgc-critical-strong) !important; }
 #d-internals #generate-hover-focus(d-bgc-critical-strong, {.d-bgc-critical-strong();});

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -137,7 +137,15 @@
 
 .d-bgc-info { &:extend(.d-bgc-blue-100); }
 #d-internals #generate-hover-focus(d-bgc-info, {.d-bgc-info();});
+
+.d-bgc-info-opaque { background-color: var(--bgc-info-opaque) !important; }
+#d-internals #generate-hover-focus(d-bgc-info-opaque, {.d-bgc-info-opaque();});
+
 .d-bgc-info-subtle { background-color: var(--bgc-info-subtle) !important; }
+#d-internals #generate-hover-focus(d-bgc-info-subtle, {.d-bgc-info-subtle();});
+
+.d-bgc-info-subtle-opaque { background-color: var(--bgc-info-subtle-opaque) !important; }
+#d-internals #generate-hover-focus(d-bgc-info-subtle-opaque, {.d-bgc-info-subtle-opaque();});
 
 .d-bgc-info-strong { background-color: var(--bgc-info-strong) !important; }
 #d-internals #generate-hover-focus(d-bgc-info-strong, {.d-bgc-info-strong();});

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -130,8 +130,10 @@
 #d-internals #generate-hover-focus(d-bgc-warning, {.d-bgc-warning();});
 
 .d-bgc-warning-subtle { background-color: var(--bgc-warning-subtle) !important; }
+#d-internals #generate-hover-focus(d-bgc-warning-subtle, {.d-bgc-warning-subtle();});
 
 .d-bgc-warning-strong { background-color: var(--bgc-warning-strong) !important; }
+#d-internals #generate-hover-focus(d-bgc-warning-strong, {.d-bgc-warning-strong();});
 
 .d-bgc-info { &:extend(.d-bgc-blue-100); }
 #d-internals #generate-hover-focus(d-bgc-info, {.d-bgc-info();});

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -120,8 +120,14 @@
 .d-bgc-success { &:extend(.d-bgc-green-100); }
 #d-internals #generate-hover-focus(d-bgc-success, {.d-bgc-success();});
 
+.d-bgc-success-opaque { background-color: var(--bgc-success-opaque) !important; }
+#d-internals #generate-hover-focus(d-bgc-success-opaque, {.d-bgc-success-opaque();});
+
 .d-bgc-success-subtle { background-color: var(--bgc-success-subtle) !important; }
 #d-internals #generate-hover-focus(d-bgc-success-subtle, {.d-bgc-success-subtle();});
+
+.d-bgc-success-subtle-opaque { background-color: var(--bgc-success-subtle-opaque) !important; }
+#d-internals #generate-hover-focus(d-bgc-success-subtle-opaque, {.d-bgc-success-subtle-opaque();});
 
 .d-bgc-success-strong { background-color: var(--bgc-success-strong) !important; }
 #d-internals #generate-hover-focus(d-bgc-success-strong, {.d-bgc-success-strong();});
@@ -129,8 +135,14 @@
 .d-bgc-warning { &:extend(.d-bgc-gold-100); }
 #d-internals #generate-hover-focus(d-bgc-warning, {.d-bgc-warning();});
 
+.d-bgc-warning-opaque { background-color: var(--bgc-warning-opaque) !important; }
+#d-internals #generate-hover-focus(d-bgc-warning-opaque, {.d-bgc-warning-opaque();});
+
 .d-bgc-warning-subtle { background-color: var(--bgc-warning-subtle) !important; }
 #d-internals #generate-hover-focus(d-bgc-warning-subtle, {.d-bgc-warning-subtle();});
+
+.d-bgc-warning-subtle-opaque { background-color: var(--bgc-warning-subtle-opaque) !important; }
+#d-internals #generate-hover-focus(d-bgc-warning-subtle-opaque, {.d-bgc-warning-subtle-opaque();});
 
 .d-bgc-warning-strong { background-color: var(--bgc-warning-strong) !important; }
 #d-internals #generate-hover-focus(d-bgc-warning-strong, {.d-bgc-warning-strong();});

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -96,11 +96,20 @@
 .d-bgc-secondary { &:extend(.d-bgc-black-100); }
 #d-internals #generate-hover-focus(d-bgc-secondary, {.d-bgc-secondary();});
 
+.d-bgc-secondary-opaque { background-color: var(--bgc-secondary-opaque); }
+#d-internals #generate-hover-focus(d-bgc-secondary-opaque, {.d-bgc-secondary-opaque();});
+
 .d-bgc-moderate { &:extend(.d-bgc-black-200); }
 #d-internals #generate-hover-focus(d-bgc-moderate, {.d-bgc-moderate();});
 
+.d-bgc-moderate-opaque { background-color: var(--bgc-moderate-opaque); }
+#d-internals #generate-hover-focus(d-bgc-moderate-opaque, {.d-bgc-moderate-opaque();});
+
 .d-bgc-bold { &:extend(.d-bgc-black-300); }
 #d-internals #generate-hover-focus(d-bgc-bold, {.d-bgc-bold();});
+
+.d-bgc-bold-opaque { background-color: var(--bgc-bold-opaque); }
+#d-internals #generate-hover-focus(d-bgc-bold-opaque, {.d-bgc-bold-opaque();});
 
 .d-bgc-strong { &:extend(.d-bgc-black-600); }
 #d-internals #generate-hover-focus(d-bgc-strong, {.d-bgc-strong();});
@@ -110,26 +119,38 @@
 
 .d-bgc-success { &:extend(.d-bgc-green-100); }
 #d-internals #generate-hover-focus(d-bgc-success, {.d-bgc-success();});
+
 .d-bgc-success-subtle { background-color: var(--bgc-success-subtle) !important; }
+#d-internals #generate-hover-focus(d-bgc-success-subtle, {.d-bgc-success-subtle();});
+
 .d-bgc-success-strong { background-color: var(--bgc-success-strong) !important; }
+#d-internals #generate-hover-focus(d-bgc-success-strong, {.d-bgc-success-strong();});
 
 .d-bgc-warning { &:extend(.d-bgc-gold-100); }
 #d-internals #generate-hover-focus(d-bgc-warning, {.d-bgc-warning();});
+
 .d-bgc-warning-subtle { background-color: var(--bgc-warning-subtle) !important; }
+
 .d-bgc-warning-strong { background-color: var(--bgc-warning-strong) !important; }
 
 .d-bgc-info { &:extend(.d-bgc-blue-100); }
 #d-internals #generate-hover-focus(d-bgc-info, {.d-bgc-info();});
 .d-bgc-info-subtle { background-color: var(--bgc-info-subtle) !important; }
+
 .d-bgc-info-strong { background-color: var(--bgc-info-strong) !important; }
+#d-internals #generate-hover-focus(d-bgc-info-strong, {.d-bgc-info-strong();});
 
 .d-bgc-critical,
 .d-bgc-error,
 .d-bgc-danger { &:extend(.d-bgc-red-100); }
 #d-internals #generate-hover-focus(d-bgc-error, {.d-bgc-error();});
 #d-internals #generate-hover-focus(d-bgc-danger, {.d-bgc-danger();});
+
 .d-bgc-critical-subtle { background-color: var(--bgc-critical-subtle) !important; }
+#d-internals #generate-hover-focus(d-bgc-critical-subtle, {.d-bgc-critical-subtle();});
+
 .d-bgc-critical-strong { background-color: var(--bgc-critical-strong) !important; }
+#d-internals #generate-hover-focus(d-bgc-critical-strong, {.d-bgc-critical-strong();});
 
 .d-bgc-transparent { background-color: transparent !important; background-image: none !important; }
 #d-internals #generate-hover-focus(d-bgc-transparent, {.d-bgc-transparent();});

--- a/lib/build/less/variables/colors.less
+++ b/lib/build/less/variables/colors.less
@@ -90,7 +90,9 @@
 @surface-colors: {
     bgc-critical:              var(--red-100);
     bgc-critical-hsl:          var(--red-100-hsl);
+    bgc-critical-opaque:       hsla(var(--red-300-hsl) / 0.11);
     bgc-critical-subtle:       #fff2f3;
+    bgc-critical-subtle-opaque:hsla(var(--red-300-hsl) / 0.05);
     bgc-critical-strong:       var(--red-400);
 
     bgc-info:                  var(--blue-100);

--- a/lib/build/less/variables/colors.less
+++ b/lib/build/less/variables/colors.less
@@ -97,7 +97,9 @@
 
     bgc-info:                  var(--blue-100);
     bgc-info-hsl:              var(--blue-100-hsl);
+    bgc-info-opaque:                  hsla(var(--blue-400-hsl) / 0.09);
     bgc-info-subtle:           #f5f9fd;
+    bgc-info-subtle-opaque:           hsla(var(--blue-400-hsl) / 0.04);
     bgc-info-strong:           var(--blue-400);
 
     bgc-warning:               var(--gold-100);

--- a/lib/build/less/variables/colors.less
+++ b/lib/build/less/variables/colors.less
@@ -113,12 +113,15 @@
 
     bgc-secondary:             var(--black-100);
     bgc-secondary-hsl:         var(--black-100-hsl);
+    bgc-secondary-opaque:      hsla(var(--black-900-hsl) / 0.02);
 
     bgc-moderate:              var(--black-200);
     bgc-moderate-hsl:          var(--black-200-hsl);
+    bgc-moderate-opaque:       hsla(var(--black-900-hsl) / 0.09);
 
     bgc-bold:                  var(--black-300);
     bgc-bold-hsl:              var(--black-300-hsl);
+    bgc-bold-opaque:           hsla(var(--black-900-hsl) / 0.18);
 
     bgc-strong:                var(--black-600);
     bgc-strong-hsl:            var(--black-600-hsl);

--- a/lib/build/less/variables/colors.less
+++ b/lib/build/less/variables/colors.less
@@ -97,19 +97,23 @@
 
     bgc-info:                  var(--blue-100);
     bgc-info-hsl:              var(--blue-100-hsl);
-    bgc-info-opaque:                  hsla(var(--blue-400-hsl) / 0.09);
+    bgc-info-opaque:           hsla(var(--blue-400-hsl) / 0.09);
     bgc-info-subtle:           #f5f9fd;
-    bgc-info-subtle-opaque:           hsla(var(--blue-400-hsl) / 0.04);
+    bgc-info-subtle-opaque:    hsla(var(--blue-400-hsl) / 0.04);
     bgc-info-strong:           var(--blue-400);
 
     bgc-warning:               var(--gold-100);
     bgc-warning-hsl:           var(--gold-100-hsl);
+    bgc-warning-opaque:        hsla(var(--gold-200-hsl) / 0.38);
     bgc-warning-subtle:        #fffae5;
+    bgc-warning-subtle-opaque: hsla(var(--gold-200-hsl) / 0.18);
     bgc-warning-strong:        var(--gold-500);
 
     bgc-success:               var(--green-100);
     bgc-success-hsl:           var(--green-100-hsl);
+    bgc-success-opaque:               hsla(var(--green-400-hsl) / 0.08);
     bgc-success-subtle:        #f8fdf7;
+    bgc-success-subtle-opaque:        hsla(var(--green-400-hsl) / 0.03);
     bgc-success-strong:        var(--green-400);
 
     bgc-primary:               var(--white);


### PR DESCRIPTION
## Description

Created `opaque` versions of select Surfaces, and applied to Components. These are surfaces that _look_ the same as their non-opaque counterpart, but have transparency applied.

For [DT-1029](https://dialpad.atlassian.net/browse/DT-1029). 

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

![fade-away](https://user-images.githubusercontent.com/1165933/225188104-214cbd5f-e32d-4af4-bf1e-da26130f5ffc.gif)


[DT-1029]: https://dialpad.atlassian.net/browse/DT-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ