### PR TITLE
docs: fix page toc

### DIFF
--- a/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -112,10 +112,6 @@ a.router-link-active {
 //      custom CSS here instead.
 //  ----------------------------------------------------------------------------
 .vuepress-toc {
-  :first-child.toc-list {
-    flex-wrap: wrap;
-  }
-
   .active-category {
     &::before {
       position: absolute;

--- a/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -48,7 +48,7 @@
 
 html {
   scroll-behavior: smooth;
-  scroll-padding-top: 6.4rem;
+  scroll-padding-top: 7.2rem;
 }
 
 // @TODO: Move to root-layout component on dialtone-vue
@@ -106,6 +106,9 @@ a.router-link-active {
 //      custom CSS here instead.
 //  ----------------------------------------------------------------------------
 .vuepress-toc {
+  :first-child.toc-list {
+    flex-wrap: wrap;
+  }
   .active-category {
     &::before {
       position: absolute;
@@ -685,4 +688,14 @@ a.header-anchor {
 
 [outline] {
   outline: 2px solid orangered;
+}
+
+// ============================================================================
+// $    MEDIA QUERIES
+// ----------------------------------------------------------------------------
+
+@media (max-width: 980px) {
+  html {
+    scroll-padding-top: 13.6rem;
+  }
 }

--- a/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -39,6 +39,7 @@
 //      [1]     Universally set border-box
 //  ----------------------------------------------------------------------------
 * {
+
   &,
   &::before,
   &::after {
@@ -54,9 +55,14 @@ html {
 // @TODO: Move to root-layout component on dialtone-vue
 .root-layout {
   min-height: 100vh;
-}
-.root-layout__content:focus-visible {
-  box-shadow: none;
+
+  &__content {
+    overflow-y: unset !important;
+
+    &:focus-visible {
+      box-shadow: none;
+    }
+  }
 }
 
 
@@ -109,6 +115,7 @@ a.router-link-active {
   :first-child.toc-list {
     flex-wrap: wrap;
   }
+
   .active-category {
     &::before {
       position: absolute;
@@ -121,8 +128,9 @@ a.router-link-active {
       content: '';
     }
   }
+
   .toc-item {
-    > .toc-list {
+    >.toc-list {
       padding-left: var(--space-400);
     }
   }
@@ -170,19 +178,22 @@ a.header-anchor {
   margin-top: var(--space-600);
   margin-bottom: var(--space-400);
 }
+
 .d-docsite--header-3 {
   .d-headline-large(); // TODO: when a redesign is imminent
   font-weight: var(--fw-semibold);
   margin-top: var(--space-500);
   margin-bottom: var(--space-300);
 }
+
 .d-docsite--header-4 {
   .d-headline-medium(); // TODO: when a redesign is imminent
   margin-top: var(--space-400);
   margin-bottom: var(--space-300);
 }
 
-.d-docsite--header-2, .d-docsite--header-3 {
+.d-docsite--header-2,
+.d-docsite--header-3 {
   &:hover a.header-anchor {
     opacity: 1;
   }
@@ -206,6 +217,7 @@ a.header-anchor {
   .d-body-base(); // TODO: when a redesign is imminent
   margin-bottom: 1em;
   max-width: 75ch;
+
   .d-notice & {
     // OVERRIDE
     margin: unset; // TODO: make sure this doesn't get inserted into components
@@ -228,6 +240,7 @@ a.header-anchor {
   .d-body-base(); // TODO: when a redesign is imminent
   margin-bottom: var(--space-300);
   max-width: 75ch;
+
   &:last-child {
     margin-bottom: 0;
   }
@@ -318,8 +331,8 @@ a.header-anchor {
     visibility: visible;
     opacity: 1;
     transition: opacity 50ms var(--ttf-in-out) 0s,
-    transform 50ms var(--ttf-in-out) 0s,
-    visibility 0s 50ms;
+      transform 50ms var(--ttf-in-out) 0s,
+      visibility 0s 50ms;
   }
 
   //  If it's in the first two columns, show the footer on the right
@@ -335,8 +348,8 @@ a.header-anchor {
     visibility: hidden;
     opacity: 0;
     transition: opacity 100ms var(--ttf-in-out) 0s,
-    transform 100ms var(--ttf-in-out) 0s,
-    visibility 0s 0s;
+      transform 100ms var(--ttf-in-out) 0s,
+      visibility 0s 0s;
   }
 }
 
@@ -590,12 +603,12 @@ a.header-anchor {
 //  ----------------------------------------------------------------------------
 
 .dialtone-definition {
-  > dt {
+  >dt {
     margin-top: var(--su16);
     font-weight: var(--fw-bold);
   }
 
-  > dd {
+  >dd {
     margin: 0;
     max-width: 72ch;
   }
@@ -668,7 +681,8 @@ a.header-anchor {
       margin: 0 !important;
       padding: 0;
       list-style: none;
-      * + * {
+
+      *+* {
         margin-top: var(--space-400);
       }
     }
@@ -677,6 +691,7 @@ a.header-anchor {
 
 .back-to-top {
   background-color: var(--primary-color);
+
   &:hover {
     background-color: var(--primary-color-hover);
   }

--- a/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -105,39 +105,22 @@ a.router-link-active {
 //      we can't add utility classes directly to the HTML. So we have to use
 //      custom CSS here instead.
 //  ----------------------------------------------------------------------------
-.toc {
-  &-item {
-    @media screen and (max-width: 980px) {
-      display: inline-block;
-      .d-link();
+.vuepress-toc {
+  .active-category {
+    &::before {
+      position: absolute;
+      top: 4px;
+      bottom: 4px;
+      left: calc(var(--space-300) * -1);
+      width: var(--size-200);
+      background-color: var(--purple-400);
+      border-radius: var(--size-200);
+      content: '';
     }
   }
-  a {
-    //  We'll base our styles on d-btn
-    // I'm not a fan of this... so TODO the whole thing up.
-    // TODO: RWD
-    .d-btn--sm();
-    .d-btn--muted();
-
-    font-weight: var(--fw-normal);
-    width: 100%;
-    justify-content: flex-start;
-
-    &.active {
-      //.d-btn--active(); // This is breaking the build
-      font-weight: var(--fw-medium);
-      --button-color-background: transparent;
-
-      &::before {
-        position: absolute;
-        top: 4px;
-        bottom: 4px;
-        left: calc(var(--space-300) * -1);
-        width: var(--size-200);
-        background-color: var(--purple-400);
-        border-radius: var(--size-200);
-        content: '';
-      }
+  .toc-item {
+    > .toc-list {
+      padding-left: var(--space-400);
     }
   }
 }
@@ -204,12 +187,6 @@ a.header-anchor {
 
 .d-ga-toc {
   grid-area: toc !important;
-}
-
-.toc-item {
-  > .toc-list {
-    padding-left: var(--space-400);
-  }
 }
 
 .d-gl-docsite {

--- a/docs/.vuepress/theme/components/PageToc.vue
+++ b/docs/.vuepress/theme/components/PageToc.vue
@@ -2,7 +2,7 @@
   <aside
     class="vuepress-toc lg:d-ps-relative lg:d-w100p d-ps-fixed d-r16 d-pt24"
   >
-    <h2 class="d-headline-eyebrow d-fw-semibold">
+    <h2 class="lg:d-pl12 d-headline-eyebrow d-fw-semibold">
       On this page
     </h2>
     <toc
@@ -14,11 +14,10 @@
 
 <script setup>
 const options = {
-  containerTag: '',
-  listClass: 'toc-list d-ls-reset',
-  itemClass: 'toc-item',
+  listClass: 'toc-list d-ls-reset lg:d-d-flex',
+  itemClass: 'toc-item lg:d-d-flex',
   linkTag: 'a',
-  linkClass: 'd-btn d-btn--sm d-btn--muted d-fw-normal d-w100p d-jc-flex-start',
+  linkClass: 'd-btn d-btn--sm d-btn--muted d-fw-normal d-w100p d-jc-flex-start d-ws-nowrap',
   linkActiveClass: 'active-item d-btn--active d-fw-medium',
   linkChildrenActiveClass: 'active-category',
 };

--- a/docs/.vuepress/theme/components/PageToc.vue
+++ b/docs/.vuepress/theme/components/PageToc.vue
@@ -1,13 +1,25 @@
 <template>
   <aside
-    class="
-      toc lg:d-ps-relative lg:d-t0 lg:d-w100p
-      d-ps-sticky d-t64 d-pt24
-      d-as-flex-start d-ga-toc"
-    >
-    <h2 class="d-p8 d-pt8 d-pl12 d-headline-eyebrow d-fw-semibold">
+    class="vuepress-toc lg:d-ps-relative lg:d-w100p d-ps-fixed d-r16 d-pt24"
+  >
+    <h2 class="d-headline-eyebrow d-fw-semibold">
       On this page
     </h2>
-    <toc :headers="$page.headers" />
+    <toc
+      :headers="$page.headers"
+      :options="options"
+    />
   </aside>
 </template>
+
+<script setup>
+const options = {
+  containerTag: '',
+  listClass: 'toc-list d-ls-reset',
+  itemClass: 'toc-item',
+  linkTag: 'a',
+  linkClass: 'd-btn d-btn--sm d-btn--muted d-fw-normal d-w100p d-jc-flex-start',
+  linkActiveClass: 'active-item d-btn--active d-fw-medium',
+  linkChildrenActiveClass: 'active-category',
+};
+</script>

--- a/docs/.vuepress/theme/components/PageToc.vue
+++ b/docs/.vuepress/theme/components/PageToc.vue
@@ -12,8 +12,8 @@
 
 <script setup>
 const options = {
-  listClass: 'toc-list d-ls-reset lg:d-d-flex',
-  itemClass: 'toc-item lg:d-d-flex',
+  listClass: 'toc-list d-ls-reset',
+  itemClass: 'toc-item lg:d-d-flex d-fw-wrap',
   linkTag: 'a',
   linkClass: 'd-btn d-btn--sm d-btn--muted d-fw-normal d-w100p d-jc-flex-start d-ws-nowrap',
   linkActiveClass: 'active-item d-btn--active d-fw-medium',

--- a/docs/.vuepress/theme/components/PageToc.vue
+++ b/docs/.vuepress/theme/components/PageToc.vue
@@ -1,8 +1,6 @@
 <template>
-  <aside
-    class="vuepress-toc lg:d-ps-relative lg:d-w100p d-ps-fixed d-r16 d-pt24"
-  >
-    <h2 class="lg:d-pl12 d-headline-eyebrow d-fw-semibold">
+  <aside class="vuepress-toc lg:d-ps-relative lg:d-t0 lg:d-w100p d-ps-sticky d-t64 d-pt24 d-as-flex-start d-ga-toc">
+    <h2 class="d-headline-eyebrow d-fw-semibold">
       On this page
     </h2>
     <toc

--- a/docs/.vuepress/theme/index.js
+++ b/docs/.vuepress/theme/index.js
@@ -93,14 +93,7 @@ export const dialtoneVuepressTheme = (options) => {
       themeDataPlugin({
         themeData: options,
       }),
-      tocPlugin({
-        defaultPropsOptions: {
-          containerTag: '',
-          listClass: 'toc-list d-ls-reset',
-          itemClass: 'toc-item',
-          linkClass: 'd-btn',
-        },
-      }),
+      tocPlugin(),
       activeHeaderLinksPlugin({
         headerLinkSelector: 'a.d-btn',
         offset: 128,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ const breakpoints = [
 const classes = [
   /\.d-d-(flex|none|block)$/, // Display Flex, None and Block
   '.d-t0',
-  /\.d-p[t|r]([0-9]*|-unset)$/, // Padding Top and Right
+  /\.d-p[t|r|l|b]([0-9]*|-unset)$/, // Padding Top and Right
   '.d-fd-column',
   '.d-ai-stretch',
   '.d-ps-relative',

--- a/lib/build/less/variables/sizes.less
+++ b/lib/build/less/variables/sizes.less
@@ -63,8 +63,6 @@
 }
 
 #d-internals #spacing-classes(0.8rem, 'size');
-
-#d-internals #spacing-classes(0.8rem, 'size');
 #d-internals #spacing-classes(1.6rem, 'size', '-16');
 #d-internals #spacing-classes(3.2rem, 'size', '-32');
 #d-internals #spacing-classes(6.4rem, 'size', '-64');


### PR DESCRIPTION
## Description

- Added back the functionality of `active` item.
- Fixed the position of the `page-toc` it was no longer being fixed on page.
- Fixed the responsive version of `page-toc`
- Fixed the `scroll-padding-top` on responsive version of the site.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/ThrM4jEi2lBxd7X2yz/giphy.gif)
