### PR TITLE
fix(avatar) change to display: flex

### DIFF
--- a/lib/build/less/components/avatar.less
+++ b/lib/build/less/components/avatar.less
@@ -39,7 +39,7 @@
   --avatar-count-color-shadow: var(--theme-sidebar-color-background);
 
   position: relative;
-  display: inline-flex;
+  display: flex;
   color: var(--avatar-color-text);
 
   //  --  CHILDREN


### PR DESCRIPTION
## Description
Seems to be numerous cases where extra space is being added below `d-avatar`. A couple examples of this below. Changing this to `display: flex` instead of `display: inline-flex` seems to fix the issue.

![Screenshot 2023-03-22 at 5 09 48 PM](https://user-images.githubusercontent.com/64808812/227066710-ab91e679-a0c8-4777-a082-4f6540e31e7b.png)
![Screenshot 2023-03-22 at 5 11 22 PM](https://user-images.githubusercontent.com/64808812/227066726-9a052be0-8e7b-42e5-9d57-7f28b3a64979.png)

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/xULW8noWqx7KJp9lRK/giphy.gif)
