### PR TITLE
feat(breadcrumbs): css variables remapping

### DIFF
--- a/docs/.vuepress/theme/components/SidebarItem.vue
+++ b/docs/.vuepress/theme/components/SidebarItem.vue
@@ -11,7 +11,7 @@
       >
         <router-link
           v-if="!subItem.planned"
-          v-slot="{ href, navigate, isActive, isExactActive }"
+          v-slot="{ href, navigate, isExactActive }"
           :to="subItem.link"
           custom
         >
@@ -20,9 +20,7 @@
             :class="[
               itemClass,
               {
-                'd-btn--active d-bgc-black-200 d-fw-medium': isActive,
-                'router-link-exact-active': isExactActive,
-                'd-fc-primary': !isActive || !isExactActive,
+                'd-btn--active d-fw-medium': isExactActive,
               },
             ]"
             @click="navigate"
@@ -50,7 +48,7 @@
 <script setup>
 import { computed } from 'vue';
 
-const itemClass = 'd-btn d-btn--muted d-bar-pill d-w100p d-jc-flex-start d-fw-normal';
+const itemClass = 'd-btn d-btn--muted d-bar-pill d-w100p d-jc-flex-start d-fw-normal d-fc-primary';
 const props = defineProps({
   item: {
     type: Object,

--- a/docs/components/breadcrumbs.md
+++ b/docs/components/breadcrumbs.md
@@ -8,7 +8,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-breadcrumbs--defau
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8918%3A21306&viewport=-61%2C443%2C1.12&t=xHutRjwo1o5zMTgT-11
 ---
 <code-well-header>
-  <nav class="d-breadcrumbs" aria-label="breadcrumb">
+  <nav class="d-breadcrumbs d-bgc-primary d-py16 d-px12" aria-label="breadcrumb">
     <ol>
       <li class="d-breadcrumbs__item">
         <a href="#" class="d-link d-link--muted">Root</a>
@@ -48,7 +48,7 @@ Breadcrumbs are always treated as secondary and should not entirely replace the 
 ## Variants and examples
 
 <code-well-header>
-    <nav class="d-breadcrumbs" aria-label="breadcrumb">
+    <nav class="d-breadcrumbs d-bgc-primary d-py16 d-px12" aria-label="breadcrumb">
         <ol>
             <li class="d-breadcrumbs__item">
                 <a href="#" class="d-link d-link--muted">Root</a>
@@ -67,7 +67,7 @@ Breadcrumbs are always treated as secondary and should not entirely replace the 
             </li>
         </ol>
     </nav>
-    <nav class="d-breadcrumbs d-breadcrumbs--inverted d-bgc-strong d-border-radius--md d-py16 d-px12 d-mxn12" aria-label="breadcrumb">
+    <nav class="d-breadcrumbs d-breadcrumbs--inverted d-bgc-contrast d-py16 d-px12 d-mt0" aria-label="inverted breadcrumb">
         <ol>
             <li class="d-breadcrumbs__item">
                 <a href="#" class="d-link d-link--inverted">Root</a>

--- a/lib/build/less/components/breadcrumbs.less
+++ b/lib/build/less/components/breadcrumbs.less
@@ -15,14 +15,14 @@
     --breadcrumbs-font-size: var(--dt-font-size-200);
     --breadcrumbs-line-height: var(--dt-font-line-height-300);
     --breadcrumbs-color-separator: var(--dt-color-black-500);
-    --breadcrumbs-color-text: var(--dt-color-foreground-secondary);
+    --breadcrumbs-color-text: var(--dt-color-link-muted);
 
     //  ============================================================================
     //  $  INVERTED STYLE
     //  ----------------------------------------------------------------------------
     &--inverted {
-        --breadcrumbs-color-separator: var(--dt-color-black-300);
-        --breadcrumbs-color-text: var(--dt-color-foreground-secondary-inverted);
+        --breadcrumbs-color-separator: var(--dt-color-black-400);
+        --breadcrumbs-color-text: var(--dt-color-link-muted-inverted);
     }
 
     //  ============================================================================


### PR DESCRIPTION
## Description

- Remapping of `breadcrumbs` component CSS variables to semantic tokens.
- Fixed the 'active' color of the sidebar item that wasn't working properly on dark mode.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/dzMu8oCKwBbpUFMBNs/giphy.gif)
