### PR TITLE
fix(input): fixed caret-color suppressed in firefox

### DIFF
--- a/lib/build/less/components/input.less
+++ b/lib/build/less/components/input.less
@@ -61,6 +61,7 @@
     transition-duration: var(--td100);
     transition-property: box-shadow, background-color;
     appearance: none;
+    caret-color: var(--input-color-text);
 
     //  --  Placeholder copy
     &::placeholder {


### PR DESCRIPTION
## Description

Input component in Firefox was suppressing the blinking caret. Can't say I've seen this bug before. Fixed by explicitly (and redundantly) setting `caret-color` property.

Resolves [DT-1021](https://dialpad.atlassian.net/browse/DT-1021). 

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

![blink](https://user-images.githubusercontent.com/1165933/225675783-92732b84-9abc-4fce-804d-5bf65ec16e53.gif)


[DT-1021]: https://dialpad.atlassian.net/browse/DT-1021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ