### PR TITLE
feat: add native css color-scheme to output

### DIFF
--- a/lib/build/less/dialtone.less
+++ b/lib/build/less/dialtone.less
@@ -59,11 +59,3 @@
 // Tokens
 @import (inline) '@dialpad/dialtone-tokens/dist/css/variables-light.css';
 @import (inline) '@dialpad/dialtone-tokens/dist/css/variables-dark.css';
-
-.dialtone-theme-light {
-  color-scheme: light;
-}
-
-.dialtone-theme-dark {
-  color-scheme: dark;
-}

--- a/lib/build/less/dialtone.less
+++ b/lib/build/less/dialtone.less
@@ -59,3 +59,11 @@
 // Tokens
 @import (inline) '@dialpad/dialtone-tokens/dist/css/variables-light.css';
 @import (inline) '@dialpad/dialtone-tokens/dist/css/variables-dark.css';
+
+.dialtone-theme-light {
+  color-scheme: light;
+}
+
+.dialtone-theme-dark {
+  color-scheme: dark;
+}

--- a/postcss/dialtone-generators.js
+++ b/postcss/dialtone-generators.js
@@ -697,6 +697,7 @@ function colorVariables (declaration) {
       declaration.clone({ prop: `${colorVar}-hsla`, value: `hsla(var(${colorVar}-h) var(${colorVar}-s) var(${colorVar}-l) / var(--alpha, 100%))` }),
     ]);
   });
+  lightCSSVariables.push({ prop: 'color-scheme', value: 'light' });
   dialtoneColors.dark.forEach(({ colorName, hexValue }) => {
     const color = tinycolor(hexValue);
     const { h: hue, s: saturation, l: lightness } = color.toHsl();
@@ -709,6 +710,7 @@ function colorVariables (declaration) {
       declaration.clone({ prop: `${colorVar}-hsla`, value: `hsla(var(${colorVar}-h) var(${colorVar}-s) var(${colorVar}-l) / var(--alpha, 100%))` }),
     ]);
   });
+  darkCSSVariables.push({ prop: 'color-scheme', value: 'dark' });
 }
 
 /**


### PR DESCRIPTION
## Description
Adds color-scheme: light / dark to the css output. This sets the styling of native controls such as scrollbars.

before:
![Screenshot 2023-06-19 at 3 16 49 PM](https://github.com/dialpad/dialtone/assets/64808812/0e43b771-85a6-49dc-ac94-86cd8caa5228)

after:
![Screenshot 2023-06-19 at 3 16 54 PM](https://github.com/dialpad/dialtone/assets/64808812/ba679977-d091-4e98-86b9-015f82c868f2)


## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/9DavVitIZ26jH0aK7s/giphy.gif)
