### PR TITLE
refactor(root-layout): bring styles from dialtone vue

### DIFF
--- a/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -52,6 +52,10 @@ html {
   scroll-padding-top: 7.2rem;
 }
 
+// Temp fix, will remove this once root-layout is update on dialtone-vue
+.root-layout__content {
+  overflow-y: unset !important;
+}
 
 //  ============================================================================
 //  $   SEARCH BUTTON
@@ -99,6 +103,8 @@ a.router-link-active {
 //      custom CSS here instead.
 //  ----------------------------------------------------------------------------
 .vuepress-toc {
+  height: fit-content;
+
   .active-category {
     &::before {
       position: absolute;

--- a/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -52,19 +52,6 @@ html {
   scroll-padding-top: 7.2rem;
 }
 
-// @TODO: Move to root-layout component on dialtone-vue
-.root-layout {
-  min-height: 100vh;
-
-  &__content {
-    overflow-y: unset !important;
-
-    &:focus-visible {
-      box-shadow: none;
-    }
-  }
-}
-
 
 //  ============================================================================
 //  $   SEARCH BUTTON

--- a/docs/.vuepress/theme/components/PageToc.vue
+++ b/docs/.vuepress/theme/components/PageToc.vue
@@ -1,5 +1,5 @@
 <template>
-  <aside class="vuepress-toc lg:d-ps-relative lg:d-t0 lg:d-w100p d-ps-sticky d-t64 d-pt24 d-as-flex-start d-ga-toc">
+  <aside class="vuepress-toc lg:d-ps-relative lg:d-t0 lg:d-w100p d-ps-sticky d-t64 d-pt24 d-ga-toc">
     <h2 class="d-headline-eyebrow d-fw-semibold">
       On this page
     </h2>

--- a/docs/.vuepress/theme/layouts/Layout.vue
+++ b/docs/.vuepress/theme/layouts/Layout.vue
@@ -1,9 +1,8 @@
 <template>
   <dt-root-layout
-    class="d-h-auto"
     header-class="dialtone-header d-d-flex d-ai-center d-p16 d-pl8 d-h64 d-jc-space-between d-zi-navigation"
-    :header-sticky="true"
     :fixed="false"
+    :header-sticky="true"
     footer-class="d-text-right"
     sidebar-class="dialtone-sidebar lg:d-d-none"
   >

--- a/lib/build/less/components/root-layout.less
+++ b/lib/build/less/components/root-layout.less
@@ -18,6 +18,7 @@
     'header' auto
     'body' 1fr
     'footer' auto / 1fr;
+  min-height: 100vh;
 
   &--fixed {
     height: 100vh;
@@ -57,6 +58,10 @@
   &__content {
     flex: 1;
     box-shadow: none;
+
+    &:focus-visible {
+      box-shadow: none;
+    }
   }
 
   &__footer {

--- a/lib/build/less/components/root-layout.less
+++ b/lib/build/less/components/root-layout.less
@@ -13,14 +13,18 @@
 //  $   BASE STYLE
 //  ----------------------------------------------------------------------------
 .d-root-layout {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
+  display: grid;
+  grid-template:
+    'header' auto
+    'body' 1fr
+    'footer' auto / 1fr;
+
+  &--fixed {
+    height: 100vh;
+  }
 
   &__header {
-    :first-child {
-      min-height: 100%;
-    }
+    grid-area: header;
 
     &--sticky {
       position: sticky;
@@ -30,8 +34,8 @@
 
   &__body {
     display: flex;
-    flex-wrap: wrap;
-    gap: 0;
+    grid-area: body;
+    overflow: auto;
     box-shadow: none;
 
     &--invert {
@@ -40,62 +44,57 @@
   }
 
   &__sidebar {
-    flex-grow: 1;
     box-shadow: none;
 
-    :first-child {
-      min-height: 100%;
+    &--sticky {
+      position: sticky;
+      top: 0;
+      height: 100%;
+      overflow: auto;
     }
   }
 
   &__content {
-    // overflow-y: unset !important;
-    flex-basis: 0;
-    flex-grow: 999;
+    flex: 1;
     box-shadow: none;
-
-    &--fixed {
-      height: 100%;
-      overflow-y: auto;
-    }
   }
 
   &__footer {
-    :first-child {
-      min-height: 100%;
+    grid-area: footer;
+  }
+}
+
+@media (max-width: 480px) {
+  .d-root-layout__responsive--sm {
+    .d-root-layout__body {
+      flex-direction: column;
+
+      &--invert {
+        flex-direction: column-reverse;
+      }
     }
   }
 }
 
 @media (max-width: 640px) {
-  .d-root-layout {
-    &__body {
+  .d-root-layout__responsive--md {
+    .d-root-layout__body {
+      flex-direction: column;
+
       &--invert {
-        //
+        flex-direction: column-reverse;
       }
     }
+  }
+}
 
-    &__sidebar {
-      :first-child {
-        //
-      }
-    }
+@media (max-width: 980px) {
+  .d-root-layout__responsive--lg {
+    .d-root-layout__body {
+      flex-direction: column;
 
-    &__content {
-      margin-bottom: var(--su128);
-
-      &--fixed {
-        //
-      }
-    }
-
-    &__header {
-      :first-child {
-        //
-      }
-
-      &--sticky {
-        //
+      &--invert {
+        flex-direction: column-reverse;
       }
     }
   }

--- a/lib/build/less/components/root-layout.less
+++ b/lib/build/less/components/root-layout.less
@@ -15,5 +15,88 @@
 .d-root-layout {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  min-height: 100vh;
+
+  &__header {
+    :first-child {
+      min-height: 100%;
+    }
+
+    &--sticky {
+      position: sticky;
+      top: 0;
+    }
+  }
+
+  &__body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0;
+    box-shadow: none;
+
+    &--invert {
+      flex-direction: row-reverse;
+    }
+  }
+
+  &__sidebar {
+    flex-grow: 1;
+    box-shadow: none;
+
+    :first-child {
+      min-height: 100%;
+    }
+  }
+
+  &__content {
+    // overflow-y: unset !important;
+    flex-basis: 0;
+    flex-grow: 999;
+    box-shadow: none;
+
+    &--fixed {
+      height: 100%;
+      overflow-y: auto;
+    }
+  }
+
+  &__footer {
+    :first-child {
+      min-height: 100%;
+    }
+  }
+}
+
+@media (max-width: 640px) {
+  .d-root-layout {
+    &__body {
+      &--invert {
+        //
+      }
+    }
+
+    &__sidebar {
+      :first-child {
+        //
+      }
+    }
+
+    &__content {
+      margin-bottom: var(--su128);
+
+      &--fixed {
+        //
+      }
+    }
+
+    &__header {
+      :first-child {
+        //
+      }
+
+      &--sticky {
+        //
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Description

Migrated styles from `dt-root-layout` component on dialtone-vue.
Refactored root-layout to use CSS GRID instead of a Flexbox approach to improve the maintenance.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/ihHdW1IRUVQJ1P5g89/giphy.gif)
