### PR TITLE
fix: zi-notification

### DIFF
--- a/postcss/constants.js
+++ b/postcss/constants.js
@@ -315,6 +315,6 @@ module.exports = {
     drawer: 500,
     modal: 600,
     'modal-element': 650,
-    'zi-notification': 700,
+    notification: 700,
   },
 };


### PR DESCRIPTION
## Description

Removed duplicated `zi-` prefix from `zi-zi-notification`

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/ZTyc58rdwZ6C7RTFtX/giphy.gif)
