### PR TITLE
fix: bgg-to-opacity

### DIFF
--- a/postcss/dialtone-generators.js
+++ b/postcss/dialtone-generators.js
@@ -150,7 +150,7 @@ function colorUtilities (Rule, clonedSource, declaration) {
       selector: appendHoverFocusSelectors(`.d-bgg-to-${color}`),
       nodes: [
         declaration.clone({ prop: '--bgg-to-opacity', value: '100%' }),
-        declaration.clone({ prop: '--bgg-to', value: `${hslaColor} / var(--bgg-from-opacity)) !important` }),
+        declaration.clone({ prop: '--bgg-to', value: `${hslaColor} / var(--bgg-to-opacity)) !important` }),
       ],
     }));
   });


### PR DESCRIPTION
## Description

`d-bgg-to-(color)` was incorrectly setting `--bgg-from-opacity`

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/iibH5ymW6LFvSIVyUc/giphy.gif)
