### PR TITLE
fix(button): set width on label

### DIFF
--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -188,6 +188,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    width: 100%;
     // background-color: rgba(0,0,0,.5);
 }
 

--- a/lib/build/less/components/button.less
+++ b/lib/build/less/components/button.less
@@ -186,9 +186,9 @@
 //  ----------------------------------------------------------------------------
 .d-btn__label {
     display: inline-flex;
+    flex: 1 auto;
     align-items: center;
     justify-content: center;
-    width: 100%;
     // background-color: rgba(0,0,0,.5);
 }
 


### PR DESCRIPTION
## Description
Button width 100% was previously set directly on the Vue component with d-100p. This prevented it from being overridden by utility classes. Moved to Dialtone classes as it should be.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/c5eqVJN7oNLTq/giphy.gif)
