### PR TITLE
feat(colors): hover and focus styles for semantic border colors

### DIFF
--- a/docs/.vuepress/client.js
+++ b/docs/.vuepress/client.js
@@ -2,7 +2,7 @@ import { defineClientConfig } from '@vuepress/client';
 
 // Common views
 import Icons from './views/Icons.vue';
-import Colors from './views/Colors.vue';
+import ColorsCatalog from './views/ColorsCatalog.vue';
 import Overview from './views/Overview.vue';
 
 // Base components
@@ -30,7 +30,7 @@ export default defineClientConfig({
   enhance ({ app, router, siteData }) {
     // Common views
     app.component('Icons', Icons);
-    app.component('Colors', Colors);
+    app.component('ColorsCatalog', ColorsCatalog);
     app.component('Overview', Overview);
 
     // Base components

--- a/docs/.vuepress/views/ColorsCatalog.vue
+++ b/docs/.vuepress/views/ColorsCatalog.vue
@@ -26,7 +26,7 @@ export default {
 
   async beforeCreate () {
     const data = await import('../../_data/colors.json');
-    this.colors = data.default;
+    this.colors = data.base;
   },
 };
 </script>

--- a/docs/_data/colors.json
+++ b/docs/_data/colors.json
@@ -1,358 +1,392 @@
-[
-  {
-    "color": "black",
-    "stops": [
-      {
-        "stop": "100",
-        "hex": "F9F9F9",
-        "copy": "primary",
-        "contrast": "AAA 19.94",
-        "primary": "no"
-      },
-      {
-        "stop": "200",
-        "hex": "E9E9E9",
-        "copy": "primary",
-        "contrast": "AAA 17.29",
-        "primary": "no"
-      },
-      {
-        "stop": "300",
-        "hex": "D2D2D2",
-        "copy": "primary",
-        "contrast": "AAA 13.88",
-        "primary": "no"
-      },
-      {
-        "stop": "400",
-        "hex": "AAAAAA",
-        "copy": "primary",
-        "contrast": "AAA 9.03",
-        "primary": "no"
-      },
-      {
-        "stop": "500",
-        "hex": "808080",
-        "copy": "primary",
-        "contrast": "AA 5.31",
-        "primary": "no"
-      },
-      {
-        "stop": "600",
-        "hex": "555555",
-        "copy": "white",
-        "contrast": "AAA 7.45",
-        "primary": "no"
-      },
-      {
-        "stop": "700",
-        "hex": "3A3A3A",
-        "copy": "white",
-        "contrast": "AAA 11.37",
-        "primary": "no"
-      },
-      {
-        "stop": "800",
-        "hex": "222222",
-        "copy": "white",
-        "contrast": "AAA 15.9",
-        "primary": "no"
-      },
-      {
-        "stop": "900",
-        "hex": "000000",
-        "copy": "white",
-        "contrast": "AAA 21",
-        "primary": "yes"
-      }
-    ]
-  },
-  {
-    "color": "purple",
-    "stops": [
-      {
-        "stop": "100",
-        "hex": "F5F0FF",
-        "copy": "primary",
-        "contrast": "AAA 18.79",
-        "primary": "no"
-      },
-      {
-        "stop": "200",
-        "hex": "DAC7FF",
-        "copy": "primary",
-        "contrast": "AAA 13.59",
-        "primary": "no"
-      },
-      {
-        "stop": "300",
-        "hex": "AB7EFF",
-        "copy": "primary",
-        "contrast": "AAA 7.15",
-        "primary": "no"
-      },
-      {
-        "stop": "400",
-        "hex": "7C52FF",
-        "copy": "white",
-        "contrast": "AA 4.65",
-        "darkContrast": "AA 4.5",
-        "primary": "yes"
-      },
-      {
-        "stop": "500",
-        "hex": "3A1D95",
-        "copy": "white",
-        "contrast": "AAA 11.73",
-        "primary": "no"
-      },
-      {
-        "stop": "600",
-        "hex": "10022C",
-        "copy": "white",
-        "contrast": "AAA 19.67",
-        "primary": "no"
-      }
-    ]
-  },
-  {
-    "color": "magenta",
-    "stops": [
-      {
-        "stop": "100",
-        "hex": "FFE0F2",
-        "copy": "primary",
-        "contrast": "AAA 17.9",
-        "primary": "no"
-      },
-      {
-        "stop": "200",
-        "hex": "F985C7",
-        "copy": "primary",
-        "contrast": "AA 9.2",
-        "primary": "no"
-      },
-      {
-        "stop": "300",
-        "hex": "F9008E",
-        "copy": "primary",
-        "contrast": "AA 5.41",
-        "primary": "no"
-      },
-      {
-        "stop": "400",
-        "hex": "8C0E56",
-        "copy": "white",
-        "contrast": "AAA 9.08",
-        "primary": "yes"
-      },
-      {
-        "stop": "500",
-        "hex": "541A3B",
-        "copy": "white",
-        "contrast": "AAA 13.22",
-        "primary": "no"
-      }
-    ]
-  },
-  {
-    "color": "gold",
-    "stops": [
-      {
-        "stop": "100",
-        "hex": "FFF4CC",
-        "copy": "primary",
-        "contrast": "AAA 17.1",
-        "primary": "no"
-      },
-      {
-        "stop": "200",
-        "hex": "FFDB80",
-        "copy": "primary",
-        "contrast": "AAA 14.74",
-        "primary": "no"
-      },
-      {
-        "stop": "300",
-        "hex": "F6AB3C",
-        "copy": "primary",
-        "contrast": "AAA 10.8",
-        "primary": "yes"
-      },
-      {
-        "stop": "400",
-        "hex": "D28F2B",
-        "copy": "primary",
-        "contrast": "AAA 7.7",
-        "primary": "no"
-      },
-      {
-        "stop": "500",
-        "hex": "815008",
-        "copy": "white",
-        "contrast": "AA 6.8",
-        "primary": "no"
-      }
-    ]
-  },
-  {
-    "color": "red",
-    "stops": [
-      {
-        "stop": "100",
-        "hex": "FFE5E6",
-        "copy": "primary",
-        "contrast": "AAA 17.6",
-        "primary": "no"
-      },
-      {
-        "stop": "200",
-        "hex": "FF8585",
-        "copy": "primary",
-        "contrast": "AAA 8.94",
-        "primary": "no"
-      },
-      {
-        "stop": "300",
-        "hex": "EC0E0E",
-        "copy": "white",
-        "contrast": "AA 4.53",
-        "primary": "no"
-      },
-      {
-        "stop": "400",
-        "hex": "B70B0B",
-        "copy": "white",
-        "contrast": "AA 6.84",
-        "primary": "yes"
-      },
-      {
-        "stop": "500",
-        "hex": "FB0505",
-        "copy": "white",
-        "contrast": "AAA 14.29",
-        "primary": "no"
-      }
-    ]
-  },
-  {
-    "color": "green",
-    "stops": [
-      {
-        "stop": "100",
-        "hex": "EDF9EB",
-        "copy": "primary",
-        "contrast": "AAA 18.35",
-        "primary": "no"
-      },
-      {
-        "stop": "200",
-        "hex": "B0FFA3",
-        "copy": "primary",
-        "contrast": "AAA 17.67",
-        "primary": "no"
-      },
-      {
-        "stop": "300",
-        "hex": "45F777",
-        "copy": "primary",
-        "contrast": "AAA 14.82",
-        "primary": "no"
-      },
-      {
-        "stop": "400",
-        "hex": "1AA340",
-        "copy": "primary",
-        "contrast": "AA 6.35",
-        "primary": "yes"
-      },
-      {
-        "stop": "500",
-        "hex": "124620",
-        "copy": "white",
-        "contrast": "AAA 10.92",
-        "primary": "no"
-      }
-    ]
-  },
-  {
-    "color": "blue",
-    "stops": [
-      {
-        "stop": "100",
-        "hex": "EAF2FA",
-        "copy": "primary",
-        "contrast": "AAA 18.57",
-        "primary": "no"
-      },
-      {
-        "stop": "200",
-        "hex": "99C8FF",
-        "copy": "primary",
-        "contrast": "AAA 12.06",
-        "primary": "no"
-      },
-      {
-        "stop": "300",
-        "hex": "51A0FE",
-        "copy": "primary",
-        "contrast": "AAA 7.8",
-        "primary": "no"
-      },
-      {
-        "stop": "400",
-        "hex": "1768C6",
-        "copy": "white",
-        "contrast": "AA 5.48",
-        "primary": "yes"
-      },
-      {
-        "stop": "500",
-        "hex": "01326D",
-        "copy": "white",
-        "contrast": "AAA 12.51",
-        "primary": "no"
-      }
-    ]
-  },
-  {
-    "color": "tan",
-    "stops": [
-      {
-        "stop": "100",
-        "hex": "F2F0EE",
-        "copy": "primary",
-        "contrast": "AAA 18.47",
-        "primary": "no"
-      },
-      {
-        "stop": "200",
-        "hex": "CEC8C4",
-        "copy": "primary",
-        "contrast": "AAA 12.68",
-        "primary": "no"
-      },
-      {
-        "stop": "300",
-        "hex": "87807B",
-        "copy": "primary",
-        "contrast": "AA 5.4",
-        "primary": "no"
-      },
-      {
-        "stop": "400",
-        "hex": "3F3D3C",
-        "copy": "white",
-        "contrast": "AAA 10.8",
-        "primary": "yes"
-      },
-      {
-        "stop": "500",
-        "hex": "121212",
-        "copy": "white",
-        "contrast": "AAA 18.73",
-        "primary": "no"
-      }
-    ]
-  }
-]
+{
+  "text": [],
+  "status-text": [],
+  "surface": [],
+  "borders": [
+    "subtle",
+    "default",
+    "moderate",
+    "bold",
+    "inverted-subtle",
+    "inverted-default",
+    "inverted-moderate",
+    "inverted-bold",
+    "focus",
+    "critical",
+    "critical-subtle",
+    "critical-strong",
+    "success",
+    "success-subtle",
+    "success-strong",
+    "warning",
+    "warning-subtle",
+    "warning-strong",
+    "brand",
+    "brand-subtle",
+    "brand-strong"
+  ],
+  "theme": [],
+  "base": [
+    {
+      "color": "black",
+      "stops": [
+        {
+          "stop": "100",
+          "hex": "F9F9F9",
+          "copy": "primary",
+          "contrast": "AAA 19.94",
+          "primary": "no"
+        },
+        {
+          "stop": "200",
+          "hex": "E9E9E9",
+          "copy": "primary",
+          "contrast": "AAA 17.29",
+          "primary": "no"
+        },
+        {
+          "stop": "300",
+          "hex": "D2D2D2",
+          "copy": "primary",
+          "contrast": "AAA 13.88",
+          "primary": "no"
+        },
+        {
+          "stop": "400",
+          "hex": "AAAAAA",
+          "copy": "primary",
+          "contrast": "AAA 9.03",
+          "primary": "no"
+        },
+        {
+          "stop": "500",
+          "hex": "808080",
+          "copy": "primary",
+          "contrast": "AA 5.31",
+          "primary": "no"
+        },
+        {
+          "stop": "600",
+          "hex": "555555",
+          "copy": "white",
+          "contrast": "AAA 7.45",
+          "primary": "no"
+        },
+        {
+          "stop": "700",
+          "hex": "3A3A3A",
+          "copy": "white",
+          "contrast": "AAA 11.37",
+          "primary": "no"
+        },
+        {
+          "stop": "800",
+          "hex": "222222",
+          "copy": "white",
+          "contrast": "AAA 15.9",
+          "primary": "no"
+        },
+        {
+          "stop": "900",
+          "hex": "000000",
+          "copy": "white",
+          "contrast": "AAA 21",
+          "primary": "yes"
+        }
+      ]
+    },
+    {
+      "color": "purple",
+      "stops": [
+        {
+          "stop": "100",
+          "hex": "F5F0FF",
+          "copy": "primary",
+          "contrast": "AAA 18.79",
+          "primary": "no"
+        },
+        {
+          "stop": "200",
+          "hex": "DAC7FF",
+          "copy": "primary",
+          "contrast": "AAA 13.59",
+          "primary": "no"
+        },
+        {
+          "stop": "300",
+          "hex": "AB7EFF",
+          "copy": "primary",
+          "contrast": "AAA 7.15",
+          "primary": "no"
+        },
+        {
+          "stop": "400",
+          "hex": "7C52FF",
+          "copy": "white",
+          "contrast": "AA 4.65",
+          "darkContrast": "AA 4.5",
+          "primary": "yes"
+        },
+        {
+          "stop": "500",
+          "hex": "3A1D95",
+          "copy": "white",
+          "contrast": "AAA 11.73",
+          "primary": "no"
+        },
+        {
+          "stop": "600",
+          "hex": "10022C",
+          "copy": "white",
+          "contrast": "AAA 19.67",
+          "primary": "no"
+        }
+      ]
+    },
+    {
+      "color": "magenta",
+      "stops": [
+        {
+          "stop": "100",
+          "hex": "FFE0F2",
+          "copy": "primary",
+          "contrast": "AAA 17.9",
+          "primary": "no"
+        },
+        {
+          "stop": "200",
+          "hex": "F985C7",
+          "copy": "primary",
+          "contrast": "AA 9.2",
+          "primary": "no"
+        },
+        {
+          "stop": "300",
+          "hex": "F9008E",
+          "copy": "primary",
+          "contrast": "AA 5.41",
+          "primary": "no"
+        },
+        {
+          "stop": "400",
+          "hex": "8C0E56",
+          "copy": "white",
+          "contrast": "AAA 9.08",
+          "primary": "yes"
+        },
+        {
+          "stop": "500",
+          "hex": "541A3B",
+          "copy": "white",
+          "contrast": "AAA 13.22",
+          "primary": "no"
+        }
+      ]
+    },
+    {
+      "color": "gold",
+      "stops": [
+        {
+          "stop": "100",
+          "hex": "FFF4CC",
+          "copy": "primary",
+          "contrast": "AAA 17.1",
+          "primary": "no"
+        },
+        {
+          "stop": "200",
+          "hex": "FFDB80",
+          "copy": "primary",
+          "contrast": "AAA 14.74",
+          "primary": "no"
+        },
+        {
+          "stop": "300",
+          "hex": "F6AB3C",
+          "copy": "primary",
+          "contrast": "AAA 10.8",
+          "primary": "yes"
+        },
+        {
+          "stop": "400",
+          "hex": "D28F2B",
+          "copy": "primary",
+          "contrast": "AAA 7.7",
+          "primary": "no"
+        },
+        {
+          "stop": "500",
+          "hex": "815008",
+          "copy": "white",
+          "contrast": "AA 6.8",
+          "primary": "no"
+        }
+      ]
+    },
+    {
+      "color": "red",
+      "stops": [
+        {
+          "stop": "100",
+          "hex": "FFE5E6",
+          "copy": "primary",
+          "contrast": "AAA 17.6",
+          "primary": "no"
+        },
+        {
+          "stop": "200",
+          "hex": "FF8585",
+          "copy": "primary",
+          "contrast": "AAA 8.94",
+          "primary": "no"
+        },
+        {
+          "stop": "300",
+          "hex": "EC0E0E",
+          "copy": "white",
+          "contrast": "AA 4.53",
+          "primary": "no"
+        },
+        {
+          "stop": "400",
+          "hex": "B70B0B",
+          "copy": "white",
+          "contrast": "AA 6.84",
+          "primary": "yes"
+        },
+        {
+          "stop": "500",
+          "hex": "FB0505",
+          "copy": "white",
+          "contrast": "AAA 14.29",
+          "primary": "no"
+        }
+      ]
+    },
+    {
+      "color": "green",
+      "stops": [
+        {
+          "stop": "100",
+          "hex": "EDF9EB",
+          "copy": "primary",
+          "contrast": "AAA 18.35",
+          "primary": "no"
+        },
+        {
+          "stop": "200",
+          "hex": "B0FFA3",
+          "copy": "primary",
+          "contrast": "AAA 17.67",
+          "primary": "no"
+        },
+        {
+          "stop": "300",
+          "hex": "45F777",
+          "copy": "primary",
+          "contrast": "AAA 14.82",
+          "primary": "no"
+        },
+        {
+          "stop": "400",
+          "hex": "1AA340",
+          "copy": "primary",
+          "contrast": "AA 6.35",
+          "primary": "yes"
+        },
+        {
+          "stop": "500",
+          "hex": "124620",
+          "copy": "white",
+          "contrast": "AAA 10.92",
+          "primary": "no"
+        }
+      ]
+    },
+    {
+      "color": "blue",
+      "stops": [
+        {
+          "stop": "100",
+          "hex": "EAF2FA",
+          "copy": "primary",
+          "contrast": "AAA 18.57",
+          "primary": "no"
+        },
+        {
+          "stop": "200",
+          "hex": "99C8FF",
+          "copy": "primary",
+          "contrast": "AAA 12.06",
+          "primary": "no"
+        },
+        {
+          "stop": "300",
+          "hex": "51A0FE",
+          "copy": "primary",
+          "contrast": "AAA 7.8",
+          "primary": "no"
+        },
+        {
+          "stop": "400",
+          "hex": "1768C6",
+          "copy": "white",
+          "contrast": "AA 5.48",
+          "primary": "yes"
+        },
+        {
+          "stop": "500",
+          "hex": "01326D",
+          "copy": "white",
+          "contrast": "AAA 12.51",
+          "primary": "no"
+        }
+      ]
+    },
+    {
+      "color": "tan",
+      "stops": [
+        {
+          "stop": "100",
+          "hex": "F2F0EE",
+          "copy": "primary",
+          "contrast": "AAA 18.47",
+          "primary": "no"
+        },
+        {
+          "stop": "200",
+          "hex": "CEC8C4",
+          "copy": "primary",
+          "contrast": "AAA 12.68",
+          "primary": "no"
+        },
+        {
+          "stop": "300",
+          "hex": "87807B",
+          "copy": "primary",
+          "contrast": "AA 5.4",
+          "primary": "no"
+        },
+        {
+          "stop": "400",
+          "hex": "3F3D3C",
+          "copy": "white",
+          "contrast": "AAA 10.8",
+          "primary": "yes"
+        },
+        {
+          "stop": "500",
+          "hex": "121212",
+          "copy": "white",
+          "contrast": "AAA 18.73",
+          "primary": "no"
+        }
+      ]
+    }
+  ],
+  "special": [
+    "transparent",
+    "unset",
+    "white"
+  ]
+}

--- a/docs/design/colors/index.md
+++ b/docs/design/colors/index.md
@@ -532,200 +532,20 @@ Define the edge of key content area, components, or surfaces.
       <th scope="col">CSS utility</th>
     </tr>
   </thead>
-  <tbody>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-subtle"></div></th>
-      <th scope="row" class="d-lh-300">
-        Subtle
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-subtle)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-subtle</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-default"></div></th>
-      <th scope="row" class="d-lh-300">
-        Default
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-default)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-default</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-moderate"></div></th>
-      <th scope="row" class="d-lh-300">
-        Moderate
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-moderate)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-moderate</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-bold"></div></th>
-      <th scope="row" class="d-lh-300">
-        Bold
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-bold)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-bold</td>
-    </tr>
+  <tbody v-for="c in borders">
     <tr>
       <th scope="row" class="d-pr0">
-        <div class="d-bgc-contrast d-d-inline-flex">
-          <div class="d-bar-circle d-w42 d-h42 d-ba d-bas-solid d-baw4 d-bc-inverted-subtle"></div>
+        <div
+            :class="['d-d-inline-flex', {'d-bgc-contrast': c.includes('inverted')}]"
+        >
+            <div :class="`d-bar-circle d-w42 d-h42 d-ba d-bas-solid d-baw4 d-bc-${c}`"></div>
         </div>
       </th>
-      <th scope="row" class="d-lh-300">
-        Subtle inverted
+      <th scope="row" class="d-lh-300 d-tt-capitalize">
+        {{ c.replace('-', ' ') }}
       </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-inverted-subtle)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-inverted-subtle</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0">
-        <div class="d-bgc-contrast d-d-inline-flex">
-          <div class="d-bar-circle d-w42 d-h42 d-ba d-bas-solid d-baw4 d-bc-inverted-default"></div>
-        </div>
-      </th>
-      <th scope="row" class="d-lh-300">
-        Default inverted
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-inverted-default)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-inverted-default</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0">
-        <div class="d-bgc-contrast d-d-inline-flex">
-          <div class="d-bar-circle d-w42 d-h42 d-ba d-bas-solid d-baw4 d-bc-inverted-moderate"></div>
-        </div>
-      </th>
-      <th scope="row" class="d-lh-300">
-        Moderate inverted
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-inverted-moderate)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-inverted-moderate</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0">
-        <div class="d-bgc-contrast d-d-inline-flex">
-          <div class="d-bar-circle d-w42 d-h42 d-ba d-bas-solid d-baw4 d-bc-inverted-bold"></div>
-        </div>
-      </th>
-      <th scope="row" class="d-lh-300">
-        Bold inverted
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-inverted-bold)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-inverted-bold</td>
-    </tr>
-  </tbody>
-  <tbody>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-focus"></div></th>
-      <th scope="row" class="d-lh-300">
-        Focus
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-focus)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-focus</td>
-    </tr>
-  </tbody>
-  <tbody>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-critical"></div></th>
-      <th scope="row" class="d-lh-300">
-        Critical
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-critical)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-critical</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-critical-subtle"></div></th>
-      <th scope="row" class="d-lh-300">
-        Critical subtle
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-critical-subtle)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-critical-subtle</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-critical-strong"></div></th>
-      <th scope="row" class="d-lh-300">
-        Critical strong
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-critical-strong)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-critical-strong</td>
-    </tr>
-  </tbody>
-  <tbody>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-success"></div></th>
-      <th scope="row" class="d-lh-300">
-        Success
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-success)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-success</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-success-subtle"></div></th>
-      <th scope="row" class="d-lh-300">
-        Success subtle
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-success-subtle)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-success-subtle</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-success-strong"></div></th>
-      <th scope="row" class="d-lh-300">
-        Success strong
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-success-strong)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-success-strong</td>
-    </tr>
-  </tbody>
-  <tbody>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-warning"></div></th>
-      <th scope="row" class="d-lh-300">
-        Warning
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-warning)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-warning</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-warning-subtle"></div></th>
-      <th scope="row" class="d-lh-300">
-        Warning subtle
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-warning-subtle)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-warning-subtle</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-warning-strong"></div></th>
-      <th scope="row" class="d-lh-300">
-        Warning strong
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-warning-strong)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-warning-strong</td>
-    </tr>
-  </tbody>
-  <tbody>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-brand"></div></th>
-      <th scope="row" class="d-lh-300">
-        Brand
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-brand)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-brand</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-brand-subtle"></div></th>
-      <th scope="row" class="d-lh-300">
-        Brand subtle
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-brand-subtle)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-brand-subtle</td>
-    </tr>
-    <tr>
-      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-primary d-ba d-bas-solid d-baw4 d-bc-brand-strong"></div></th>
-      <th scope="row" class="d-lh-300">
-        Brand strong
-      </th>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-brand-strong)</td>
-      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-brand-strong</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--bc-{{c}})</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bc-{{c}}</td>
     </tr>
   </tbody>
 </table>
@@ -868,7 +688,9 @@ Define the edge of key content area, components, or surfaces.
     </tr>
     <tr>
       <td class="d-pl0">
-        <div class="d-theme-sidebar-icon-fc d-p6 d-fco8-circle h:d-fco100 d-ta-center"> <dt-icon name="info"></dt-icon> </div>
+        <div class="d-theme-sidebar-icon-fc d-p6 d-fco8-circle h:d-fco100 d-ta-center">
+            <dt-icon name="info"></dt-icon>
+        </div>
       </td>
       <th scope="row">
         Sidebar
@@ -1108,4 +930,8 @@ Base colors are the literal value of all available colors. Use these if all abst
 
 Each of the colors listed above references one of these. For example, `var(--fc-primary)` is an alias to `var(--black-900)`, and `var(--fc-critical)` is an alias to `var(--red-300)`.
 
-<colors></colors>
+<colors-catalog />
+
+<script setup>
+    import { borders } from '@data/colors.json';
+</script>

--- a/docs/utilities/backgrounds/color.md
+++ b/docs/utilities/backgrounds/color.md
@@ -91,7 +91,7 @@ Use `fv:d-bgc-{color}` to change an element's `:focus-visible` state background 
 ```
 
 <script setup>
-  import colors from '@data/colors.json';
+  import { base as baseColors} from '@data/colors.json';
 </script>
 
 ## Classes
@@ -259,7 +259,7 @@ Use `fv:d-bgc-{color}` to change an element's `:focus-visible` state background 
               </td>
           </tr>
       </tbody>
-      <tbody v-for="{ color, stops } in colors">
+      <tbody v-for="{ color, stops } in baseColors">
         <tr v-for="{ stop } in stops">
             <th scope="row" class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">.d-bgc-{{ color }}-{{ stop }}</th>
             <td>

--- a/docs/utilities/backgrounds/gradients.md
+++ b/docs/utilities/backgrounds/gradients.md
@@ -93,7 +93,7 @@ Use `fv:d-bgg-{from|to}-{color}` to change an element's background gradient star
 
 <script setup>
   import { gradients } from '@data/backgrounds.json';
-  import colors from '@data/colors.json';
+  import { base as baseColors} from '@data/colors.json';
 </script>
 
 ## Directions
@@ -123,7 +123,7 @@ The starting stop (`d-bgg-from-{color}`) should be declared. Optionally an endin
 <utility-class-table>
  <template #content>
         <div v-for="direction in ['from', 'to']" style="display: contents">
-          <tbody v-for="{ color, stops } in colors">
+          <tbody v-for="{ color, stops } in baseColors">
               <tr v-for="{ stop } in stops">
                   <th scope="row" class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">.d-bgg-{{ direction }}-{{ color }}-{{ stop }}</th>
                   <td>

--- a/docs/utilities/borders/color.md
+++ b/docs/utilities/borders/color.md
@@ -97,52 +97,54 @@ Use `fv:d-bc-{color}` to change an element's border color when in `:focus-visibl
 <button class="d-ba d-baw2 d-bc-red-300 fv:d-bc-purple-400">...</button>
 ```
 
-<script setup>
-  import colors from '@data/colors.json';
-</script>
-
 ## Classes
 
 <div class="d-h464 d-of-y-scroll d-bb d-bc-black-200">
   <utility-class-table>
     <template #content>
       <tbody>
-          <tr>
-              <th scope="row" class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">.d-bc-transparent</th>
+          <tr v-for="c in special">
+              <th scope="row" class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">.d-bc-{{c}}</th>
               <td>
                   <div class="d-d-flex d-jc-space-between d-ai-center">
                       <div class="d-fl-grow1 d-ff-mono d-fs-100">
-                          border-color: transparent !important;
+                        <span v-if="c === 'white'">
+                            --bco: 100%;<br/>
+                            border-color: hsla(var(--{{ c }}-h) var(--{{ c }}-s) var(--{{ c }}-l) / var(--bco)) !important;
+                        </span>
+                        <span v-else>border-color: {{c}} !important;</span>
                       </div>
-                      <div class="d-fl-shrink0 d-m4 d-ml16 d-h42 d-w42 d-bar4 d-bc-transparent d-ba d-baw2"></div>
-                  </div>
-              </td>
-          </tr>
-          <tr>
-              <th scope="row" class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">.d-bc-unset</th>
-              <td>
-                  <div class="d-d-flex d-jc-space-between d-ai-center">
-                      <div class="d-fl-grow1 d-ff-mono d-fs-100">
-                          border-color: unset !important;
+                      <div
+                        :class="['d-d-inline-flex', {'d-bgc-contrast': c.includes('white')}]"
+                      >
+                        <div
+                            :class="`d-fl-shrink0 d-m4 d-h42 d-w42 d-bar4 d-bc-${c} d-ba d-baw2`"
+                        />
                       </div>
-                      <div class="d-fl-shrink0 d-m4 d-ml16 d-h42 d-w42 d-bar4 d-bc-unset d-ba d-baw2"></div>
-                  </div>
-              </td>
-          </tr>
-          <tr>
-              <th scope="row" class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">.d-bc-white</th>
-              <td>
-                  <div class="d-d-flex d-jc-space-between d-ai-center">
-                      <div class="d-fl-grow1 d-ff-mono d-fs-100">
-                          --bco: 100%;<br/>
-                          border-color: hsla(var(--white-h) var(--white-s) var(--white-l) / var(--bco)) !important;
-                      </div>
-                      <div class="d-fl-shrink0 d-d-flex d-m4 d-p4 d-ml16 d-h42 d-w42 d-bar4 d-bgc-black-700"><div class="d-w100p d-h100p d-bc-white d-ba d-bar4"></div></div>
                   </div>
               </td>
           </tr>
       </tbody>
-      <tbody v-for="{color: c, stops} in colors">
+      <tbody>
+          <tr v-for="c in borders">
+              <th scope="row" class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">.d-bc-{{c}}</th>
+              <td>
+                  <div class="d-d-flex d-jc-space-between d-ai-center">
+                      <div class="d-fl-grow1 d-ff-mono d-fs-100">
+                        <span>border-color: var(--bc-{{c}})</span>
+                      </div>
+                      <div
+                        :class="['d-d-inline-flex', {'d-bgc-contrast': c.includes('inverted')}]"
+                      >
+                        <div
+                            :class="`d-fl-shrink0 d-m4 d-h42 d-w42 d-bar4 d-bc-${c} d-ba d-baw2`"
+                        />
+                      </div>
+                  </div>
+              </td>
+          </tr>
+      </tbody>
+      <tbody v-for="{color: c, stops} in base">
           <tr v-for="{ stop, copy } in stops">
               <th scope="row" class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">.d-bc-{{ c }}-{{ stop }}</th>
               <td>
@@ -163,3 +165,7 @@ Use `fv:d-bc-{color}` to change an element's border color when in `:focus-visibl
     </template>
   </utility-class-table>
 </div>
+
+<script setup>
+import {base, special, borders} from '@data/colors.json';
+</script>

--- a/docs/utilities/borders/divide-color.md
+++ b/docs/utilities/borders/divide-color.md
@@ -64,7 +64,7 @@ Use `d-dco{n}` to change a divider opacity value.
 ```
 
 <script setup>
-  import colors from '@data/colors.json';
+  import { base as baseColors} from '@data/colors.json';
 </script>
 
 ## Classes
@@ -72,7 +72,7 @@ Use `d-dco{n}` to change a divider opacity value.
 <div class="d-h464 d-of-y-scroll d-bb d-bc-black-200">
   <utility-class-table>
     <template #content>
-      <tbody v-for="{ color: c, stops } in colors">
+      <tbody v-for="{ color: c, stops } in baseColors">
         <tr v-for="{ stop, copy } in stops">
           <th scope="row" class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">.d-divide-{{ c }}-{{ stop }}</th>
           <td>

--- a/docs/utilities/typography/color.md
+++ b/docs/utilities/typography/color.md
@@ -109,7 +109,7 @@ Use `d:d-fc-{color}` to set a different text color when the user prefers dark mo
 
 <script setup>
   import { fontColorVars } from '@data/type.json';
-  import colors from '@data/colors.json';
+  import { base as baseColors } from '@data/colors.json';
 </script>
 
 ## Classes
@@ -191,7 +191,7 @@ Use `d:d-fc-{color}` to set a different text color when the user prefers dark mo
           </td>
         </tr>
       </tbody>
-      <tbody v-for="{ color, stops } in colors">
+      <tbody v-for="{ color, stops } in baseColors">
         <tr v-for="{ stop } in stops.reverse()">
           <th scope="row" class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">.d-fc-{{ color }}-{{ stop }}</th>
           <td>

--- a/lib/build/less/utilities/borders.less
+++ b/lib/build/less/utilities/borders.less
@@ -36,37 +36,6 @@
 .d-ba-unset { border: unset !important; }
 
 //  ============================================================================
-//  $$  COLOR
-//  ----------------------------------------------------------------------------
-.d-bc-transparent       { border-color: transparent !important; }
-.d-bc-current           { border-color: currentColor !important; }
-.d-bc-unset             { border-color: unset !important; }
-
-.d-bc-subtle            { border-color: var(--bc-subtle) !important; }
-.d-bc-default           { border-color: var(--bc-default) !important; }
-.d-bc-moderate          { border-color: var(--bc-moderate) !important; }
-.d-bc-bold              { border-color: var(--bc-bold) !important; }
-
-.d-bc-inverted-subtle   { border-color: var(--bc-inverted-subtle) !important; }
-.d-bc-inverted-default  { border-color: var(--bc-inverted-default) !important; }
-.d-bc-inverted-moderate { border-color: var(--bc-inverted-moderate) !important; }
-.d-bc-inverted-bold     { border-color: var(--bc-inverted-bold) !important; }
-
-.d-bc-focus           { border-color: var(--bc-focus) !important; }
-.d-bc-critical        { border-color: var(--bc-critical) !important; }
-.d-bc-critical-subtle { border-color: var(--bc-critical-subtle) !important; }
-.d-bc-critical-strong { border-color: var(--bc-critical-strong) !important; }
-.d-bc-success         { border-color: var(--bc-success) !important; }
-.d-bc-success-subtle  { border-color: var(--bc-success-subtle) !important; }
-.d-bc-success-strong  { border-color: var(--bc-success-strong) !important; }
-.d-bc-warning         { border-color: var(--bc-warning) !important; }
-.d-bc-warning-subtle  { border-color: var(--bc-warning-subtle) !important; }
-.d-bc-warning-strong  { border-color: var(--bc-warning-strong) !important; }
-.d-bc-brand           { border-color: var(--bc-brand) !important; }
-.d-bc-brand-subtle    { border-color: var(--bc-brand-subtle) !important; }
-.d-bc-brand-strong    { border-color: var(--bc-brand-strong) !important; }
-
-//  ============================================================================
 //  $  BORDER RADIUS
 //  ============================================================================
 //  $$ ALL

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -190,10 +190,76 @@
 //  ----------------------------------------------------------------------------
 .d-bc-transparent { border-color: transparent !important; }
 #d-internals #generate-hover-focus(d-bc-transparent, {.d-bc-transparent();});
+
 .d-bc-current { border-color: currentColor !important; }
 #d-internals #generate-hover-focus(d-bc-current , {.d-bc-current();});
+
 .d-bc-unset { border-color: unset !important; }
 #d-internals #generate-hover-focus(d-bc-unset, {.d-bc-unset();});
+
+.d-bc-subtle { border-color: var(--bc-subtle) !important; }
+#d-internals #generate-hover-focus(d-bc-subtle, {.d-bc-subtle();});
+
+.d-bc-default { border-color: var(--bc-default) !important; }
+#d-internals #generate-hover-focus(d-bc-default, {.d-bc-default();});
+
+.d-bc-moderate { border-color: var(--bc-moderate) !important; }
+#d-internals #generate-hover-focus(d-bc-moderate, {.d-bc-moderate();});
+
+.d-bc-bold { border-color: var(--bc-bold) !important; }
+#d-internals #generate-hover-focus(d-bc-bold, {.d-bc-bold();});
+
+
+.d-bc-inverted-subtle { border-color: var(--bc-inverted-subtle) !important; }
+#d-internals #generate-hover-focus(d-bc-inverted-subtle, {.d-bc-inverted-subtle();});
+
+.d-bc-inverted-default { border-color: var(--bc-inverted-default) !important; }
+#d-internals #generate-hover-focus(d-bc-inverted-default, {.d-bc-inverted-default();});
+
+.d-bc-inverted-moderate { border-color: var(--bc-inverted-moderate) !important; }
+#d-internals #generate-hover-focus(d-bc-inverted-moderate, {.d-bc-inverted-moderate();});
+
+.d-bc-inverted-bold { border-color: var(--bc-inverted-bold) !important; }
+#d-internals #generate-hover-focus(d-bc-inverted-bold, {.d-bc-inverted-bold();});
+
+.d-bc-focus { border-color: var(--bc-focus) !important; }
+#d-internals #generate-hover-focus(d-bc-focus, {.d-bc-focus();});
+
+.d-bc-critical { border-color: var(--bc-critical) !important; }
+#d-internals #generate-hover-focus(d-bc-critical, {.d-bc-critical();});
+
+.d-bc-critical-subtle { border-color: var(--bc-critical-subtle) !important; }
+#d-internals #generate-hover-focus(d-bc-critical-subtle, {.d-bc-critical-subtle();});
+
+.d-bc-critical-strong { border-color: var(--bc-critical-strong) !important; }
+#d-internals #generate-hover-focus(d-bc-critical-strong, {.d-bc-critical-strong();});
+
+.d-bc-success { border-color: var(--bc-success) !important; }
+#d-internals #generate-hover-focus(d-bc-success, {.d-bc-success();});
+
+.d-bc-success-subtle { border-color: var(--bc-success-subtle) !important; }
+#d-internals #generate-hover-focus(d-bc-success-subtle, {.d-bc-success-subtle();});
+
+.d-bc-success-strong { border-color: var(--bc-success-strong) !important; }
+#d-internals #generate-hover-focus(d-bc-success-strong, {.d-bc-success-strong();});
+
+.d-bc-warning { border-color: var(--bc-warning) !important; }
+#d-internals #generate-hover-focus(d-bc-warning, {.d-bc-warning();});
+
+.d-bc-warning-subtle { border-color: var(--bc-warning-subtle) !important; }
+#d-internals #generate-hover-focus(d-bc-warning-subtle, {.d-bc-warning-subtle();});
+
+.d-bc-warning-strong { border-color: var(--bc-warning-strong) !important; }
+#d-internals #generate-hover-focus(d-bc-warning-strong, {.d-bc-warning-strong();});
+
+.d-bc-brand { border-color: var(--bc-brand) !important; }
+#d-internals #generate-hover-focus(d-bc-brand, {.d-bc-brand();});
+
+.d-bc-brand-subtle { border-color: var(--bc-brand-subtle) !important; }
+#d-internals #generate-hover-focus(d-bc-brand-subtle, {.d-bc-brand-subtle();});
+
+.d-bc-brand-strong { border-color: var(--bc-brand-strong) !important; }
+#d-internals #generate-hover-focus(d-bc-brand-strong, {.d-bc-brand-strong();});
 
 //  $   OPACITY CLASSES
 //  ----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

- Moved the border colors from borders.less to colors.less
- Added focus and hover variants to all semantic border colors

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/VKmyLMvEyEpndna081/giphy.gif)
