### PR TITLE
fix: fonts migration

### DIFF
--- a/lib/build/js/dialtone_migration_helper/configs/fonts.mjs
+++ b/lib/build/js/dialtone_migration_helper/configs/fonts.mjs
@@ -23,12 +23,12 @@ export default {
     // Size variables
     {
       from: /@fs(-[0-9]+)(-(mobile|tc8|tv))?|var\(--fs(-[0-9]+)(-(mobile|tc8|tv))?\)/g,
-      to: 'var(--dt-font-size$1$2)',
+      to: 'var(--dt-font-size$1$2$4$5)',
     },
     // Weight variables
     {
       from: /@fw-(normal|medium|bold)|var\(--fw-(normal|medium|bold)\)/g,
-      to: 'var(--dt-font-weight-$1)',
+      to: 'var(--dt-font-weight-$1$2)',
     },
     // Special weight case
     {
@@ -38,7 +38,7 @@ export default {
       // Line heights
     {
       from: /@lh(-[0-9]+)|var\(--lh(-[0-9]+)\)/g,
-      to: 'var(--dt-font-line-height$1)',
+      to: 'var(--dt-font-line-height$1$2)',
     },
     // Font family
     {


### PR DESCRIPTION
## Description

After adding LESS to CSS variables migration, RegExp indices changed, adding the new indices to the replacement variables, should fix the issue.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/pGP4c8488ioAp9phUa/giphy.gif)
