### PR TITLE
fix: colors base palette

### DIFF
--- a/docs/.vuepress/baseComponents/BaseColor.vue
+++ b/docs/.vuepress/baseComponents/BaseColor.vue
@@ -14,26 +14,24 @@
       </h2>
     </header>
     <div
-      v-for="(s, index) in stops"
+      v-for="({ stop, copy, hex, contrast, invertedContrast }, index) in stops"
       :key="index"
-      :class="dynamicClasses(s, index)"
+      :class="dynamicClasses(stop, copy, index)"
       class="d-d-flex d-jc-space-between d-ai-center d-px12 d-py8 d-fs-100 d-lh6 d-ff-mono"
     >
       <div>
-        <strong>var(--{{ color }}{{ s.stop ? `-${s.stop}` : '' }})</strong>
+        <strong>var(--{{ color }}{{ stop ? `-${stop}` : '' }})</strong>
         <br>
-        <span>#{{ s.hex }}</span>
+        <span>#{{ hex }}</span>
       </div>
       <div class="d-d-flex d-fd-column d-fs-100 d-lh2 d-fw-bold d-bar-sm d-px4 py2">
-        <div>
-          {{ s.contrast }}
-        </div>
-        <div
-          v-if="s.darkContrast"
-          class="d-fc-primary"
+        <span> {{ contrast }}</span>
+        <span
+          v-if="invertedContrast"
+          :class="copy === 'primary-inverted' ? 'd-fc-primary' : 'd-fc-primary-inverted'"
         >
-          {{ s.darkContrast }}
-        </div>
+          {{ invertedContrast }}
+        </span>
       </div>
     </div>
   </aside>
@@ -55,11 +53,16 @@ export default {
   },
 
   methods: {
-    dynamicClasses (s, index) {
-      const bgColor = { [`d-bgc-${this.color}${s.stop ? '-' + s.stop : ''}`]: true };
-      const fontColor = { [`d-fc-${s.copy}`]: true };
-
-      return { ...bgColor, ...fontColor, 'd-btr4': index === 0, 'd-bbr4': index === (this.stops.length - 1) };
+    dynamicClasses (stop, copy, index) {
+      const stopColor = [this.color, stop].join('-');
+      return [
+        `d-bgc-${stopColor}`,
+        `d-fc-${copy}`,
+        {
+          'd-btr4': index === 0,
+          'd-bbr4': index === (this.stops.length - 1),
+        },
+      ];
     },
   },
 };

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -25,6 +25,7 @@ const themeConfig = {
   editLink: false,
   colorModeSwitch: false,
   contributors: false,
+  themeMode: 'dark',
 };
 
 const __dirname = getDirname(import.meta.url);

--- a/docs/.vuepress/theme/client.js
+++ b/docs/.vuepress/theme/client.js
@@ -5,6 +5,7 @@ import NotFound from './layouts/NotFound.vue';
 // CSS
 import '../../../lib/dist/css/dialtone.css';
 import './assets/less/dialtone-docs.less';
+import { useThemeData } from '@vuepress/plugin-theme-data/client';
 
 export default defineClientConfig({
   async enhance ({ app, router }) {
@@ -13,7 +14,8 @@ export default defineClientConfig({
       await registerDialtoneVue(app);
       await registerEmojiDialtoneVue(app);
       await registerDialtoneCombinator(app);
-      document.body.classList.add('dialtone-theme-light');
+      const defaultTheme = useThemeData().value.themeMode;
+      document.body.classList.add(`dialtone-theme-${defaultTheme}`);
     }
     router.options.scrollBehavior = (to, from, savedPosition) => {
       return to.hash

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -126,7 +126,8 @@
 
 <script setup>
 import { useRoute } from 'vue-router';
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
+import { useThemeData } from '@vuepress/plugin-theme-data/client';
 
 defineProps({
   items: {
@@ -137,10 +138,8 @@ defineProps({
 defineEmits(['search']);
 
 const route = useRoute();
-const currentTheme = ref('light');
-
 const isCurrentThemeLight = computed(() => {
-  return currentTheme.value === 'light';
+  return useThemeData().value.themeMode === 'light';
 });
 const currentThemeIconName = computed(() => {
   return isCurrentThemeLight.value ? 'sun' : 'moon';
@@ -150,7 +149,7 @@ const isActiveLink = (text) => {
   return route.path.search(linkBase) !== -1;
 };
 const toggleTheme = () => {
-  currentTheme.value = isCurrentThemeLight.value ? 'dark' : 'light';
+  useThemeData().value.themeMode = isCurrentThemeLight.value ? 'dark' : 'light';
   document.body.classList.toggle('dialtone-theme-light');
   document.body.classList.toggle('dialtone-theme-dark');
 };

--- a/docs/.vuepress/views/ColorsCatalog.vue
+++ b/docs/.vuepress/views/ColorsCatalog.vue
@@ -1,6 +1,9 @@
 <template>
   <section class="d-stack16">
-    <div class="d-d-grid d-gg24 d-g-cols2 md:d-g-cols1">
+    <div
+      class="d-d-grid d-gg24 d-g-cols2 md:d-g-cols1"
+      :class="themeModeClass"
+    >
       <base-color
         v-for="color in colors"
         :key="color.color"
@@ -13,6 +16,7 @@
 
 <script>
 import BaseColor from '../baseComponents/BaseColor.vue';
+import { base as colorsData } from '../../_data/colors.json';
 
 export default {
   name: 'Colors',
@@ -20,13 +24,20 @@ export default {
     BaseColor,
   },
 
-  data: () => ({
-    colors: [],
-  }),
+  props: {
+    /**
+     * Defines the themeMode colors catalog to show
+     * @values: lightMode, darkMode
+     */
+    themeMode: {
+      type: String,
+      required: true,
+    },
+  },
 
-  async beforeCreate () {
-    const data = await import('../../_data/colors.json');
-    this.colors = data.base;
+  created () {
+    this.colors = colorsData[this.themeMode];
+    this.themeModeClass = this.themeMode === 'lightMode' ? 'dialtone-theme-light' : 'dialtone-theme-dark';
   },
 };
 </script>

--- a/docs/_data/colors.json
+++ b/docs/_data/colors.json
@@ -39,364 +39,633 @@
     "brand-strong-inverted"
   ],
   "theme": [],
-  "base": [
-    {
+  "base": {
+    "lightMode": [
+      {
+        "color": "black",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "F9F9F9",
+            "copy": "primary",
+            "contrast": "AAA 19.94"
+          },
+          {
+            "stop": "200",
+            "hex": "E9E9E9",
+            "copy": "primary",
+            "contrast": "AAA 17.29"
+          },
+          {
+            "stop": "300",
+            "hex": "D2D2D2",
+            "copy": "primary",
+            "contrast": "AAA 13.88"
+          },
+          {
+            "stop": "400",
+            "hex": "AAAAAA",
+            "copy": "primary",
+            "contrast": "AAA 9.03"
+          },
+          {
+            "stop": "500",
+            "hex": "808080",
+            "copy": "primary",
+            "contrast": "AA 5.31"
+          },
+          {
+            "stop": "600",
+            "hex": "555555",
+            "copy": "primary-inverted",
+            "contrast": "AAA 7.45"
+          },
+          {
+            "stop": "700",
+            "hex": "3A3A3A",
+            "copy": "primary-inverted",
+            "contrast": "AAA 11.37"
+          },
+          {
+            "stop": "800",
+            "hex": "222222",
+            "copy": "primary-inverted",
+            "contrast": "AAA 15.9"
+          },
+          {
+            "stop": "900",
+            "hex": "000000",
+            "copy": "primary-inverted",
+            "contrast": "AAA 21"
+          }
+        ]
+      },
+      {
+        "color": "purple",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "F5F0FF",
+            "copy": "primary",
+            "contrast": "AAA 18.79"
+          },
+          {
+            "stop": "200",
+            "hex": "DAC7FF",
+            "copy": "primary",
+            "contrast": "AAA 13.59"
+          },
+          {
+            "stop": "300",
+            "hex": "AB7EFF",
+            "copy": "primary",
+            "contrast": "AAA 7.15"
+          },
+          {
+            "stop": "400",
+            "hex": "7C52FF",
+            "copy": "primary-inverted",
+            "contrast": "AA 4.65",
+            "invertedContrast": "AA 4.5"
+          },
+          {
+            "stop": "500",
+            "hex": "3A1D95",
+            "copy": "primary-inverted",
+            "contrast": "AAA 11.73"
+          },
+          {
+            "stop": "600",
+            "hex": "10022C",
+            "copy": "primary-inverted",
+            "contrast": "AAA 19.67"
+          }
+        ]
+      },
+      {
+        "color": "magenta",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "FFE0F2",
+            "copy": "primary",
+            "contrast": "AAA 17.9"
+          },
+          {
+            "stop": "200",
+            "hex": "F985C7",
+            "copy": "primary",
+            "contrast": "AAA 9.2"
+          },
+          {
+            "stop": "300",
+            "hex": "F9008E",
+            "copy": "primary",
+            "contrast": "AA 5.41"
+          },
+          {
+            "stop": "400",
+            "hex": "8C0E56",
+            "copy": "primary-inverted",
+            "contrast": "AAA 9.08"
+          },
+          {
+            "stop": "500",
+            "hex": "541A3B",
+            "copy": "primary-inverted",
+            "contrast": "AAA 13.22"
+          }
+        ]
+      },
+      {
+        "color": "gold",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "FFF4CC",
+            "copy": "primary",
+            "contrast": "AAA 19.06"
+          },
+          {
+            "stop": "200",
+            "hex": "FFDB80",
+            "copy": "primary",
+            "contrast": "AAA 15.69"
+          },
+          {
+            "stop": "300",
+            "hex": "F6AB3C",
+            "copy": "primary",
+            "contrast": "AAA 10.8"
+          },
+          {
+            "stop": "400",
+            "hex": "D28F2B",
+            "copy": "primary",
+            "contrast": "AAA 7.7"
+          },
+          {
+            "stop": "500",
+            "hex": "815008",
+            "copy": "primary-inverted",
+            "contrast": "AA 6.8"
+          }
+        ]
+      },
+      {
+        "color": "red",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "FFE5E6",
+            "copy": "primary",
+            "contrast": "AAA 17.6"
+          },
+          {
+            "stop": "200",
+            "hex": "FF8585",
+            "copy": "primary",
+            "contrast": "AAA 8.94"
+          },
+          {
+            "stop": "300",
+            "hex": "EC0E0E",
+            "copy": "primary-inverted",
+            "contrast": "AA 4.53"
+          },
+          {
+            "stop": "400",
+            "hex": "B70B0B",
+            "copy": "primary-inverted",
+            "contrast": "AA 6.84"
+          },
+          {
+            "stop": "500",
+            "hex": "FB0505",
+            "copy": "primary-inverted",
+            "contrast": "AAA 14.29"
+          }
+        ]
+      },
+      {
+        "color": "green",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "EDF9EB",
+            "copy": "primary",
+            "contrast": "AAA 19.35"
+          },
+          {
+            "stop": "200",
+            "hex": "B0FFA3",
+            "copy": "primary",
+            "contrast": "AAA 17.67"
+          },
+          {
+            "stop": "300",
+            "hex": "45F777",
+            "copy": "primary",
+            "contrast": "AAA 14.82"
+          },
+          {
+            "stop": "400",
+            "hex": "1AA340",
+            "copy": "primary",
+            "contrast": "AA 6.35"
+          },
+          {
+            "stop": "500",
+            "hex": "124620",
+            "copy": "primary-inverted",
+            "contrast": "AAA 10.92"
+          }
+        ]
+      },
+      {
+        "color": "blue",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "EAF2FA",
+            "copy": "primary",
+            "contrast": "AAA 18.57"
+          },
+          {
+            "stop": "200",
+            "hex": "99C8FF",
+            "copy": "primary",
+            "contrast": "AAA 12.06"
+          },
+          {
+            "stop": "300",
+            "hex": "51A0FE",
+            "copy": "primary",
+            "contrast": "AAA 7.8"
+          },
+          {
+            "stop": "400",
+            "hex": "1768C6",
+            "copy": "primary-inverted",
+            "contrast": "AA 5.48"
+          },
+          {
+            "stop": "500",
+            "hex": "01326D",
+            "copy": "primary-inverted",
+            "contrast": "AAA 12.51"
+          }
+        ]
+      },
+      {
+        "color": "tan",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "F2F0EE",
+            "copy": "primary",
+            "contrast": "AAA 18.47"
+          },
+          {
+            "stop": "200",
+            "hex": "CEC8C4",
+            "copy": "primary",
+            "contrast": "AAA 12.68"
+          },
+          {
+            "stop": "300",
+            "hex": "87807B",
+            "copy": "primary",
+            "contrast": "AA 5.4"
+          },
+          {
+            "stop": "400",
+            "hex": "3F3D3C",
+            "copy": "primary-inverted",
+            "contrast": "AAA 10.8"
+          },
+          {
+            "stop": "500",
+            "hex": "121212",
+            "copy": "primary-inverted",
+            "contrast": "AAA 18.73"
+          }
+        ]
+      }
+    ],
+    "darkMode": [
+      {
       "color": "black",
       "stops": [
         {
           "stop": "100",
-          "hex": "F9F9F9",
+          "hex": "000000",
           "copy": "primary",
-          "contrast": "AAA 19.94",
-          "primary": "no"
+          "contrast": "AAA 19.94"
         },
         {
           "stop": "200",
-          "hex": "E9E9E9",
+          "hex": "222222",
           "copy": "primary",
-          "contrast": "AAA 17.29",
-          "primary": "no"
+          "contrast": "AAA 15.11"
         },
         {
           "stop": "300",
-          "hex": "D2D2D2",
+          "hex": "3A3A3A",
           "copy": "primary",
-          "contrast": "AAA 13.88",
-          "primary": "no"
+          "contrast": "AAA 10.8"
         },
         {
           "stop": "400",
-          "hex": "AAAAAA",
+          "hex": "555555",
           "copy": "primary",
-          "contrast": "AAA 9.03",
-          "primary": "no"
+          "contrast": "AAA 7.08"
         },
         {
           "stop": "500",
           "hex": "808080",
-          "copy": "primary",
-          "contrast": "AA 5.31",
-          "primary": "no"
+          "copy": "primary-inverted",
+          "contrast": "AA 5.31"
         },
         {
           "stop": "600",
-          "hex": "555555",
+          "hex": "AAAAAA",
           "copy": "primary-inverted",
-          "contrast": "AAA 7.45",
-          "primary": "no"
+          "contrast": "AAA 9.03"
         },
         {
           "stop": "700",
-          "hex": "3A3A3A",
+          "hex": "D2D2D2",
           "copy": "primary-inverted",
-          "contrast": "AAA 11.37",
-          "primary": "no"
+          "contrast": "AAA 13.88"
         },
         {
           "stop": "800",
-          "hex": "222222",
+          "hex": "E9E9E9",
           "copy": "primary-inverted",
-          "contrast": "AAA 15.9",
-          "primary": "no"
+          "contrast": "AAA 17.29"
         },
         {
           "stop": "900",
-          "hex": "000000",
+          "hex": "F9F9F9",
           "copy": "primary-inverted",
-          "contrast": "AAA 21",
-          "primary": "yes"
+          "contrast": "AAA 19.94"
         }
       ]
     },
-    {
-      "color": "purple",
-      "stops": [
-        {
-          "stop": "100",
-          "hex": "F5F0FF",
-          "copy": "primary",
-          "contrast": "AAA 18.79",
-          "primary": "no"
-        },
-        {
-          "stop": "200",
-          "hex": "DAC7FF",
-          "copy": "primary",
-          "contrast": "AAA 13.59",
-          "primary": "no"
-        },
-        {
-          "stop": "300",
-          "hex": "AB7EFF",
-          "copy": "primary",
-          "contrast": "AAA 7.15",
-          "primary": "no"
-        },
-        {
-          "stop": "400",
-          "hex": "7C52FF",
-          "copy": "primary-inverted",
-          "contrast": "AA 4.65",
-          "darkContrast": "AA 4.5",
-          "primary": "yes"
-        },
-        {
-          "stop": "500",
-          "hex": "3A1D95",
-          "copy": "primary-inverted",
-          "contrast": "AAA 11.73",
-          "primary": "no"
-        },
-        {
-          "stop": "600",
-          "hex": "10022C",
-          "copy": "primary-inverted",
-          "contrast": "AAA 19.67",
-          "primary": "no"
-        }
-      ]
-    },
-    {
-      "color": "magenta",
-      "stops": [
-        {
-          "stop": "100",
-          "hex": "FFE0F2",
-          "copy": "primary",
-          "contrast": "AAA 17.9",
-          "primary": "no"
-        },
-        {
-          "stop": "200",
-          "hex": "F985C7",
-          "copy": "primary",
-          "contrast": "AA 9.2",
-          "primary": "no"
-        },
-        {
-          "stop": "300",
-          "hex": "F9008E",
-          "copy": "primary",
-          "contrast": "AA 5.41",
-          "primary": "no"
-        },
-        {
-          "stop": "400",
-          "hex": "8C0E56",
-          "copy": "primary-inverted",
-          "contrast": "AAA 9.08",
-          "primary": "yes"
-        },
-        {
-          "stop": "500",
-          "hex": "541A3B",
-          "copy": "primary-inverted",
-          "contrast": "AAA 13.22",
-          "primary": "no"
-        }
-      ]
-    },
-    {
-      "color": "gold",
-      "stops": [
-        {
-          "stop": "100",
-          "hex": "FFF4CC",
-          "copy": "primary",
-          "contrast": "AAA 17.1",
-          "primary": "no"
-        },
-        {
-          "stop": "200",
-          "hex": "FFDB80",
-          "copy": "primary",
-          "contrast": "AAA 14.74",
-          "primary": "no"
-        },
-        {
-          "stop": "300",
-          "hex": "F6AB3C",
-          "copy": "primary",
-          "contrast": "AAA 10.8",
-          "primary": "yes"
-        },
-        {
-          "stop": "400",
-          "hex": "D28F2B",
-          "copy": "primary",
-          "contrast": "AAA 7.7",
-          "primary": "no"
-        },
-        {
-          "stop": "500",
-          "hex": "815008",
-          "copy": "primary-inverted",
-          "contrast": "AA 6.8",
-          "primary": "no"
-        }
-      ]
-    },
-    {
-      "color": "red",
-      "stops": [
-        {
-          "stop": "100",
-          "hex": "FFE5E6",
-          "copy": "primary",
-          "contrast": "AAA 17.6",
-          "primary": "no"
-        },
-        {
-          "stop": "200",
-          "hex": "FF8585",
-          "copy": "primary",
-          "contrast": "AAA 8.94",
-          "primary": "no"
-        },
-        {
-          "stop": "300",
-          "hex": "EC0E0E",
-          "copy": "primary-inverted",
-          "contrast": "AA 4.53",
-          "primary": "no"
-        },
-        {
-          "stop": "400",
-          "hex": "B70B0B",
-          "copy": "primary-inverted",
-          "contrast": "AA 6.84",
-          "primary": "yes"
-        },
-        {
-          "stop": "500",
-          "hex": "FB0505",
-          "copy": "primary-inverted",
-          "contrast": "AAA 14.29",
-          "primary": "no"
-        }
-      ]
-    },
-    {
-      "color": "green",
-      "stops": [
-        {
-          "stop": "100",
-          "hex": "EDF9EB",
-          "copy": "primary",
-          "contrast": "AAA 18.35",
-          "primary": "no"
-        },
-        {
-          "stop": "200",
-          "hex": "B0FFA3",
-          "copy": "primary",
-          "contrast": "AAA 17.67",
-          "primary": "no"
-        },
-        {
-          "stop": "300",
-          "hex": "45F777",
-          "copy": "primary",
-          "contrast": "AAA 14.82",
-          "primary": "no"
-        },
-        {
-          "stop": "400",
-          "hex": "1AA340",
-          "copy": "primary",
-          "contrast": "AA 6.35",
-          "primary": "yes"
-        },
-        {
-          "stop": "500",
-          "hex": "124620",
-          "copy": "primary-inverted",
-          "contrast": "AAA 10.92",
-          "primary": "no"
-        }
-      ]
-    },
-    {
-      "color": "blue",
-      "stops": [
-        {
-          "stop": "100",
-          "hex": "EAF2FA",
-          "copy": "primary",
-          "contrast": "AAA 18.57",
-          "primary": "no"
-        },
-        {
-          "stop": "200",
-          "hex": "99C8FF",
-          "copy": "primary",
-          "contrast": "AAA 12.06",
-          "primary": "no"
-        },
-        {
-          "stop": "300",
-          "hex": "51A0FE",
-          "copy": "primary",
-          "contrast": "AAA 7.8",
-          "primary": "no"
-        },
-        {
-          "stop": "400",
-          "hex": "1768C6",
-          "copy": "primary-inverted",
-          "contrast": "AA 5.48",
-          "primary": "yes"
-        },
-        {
-          "stop": "500",
-          "hex": "01326D",
-          "copy": "primary-inverted",
-          "contrast": "AAA 12.51",
-          "primary": "no"
-        }
-      ]
-    },
-    {
-      "color": "tan",
-      "stops": [
-        {
-          "stop": "100",
-          "hex": "F2F0EE",
-          "copy": "primary",
-          "contrast": "AAA 18.47",
-          "primary": "no"
-        },
-        {
-          "stop": "200",
-          "hex": "CEC8C4",
-          "copy": "primary",
-          "contrast": "AAA 12.68",
-          "primary": "no"
-        },
-        {
-          "stop": "300",
-          "hex": "87807B",
-          "copy": "primary",
-          "contrast": "AA 5.4",
-          "primary": "no"
-        },
-        {
-          "stop": "400",
-          "hex": "3F3D3C",
-          "copy": "primary-inverted",
-          "contrast": "AAA 10.8",
-          "primary": "yes"
-        },
-        {
-          "stop": "500",
-          "hex": "121212",
-          "copy": "primary-inverted",
-          "contrast": "AAA 18.73",
-          "primary": "no"
-        }
-      ]
-    }
-  ],
+      {
+        "color": "purple",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "10022C",
+            "copy": "primary",
+            "contrast": "AAA 18.69"
+          },
+          {
+            "stop": "200",
+            "hex": "3A1D95",
+            "copy": "primary",
+            "contrast": "AAA 11.14"
+          },
+          {
+            "stop": "300",
+            "hex": "7C52FF",
+            "copy": "primary-inverted",
+            "contrast": "AA 4.5"
+          },
+          {
+            "stop": "400",
+            "hex": "AB7EFF",
+            "copy": "primary-inverted",
+            "contrast": "AAA 7.15"
+          },
+          {
+            "stop": "500",
+            "hex": "DAC7FF",
+            "copy": "primary-inverted",
+            "contrast": "AAA 13.59"
+          },
+          {
+            "stop": "600",
+            "hex": "F5F0FF",
+            "copy": "primary-inverted",
+            "contrast": "AAA 18.79"
+          }
+        ]
+      },
+      {
+        "color": "magenta",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "541A3B",
+            "copy": "primary",
+            "contrast": "AAA 12.56"
+          },
+          {
+            "stop": "200",
+            "hex": "8C0E56",
+            "copy": "primary",
+            "contrast": "AAA 8.62"
+          },
+          {
+            "stop": "300",
+            "hex": "F9008E",
+            "copy": "primary-inverted",
+            "contrast": "AA 5.41"
+          },
+          {
+            "stop": "400",
+            "hex": "F985C7",
+            "copy": "primary-inverted",
+            "contrast": "AAA 9.2"
+          },
+          {
+            "stop": "500",
+            "hex": "FFE0F2",
+            "copy": "primary-inverted",
+            "contrast": "AAA 17.19"
+          }
+        ]
+      },
+      {
+        "color": "gold",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "815008",
+            "copy": "primary",
+            "contrast": "AA 6.46"
+          },
+          {
+            "stop": "200",
+            "hex": "D28F2B",
+            "copy": "primary-inverted",
+            "contrast": "AAA 7.7"
+          },
+          {
+            "stop": "300",
+            "hex": "F6AB3C",
+            "copy": "primary-inverted",
+            "contrast": "AAA 10.8"
+          },
+          {
+            "stop": "400",
+            "hex": "FFDB80",
+            "copy": "primary-inverted",
+            "contrast": "AAA 15.69"
+          },
+          {
+            "stop": "500",
+            "hex": "FFF4CC",
+            "copy": "primary-inverted",
+            "contrast": "AAA 19.06"
+          }
+        ]
+      },
+      {
+        "color": "red",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "5B0505",
+            "copy": "primary",
+            "contrast": "AAA 13.58"
+          },
+          {
+            "stop": "200",
+            "hex": "B70B0B",
+            "copy": "primary",
+            "contrast": "AA 6.5"
+          },
+          {
+            "stop": "300",
+            "hex": "EC0E0E",
+            "copy": "primary-inverted",
+            "contrast": "AA 4.63"
+          },
+          {
+            "stop": "400",
+            "hex": "FF8585",
+            "copy": "primary-inverted",
+            "contrast": "AAA 8.94"
+          },
+          {
+            "stop": "500",
+            "hex": "FFE5E6",
+            "copy": "primary-inverted",
+            "contrast": "AAA 17.6"
+          }
+        ]
+      },
+      {
+        "color": "green",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "124620",
+            "copy": "primary",
+            "contrast": "AAA 10.37"
+          },
+          {
+            "stop": "200",
+            "hex": "1AA340",
+            "copy": "primary-inverted",
+            "contrast": "AA 6.35"
+          },
+          {
+            "stop": "300",
+            "hex": "45F777",
+            "copy": "primary-inverted",
+            "contrast": "AAA 14.82"
+          },
+          {
+            "stop": "400",
+            "hex": "B0FFA3",
+            "copy": "primary-inverted",
+            "contrast": "AAA 17.67"
+          },
+          {
+            "stop": "500",
+            "hex": "EDF9EB",
+            "copy": "primary-inverted",
+            "contrast": "AAA 19.35"
+          }
+        ]
+      },
+      {
+        "color": "blue",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "01326D",
+            "copy": "primary",
+            "contrast": "AAA 11.88"
+          },
+          {
+            "stop": "200",
+            "hex": "1768C6",
+            "copy": "primary",
+            "contrast": "AA 5.2"
+          },
+          {
+            "stop": "300",
+            "hex": "51A0FE",
+            "copy": "primary-inverted",
+            "contrast": "AAA 7.8"
+          },
+          {
+            "stop": "400",
+            "hex": "99C8FF",
+            "copy": "primary-inverted",
+            "contrast": "AAA 12.06"
+          },
+          {
+            "stop": "500",
+            "hex": "EAF2FA",
+            "copy": "primary-inverted",
+            "contrast": "AAA 18.57"
+          }
+        ]
+      },
+      {
+        "color": "tan",
+        "stops": [
+          {
+            "stop": "100",
+            "hex": "121212",
+            "copy": "primary",
+            "contrast": "AAA 17.79"
+          },
+          {
+            "stop": "200",
+            "hex": "3F3D3C",
+            "copy": "primary",
+            "contrast": "AAA 10.25"
+          },
+          {
+            "stop": "300",
+            "hex": "87807B",
+            "copy": "primary-inverted",
+            "contrast": "AA 5.4"
+          },
+          {
+            "stop": "400",
+            "hex": "CEC8C4",
+            "copy": "primary-inverted",
+            "contrast": "AAA 12.68"
+          },
+          {
+            "stop": "500",
+            "hex": "F2F0EE",
+            "copy": "primary-inverted",
+            "contrast": "AAA 18.47"
+          }
+        ]
+      }
+    ]
+  },
   "special": [
     "transparent",
     "unset",

--- a/docs/design/colors/index.md
+++ b/docs/design/colors/index.md
@@ -1098,7 +1098,13 @@ Base colors are the literal value of all available colors. Use these only if all
 
 Each of the colors listed above references these. For example, `var(--dt-color-foreground-primary)` is an alias to `var(--dt-color-black-900)`, and `var(--dt-color-foreground-critical)` is an alias to `var(--dt-color-red-300)`.
 
-<colors-catalog />
+### Light Theme
+
+<colors-catalog theme-mode="lightMode" />
+
+### Dark Theme
+
+<colors-catalog theme-mode="darkMode" />
 
 <script setup>
     import { borders } from '@data/colors.json';

--- a/lib/build/js/dialtone_migration_helper/configs/colors.mjs
+++ b/lib/build/js/dialtone_migration_helper/configs/colors.mjs
@@ -12,52 +12,56 @@ export default {
     // ------------------------------------------------------------ //
     // LESS variables
     {
-      from: /@(black|purple|orange|magenta|gold|green|red|blue|tan)(-[1-9]00)/gi,
+      from: /@(black|purple|orange|magenta|gold|green|red|blue|tan)(-[1-9]00)/g,
       to: '@dt-color-$1$2',
     },
     // Neutral LESS variables
     {
-      from: /@(white|black)/gi,
+      from: /@(white|black)/g,
       to: '@dt-color-neutral-$1',
     },
     // CSS variables
     {
-      from: /var\(--(black|purple|orange|magenta|gold|green|red|blue|tan)(-[1-9]00)(-(h|s|l|hsl))?\)/gi,
+      from: /var\(--(black|purple|orange|magenta|gold|green|red|blue|tan)(-[1-9]00)(-(h|s|l|hsl))?\)/g,
       to: 'var(--dt-color-$1$2$3)',
     },
     // Neutral CSS variables
     {
-      from: /var\(--(white|black)(-(h|s|l|hsl))?\)/gi,
+      from: /var\(--(white|black)(-(h|s|l|hsl))?\)/g,
       to: 'var(--dt-color-neutral-$1$2)',
     },
     // Background colors
     {
       // eslint-disable-next-line max-len
-      from: /var\(--bgc-(primary|secondary|moderate|bold|strong|contrast|critical|success|warning|info)(-(subtle|opaque|subtle-opaque|strong))?\)/gi,
+      from: /var\(--bgc-(primary|secondary|moderate|bold|strong|contrast|critical|success|warning|info)(-(subtle|opaque|subtle-opaque|strong))?\)/g,
       to: 'var(--dt-color-surface-$1$2)',
     },
     // Special Background color cases
     {
       // eslint-disable-next-line max-len
-      from: /var\(--bgc-(error|danger)(-(subtle|opaque|subtle-opaque|strong))?\)/gi,
+      from: /var\(--bgc-(error|danger)(-(subtle|opaque|subtle-opaque|strong))?\)/g,
       to: 'var(--dt-color-surface-critical$2)',
     },
     // Border colors
     {
       // eslint-disable-next-line max-len
-      from: /var\(--bc-(default|subtle|moderate|bold|focus|critical|success|warning|brand|ai|accent)(-(inverted|subtle|strong|subtle-inverted|strong-inverted))?\)/gi,
+      from: /var\(--bc-(default|subtle|moderate|bold|focus|critical|success|warning|brand|ai|accent)(-(inverted|subtle|strong|subtle-inverted|strong-inverted))?\)/g,
       to: 'var(--dt-color-border-$1$2)',
     },
     // Font colors
     {
       // eslint-disable-next-line max-len
-      from: /var\(--fc-(primary|secondary|tertiary|muted|placeholder|disabled|critical|success|warning)(-(strong|inverted|strong-inverted))?\)/gi,
+      from: /var\(--fc-(primary|secondary|tertiary|muted|placeholder|disabled|critical|success|warning)(-(strong|inverted|strong-inverted))?\)/g,
       to: 'var(--dt-color-foreground-$1$2)',
     },
     // Special Font color cases
     {
-      from: /var\(--fc-(error|danger)(-(strong|inverted|strong-inverted))?\)/gi,
+      from: /var\(--fc-(error|danger)(-(strong|inverted|strong-inverted))?\)/g,
       to: 'var(--dt-color-foreground-critical$2)',
+    },
+    {
+      from: /d-(fc|bc)-white/g,
+      to: 'd-$1-neutral-white',
     },
   ],
 };

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -48,11 +48,11 @@
 .d-bgc-secondary { background-color: var(--dt-color-surface-secondary) !important; }
 .d-bgc-secondary-opaque { background-color: var(--dt-color-surface-secondary-opaque) !important; }
 .d-bgc-moderate { background-color: var(--dt-color-surface-moderate) !important; }
-.d-bgc-moderate-opaque { background-color: var(--dt-color-surface-moderate-opaque)!important; }
-.d-bgc-strong-opaque { background-color: var(--dt-color-surface-strong-opaque)!important; }
-.d-bgc-contrast-opaque { background-color: var(--dt-color-surface-contrast-opaque)!important; }
+.d-bgc-moderate-opaque { background-color: var(--dt-color-surface-moderate-opaque) !important; }
+.d-bgc-strong-opaque { background-color: var(--dt-color-surface-strong-opaque) !important; }
+.d-bgc-contrast-opaque { background-color: var(--dt-color-surface-contrast-opaque) !important; }
 .d-bgc-bold { background-color: var(--dt-color-surface-bold) !important; }
-.d-bgc-bold-opaque { background-color: var(--dt-color-surface-bold-opaque)!important; }
+.d-bgc-bold-opaque { background-color: var(--dt-color-surface-bold-opaque) !important; }
 .d-bgc-strong { background-color: var(--dt-color-surface-strong) !important; }
 .d-bgc-contrast { background-color: var(--dt-color-surface-contrast) !important; }
 .d-bgc-success { background-color: var(--dt-color-surface-success) !important; }


### PR DESCRIPTION
## Description

- Separated light/dark theme base palette to showcase the correct values for colors on different theme modes.
- Fixed contrast ratio values

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/l0HlQXcnyJEYBVsxa/giphy.gif)
