### PR TITLE
fix: update paths in getting started and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,16 @@ This is the home for Dialtone, Dialpad's design system. It includes the resource
 To add Dialtone into your project, you can install it via NPM:
 
 ```
-npm install --save-dev @dialpad/dialtone
+npm install @dialpad/dialtone
 ```
 
 Once installed, add the following line in your Less file:
 ```
-@import "your/path/to/dialtone.less";
+@import "node_modules/@dialpad/dialtone/lib/build/less/dialtone.less";
 ```
 If you only need access to Dialtone's variables and customizations to build a file and don't need the whole library exported, use this line instead in your Less file:
 ```
-@import (reference) "your/path/to/dialtone.less";
+@import (reference) "node_modules/@dialpad/dialtone/lib/build/less/dialtone.less";
 ```
 
 ## Building Dialtone locally

--- a/docs/guides/getting-started/index.md
+++ b/docs/guides/getting-started/index.md
@@ -14,27 +14,13 @@ npm install @dialpad/dialtone
 Add the following line in your Less file:
 
 ```less
-@import "your/path/to/dialtone.less";
+@import "node_modules/@dialpad/dialtone/lib/build/less/dialtone.less";
 ```
 
 If you only need access to Dialtone's variables and customizations to build a file and don't need the whole library exported, use this line instead in your Less file:
 
 ```less
-@import (reference) "your/path/to/dialtone.less";
-```
-
-## Theming
-
-To customize your Dialtone installation, create a new Less file in the `/lib/build/less/themes/` folder. By default this will compile during build, which can be added as an additional CSS file in your page `head`.
-
-```less
-@import "your/path/to/dialtone.less";
-```
-
-If you only need access to Dialtone's variables and customizations to build a file and don't need the whole library exported, use this line instead in your Less file:
-
-```less
-@import (reference) "your/path/to/dialtone.less";
+@import (reference) "node_modules/@dialpad/dialtone/lib/build/less/dialtone.less";
 ```
 
 ## Usage


### PR DESCRIPTION
## Description
Update the paths to be actual default paths in documentation.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/xUPGcM9CazM9H5KrEA/giphy.gif)
