### PR TITLE
feat: migration script --include option

### DIFF
--- a/lib/build/js/dialtone_migration_helper/helpers.mjs
+++ b/lib/build/js/dialtone_migration_helper/helpers.mjs
@@ -75,12 +75,10 @@ export const findMatchedFiles = async (fileList, config) => {
         return f.matches > 0;
       });
 
-    const matchedFiles = filtered.reduce((prev, current) => {
+    return filtered.reduce((prev, current) => {
       const fn = path.relative(config.globbyConfig.cwd, current.file);
       return [...prev, fn];
     }, []);
-
-    return matchedFiles;
   });
 };
 

--- a/lib/build/js/dialtone_migration_helper/index.mjs
+++ b/lib/build/js/dialtone_migration_helper/index.mjs
@@ -24,13 +24,9 @@ import yargs from 'yargs';
   const argv = yargs(hideBin(process.argv))
     .scriptName('dialtone-migration-helper')
     .usage(
-      '$0 --file migration-config-file.js --cwd "../root/directory" --include "file1.ext" "**/*.ext2" --ignore "**/ignored/**", "**/another_ignored/**"',
+      '$0 --cwd "../root/directory" --include "file1.ext" "**/*.ext2" --ignore "**/ignored/**", "**/another_ignored/**"',
     )
     .options({
-      config: {
-        type: 'string',
-        description: 'Migration configuration module.',
-      },
       cwd: {
         type: 'string',
         description: 'Root directory for scan. Defaults to CWD.',
@@ -61,11 +57,10 @@ import yargs from 'yargs';
   );
 
   // load configuration from arg or list
-  const [configData, configFile] = !argv.config
-    ? await inquireForFile(CONFIG_FOLDER, configList).catch((err) =>
-      error('inquireForFile: ' + err),
-    )
-    : await readConfigFile(argv.config).catch((err) => error('readConfigFile: ' + err));
+  const [configData, configFile] = await inquireForFile(CONFIG_FOLDER, configList)
+      .catch((err) =>
+        error('inquireForFile: ' + err),
+      );
 
   // set up some globby defaults
   configData.globbyConfig = configData.globbyConfig || {};

--- a/lib/build/js/dialtone_migration_helper/index.mjs
+++ b/lib/build/js/dialtone_migration_helper/index.mjs
@@ -24,7 +24,7 @@ import yargs from 'yargs';
   const argv = yargs(hideBin(process.argv))
     .scriptName('dialtone-migration-helper')
     .usage(
-      '$0 --file migration-config-file.js --cwd "../root/directory --ignore "**/ignored/**", "**/another_ignored/**"',
+      '$0 --file migration-config-file.js --cwd "../root/directory" --include "file1.ext" "**/*.ext2" --ignore "**/ignored/**", "**/another_ignored/**"',
     )
     .options({
       config: {
@@ -35,6 +35,10 @@ import yargs from 'yargs';
         type: 'string',
         description: 'Root directory for scan. Defaults to CWD.',
         default: process.cwd(),
+      },
+      include: {
+        type: 'array',
+        description: 'Glob patters to include during search, if omitted, will include all the files on the CWD.',
       },
       ignore: {
         type: 'array',
@@ -74,6 +78,10 @@ import yargs from 'yargs';
   // take CWD if specified from command line
   const cwd = !argv.cwd ? process.cwd() : normalize(argv.cwd);
   configData.globbyConfig.cwd = configData.globbyConfig.cwd || cwd;
+  // push include list to configuration array
+  if (argv.include) {
+    configData.patterns = argv.include;
+  }
   // push ignore list to configuration array
   if (argv.ignore) {
     configData.globbyConfig.ignore = argv.ignore;
@@ -88,7 +96,8 @@ import yargs from 'yargs';
     console.log(
       '\n' +
         chalk.cyan('??') +
-        ' No matches found! Check your patterns and cwd settings if you think this is an error.',
+        ' No matches found! Check your patterns and cwd settings if you think this is an error ' +
+        `patterns: [${configData.patterns}] | cwd: [${configData.globbyConfig.cwd}] `,
     );
     process.exit(0);
   }


### PR DESCRIPTION
## Description

Added the --include option to the migration script, this gives you the ability to run the script over just one file or multiple selected files.

If not set, the script will run over the `patterns` object on the migration configs by default.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/3o7abKhOpu0NwenH3O/giphy.gif)
