### PR TITLE
feat(modal, tabs): backdrop and border color

### DIFF
--- a/docs/.vuepress/baseComponents/CodeWellHeader.vue
+++ b/docs/.vuepress/baseComponents/CodeWellHeader.vue
@@ -34,7 +34,7 @@ export default {
       return [
         'd-fl-center d-fd-column d-p24 d-w100p d-of-auto d-stack8',
         this.bgclass,
-        { 'd-ba d-bc-subtle d-btr8 d-baw2': this.isSurfacePrimary },
+        { 'd-ba d-bc-subtle d-btr8 d-baw1': this.isSurfacePrimary },
         this.$attrs.class,
       ];
     },

--- a/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -134,8 +134,8 @@ a.router-link-active {
 //  ----------------------------------------------------------------------------
 .dialtone-header {
   // TODO: redo 😜
-  border: var(--dt-size-100) solid var(--dt-color-border-default);
-  background-color: var(--dt-color-surface-primary);
+  border-bottom: var(--dt-size-100) solid var(--dt-color-border-subtle);
+  background-color: var(--dt-color-surface-secondary);
 }
 
 .dialtone-sidebar {
@@ -418,7 +418,7 @@ a.header-anchor {
 //  ----------------------------------------------------------------------------
 
 .hero {
-  background-color: var(--dt-color-surface-secondary);
+  background-color: var(--dt-color-surface-primary);
   position: relative;
 
   &--inner-wrapper {
@@ -455,7 +455,7 @@ a.header-anchor {
     bottom: 0;
     background-color: var(--dt-color-surface-strong);
     opacity: .05;
-    mask: url(/assets/images/home-dp-logo.svg) 80% center no-repeat;
+    mask: url(/assets/images/home-dp-logo.svg) 80% bottom no-repeat;
   }
 
   @media (max-width: 640px) {
@@ -465,8 +465,8 @@ a.header-anchor {
 }
 
 .links {
-  padding-top: calc(var(--dt-space-300) * 24);
-  padding-bottom: calc(var(--dt-space-300) * 24);
+  padding-top: var(--dt-space-650);
+  padding-bottom: var(--dt-space-650);
 
   @media (max-width: 640px) {
     display: block !important;
@@ -545,7 +545,8 @@ a.header-anchor {
 
     &:not(.dialtone-wall__item--disabled):hover {
       text-decoration: none;
-      box-shadow: var(--bs-sm);
+      box-shadow: var(--dt-shadow-small);
+      border-color: var(--dt-color-border-moderate);
     }
 
     &:not(.dialtone-wall__item--disabled):active {

--- a/docs/.vuepress/theme/assets/less/dialtone-syntax.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-syntax.less
@@ -10,7 +10,7 @@ div[class*=language-] {
 	padding: var(--dt-space-400);
 	margin: var(--dt-space-500) 0;
 	border-radius: var(--dt-size-500);
-	background-color: var(--dt-color-surface-contrast);
+	background-color: var(--dt-color-surface-contrast-opaque);
 
 	pre {
 		padding: 1em !important;

--- a/docs/.vuepress/theme/components/DialtoneLogo.vue
+++ b/docs/.vuepress/theme/components/DialtoneLogo.vue
@@ -1,6 +1,6 @@
 <template>
   <router-link
-    class="d-btn d-py6 d-w216 d-jc-flex-start"
+    class="d-btn h:d-bgc-transparent d-py6 d-w216 d-jc-flex-start"
     title="Go back to the homepage"
     to="/"
   >

--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -785,11 +785,11 @@
       </div>
     </div>
   </section>
-  <section class="d-bgc-purple-500 d-py64 d-ta-center">
-    <div class="d-headline-large d-fw-medium d-fc-primary-inverted d-px48 d-flow16 d-d-flex d-jc-center d-ai-center">
+  <section class="d-bt d-bbw1 d-bc-subtle d-bgc-secondary d-py64 d-ta-center">
+    <div class="d-headline-large d-fw-medium d-fc-secondary d-px48 d-flow16 d-d-flex d-jc-center d-ai-center">
       <div>Don't see something? Want to contribute?</div>
       <a
-        class="d-btn d-btn--inverted d-btn--lg d-btn--primary"
+        class="d-btn d-btn--muted d-btn--outlined d-btn--lg"
         href="https://dialpad.atlassian.net/secure/CreateIssue.jspa?issuetype=10901&pid=12428"
         target="_blank"
         rel="noopener noreferrer"

--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -518,7 +518,7 @@
   <section class="links d-d-grid d-gg16 d-g-cols12 d-wmx1340 d-mx-auto">
     <div class="link d-body-base d-gc3 d-px32 d-ta-center">
       <router-link
-        class="d-fc-secondary h:d-fc-purple-400 d-d-block d-td-none d-bar8 d-pt4"
+        class="d-fc-primary h:d-fc-purple-400 d-d-block d-td-none d-bar8 d-pt4"
         to="/design/"
       >
         <svg
@@ -573,7 +573,7 @@
     </div>
     <div class="link d-body-base d-gc3 d-px32 d-ta-center">
       <router-link
-        class="d-fc-secondary h:d-fc-purple-400 d-d-block d-td-none d-bar8 d-pt4"
+        class="d-fc-primary h:d-fc-purple-400 d-d-block d-td-none d-bar8 d-pt4"
         to="/components/"
       >
         <svg
@@ -653,7 +653,7 @@
     </div>
     <div class="link d-body-base d-gc3 d-px32 d-ta-center">
       <router-link
-        class="d-fc-secondary h:d-fc-purple-400 d-d-block d-td-none d-bar8 d-pt4"
+        class="d-fc-primary h:d-fc-purple-400 d-d-block d-td-none d-bar8 d-pt4"
         to="/utilities/"
       >
         <svg
@@ -726,7 +726,7 @@
     </div>
     <div class="link d-body-base d-gc3 d-px32 d-ta-center">
       <router-link
-        class="d-fc-secondary h:d-fc-purple-400 d-d-block d-td-none d-bar8 d-pt4"
+        class="d-fc-primary h:d-fc-purple-400 d-d-block d-td-none d-bar8 d-pt4"
         to="/guides/"
       >
         <svg
@@ -785,7 +785,7 @@
       </div>
     </div>
   </section>
-  <section class="d-bt d-bbw1 d-bc-subtle d-bgc-secondary d-py64 d-ta-center">
+  <section class="d-bt d-bc-subtle d-bgc-secondary d-py64 d-ta-center">
     <div class="d-headline-large d-fw-medium d-fc-secondary d-px48 d-flow16 d-d-flex d-jc-center d-ai-center">
       <div>Don't see something? Want to contribute?</div>
       <a

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -8,7 +8,7 @@
       v-for="link in items"
       :key="link.text"
       :to="link.link"
-      class="d-btn d-btn--md d-bar-pill"
+      class="d-btn d-btn--muted d-btn--md d-bar-pill"
       :class="{ 'd-btn--active': isActiveLink(link.text) }"
     >
       {{ link.text }}

--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -25,7 +25,7 @@
 .d-modal {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
-    --modal-backdrop-color-background: hsla(var(--bgc-contrast-hsl) / 0.7);
+    --modal-backdrop-color-background: hsla(var(--dt-color-neutral-black-hsl) / 0.7); // TODO: token candidate
     --modal-dialog-padding: var(--dt-space-600);
     --modal-dialog-color-background: var(--dt-color-surface-primary);
     --modal-dialog-color-border: var(--dt-color-border-subtle);

--- a/lib/build/less/components/tabs.less
+++ b/lib/build/less/components/tabs.less
@@ -166,7 +166,7 @@
 
     &::after,
     &:hover::after {
-        --tab-color-background: var(--dt-color-border-brand);
+        --tab-color-background: var(--dt-action-color-foreground-base-default);
 
         .d-tablist--no-border & {
             background-color: var(--tab-color-background);


### PR DESCRIPTION
## Description
1. Modal backdrop for both light and dark (candidate Design Token).
1. Align selected Tab's border color to foreground color
1. Doc site style housekeeping.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

![FixedDeficientIlladopsis-size_restricted](https://github.com/dialpad/dialtone/assets/1165933/b1b15d43-4996-46f4-a4dd-be11cd226e88)


