### PR TITLE
fix: set tokens for body values in dialtone-globals.less

### DIFF
--- a/lib/build/less/dialtone-globals.less
+++ b/lib/build/less/dialtone-globals.less
@@ -22,16 +22,16 @@ html,
 body {
     margin: 0;
     /* stylelint-disable-next-line meowtec/no-px */
-    font-size: 10px; // [1]
+    font-size: 10px;
 }
 
 body {
-    color: var(--base-color-text);
-    font-size: var(--base--font-size); // [2]
-    font-family: var(--base--font-family);
-    line-height: var(--base--line-height);
-    background-color: var(--base-color-background);
-    -webkit-text-size-adjust: 100%; // [3]
+    color: var(--dt-color-foreground-primary);
+    font-size: var(--dt-typography-body-base-font-size);
+    font-family: var(--dt-typography-body-base-font-family);
+    line-height: var(--dt-typography-body-base-line-height);
+    background-color: var(--dt-color-surface-primary);
+    -webkit-text-size-adjust: 100%;
 }
 
 
@@ -47,14 +47,6 @@ body {
     &.d-svg--system {
         fill: currentColor;
     }
-}
-
-.d-svg-primary--stroke {
-    stroke: var(--primary-color);
-}
-
-.d-svg-primary--fill {
-    fill: var(--primary-color);
 }
 
 //  ============================================================================


### PR DESCRIPTION
## Description
Set body properties in dialtone-globals to their correct token values for dialtone 8.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/MDJ9IbxxvDUQM/giphy.gif)
