### PR TITLE
refactor(modal): backdrop-color-background variable

### DIFF
--- a/docs/design/colors/index.md
+++ b/docs/design/colors/index.md
@@ -503,6 +503,15 @@ Background colors for default application UI surfaces. Surface colors are contai
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--dt-color-surface-contrast-opaque)</td>
       <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-contrast-opaque</td>
     </tr>
+    <tr>
+      <th scope="row" class="d-pr0"><div class="d-bar-circle d-w42 d-h42 d-bgc-backdrop"></div></th>
+      <th scope="row" class="d-lh-300">
+        Surface Backdrop
+        <div class="d-fw-normal d-fs-100">Modal Backdrop surface background color.</div>
+      </th>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">var(--dt-color-surface-backdrop)</td>
+      <td class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100 d-ws-nowrap">.d-bgc-backdrop</td>
+    </tr>
   </tbody>
   <tbody>
     <tr>

--- a/lib/build/less/components/modal.less
+++ b/lib/build/less/components/modal.less
@@ -25,7 +25,7 @@
 .d-modal {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
-    --modal-backdrop-color-background: hsla(var(--dt-color-neutral-black-hsl) / 0.7); // TODO: token candidate
+    --modal-backdrop-color-background: var(--dt-color-surface-backdrop);
     --modal-dialog-padding: var(--dt-space-600);
     --modal-dialog-color-background: var(--dt-color-surface-primary);
     --modal-dialog-color-border: var(--dt-color-border-subtle);

--- a/lib/build/less/utilities/colors.less
+++ b/lib/build/less/utilities/colors.less
@@ -55,6 +55,7 @@
 .d-bgc-bold-opaque { background-color: var(--dt-color-surface-bold-opaque) !important; }
 .d-bgc-strong { background-color: var(--dt-color-surface-strong) !important; }
 .d-bgc-contrast { background-color: var(--dt-color-surface-contrast) !important; }
+.d-bgc-backdrop { background-color: var(--dt-color-surface-backdrop) !important; }
 .d-bgc-success { background-color: var(--dt-color-surface-success) !important; }
 .d-bgc-success-opaque { background-color: var(--dt-color-surface-success-opaque) !important; }
 .d-bgc-success-subtle { background-color: var(--dt-color-surface-success-subtle) !important; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@commitlint/config-conventional": "^17.6.6",
         "@dialpad/conventional-changelog-angular": "^1.1.1",
         "@dialpad/dialtone-combinator": "^0.3.1",
-        "@dialpad/dialtone-tokens": "^1.20.0",
+        "@dialpad/dialtone-tokens": "^1.21.0",
         "@dialpad/dialtone-vue": "3.77.0-dialtone8-vue3.4",
         "@dialpad/postcss-responsive-variations": "^1.1.5",
         "@dialpad/semantic-release-changelog-json": "^1.0.0",
@@ -1497,9 +1497,9 @@
       }
     },
     "node_modules/@dialpad/dialtone-tokens": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-tokens/-/dialtone-tokens-1.20.0.tgz",
-      "integrity": "sha512-pq7Ub0wy5yZ29dPm+RY4be3B6GopRwE16yw7fyV36BvNBidL4MYFu9jwDvjee1tcaoVX5Bn2nQXLbeJdh+bRhQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-tokens/-/dialtone-tokens-1.21.0.tgz",
+      "integrity": "sha512-owcrAF2qRMWE3UPKsK82IrMFUSKu6mc0QlgUnQ4tJ6URhdO1yS29n5mF/iKGIJn7NNfv1mz+xFR7hw0PZbrZqA==",
       "dev": true
     },
     "node_modules/@dialpad/dialtone-vue": {
@@ -38184,9 +38184,9 @@
       "requires": {}
     },
     "@dialpad/dialtone-tokens": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-tokens/-/dialtone-tokens-1.20.0.tgz",
-      "integrity": "sha512-pq7Ub0wy5yZ29dPm+RY4be3B6GopRwE16yw7fyV36BvNBidL4MYFu9jwDvjee1tcaoVX5Bn2nQXLbeJdh+bRhQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-tokens/-/dialtone-tokens-1.21.0.tgz",
+      "integrity": "sha512-owcrAF2qRMWE3UPKsK82IrMFUSKu6mc0QlgUnQ4tJ6URhdO1yS29n5mF/iKGIJn7NNfv1mz+xFR7hw0PZbrZqA==",
       "dev": true
     },
     "@dialpad/dialtone-vue": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@commitlint/config-conventional": "^17.6.6",
     "@dialpad/conventional-changelog-angular": "^1.1.1",
     "@dialpad/dialtone-combinator": "^0.3.1",
-    "@dialpad/dialtone-tokens": "^1.20.0",
+    "@dialpad/dialtone-tokens": "^1.21.0",
     "@dialpad/dialtone-vue": "3.77.0-dialtone8-vue3.4",
     "@dialpad/postcss-responsive-variations": "^1.1.5",
     "@dialpad/semantic-release-changelog-json": "^1.0.0",

--- a/postcss/constants.js
+++ b/postcss/constants.js
@@ -171,6 +171,7 @@ module.exports = {
       'strong',
       'contrast',
       'bold',
+      'backdrop',
       'success',
       'warning',
       'info',


### PR DESCRIPTION
## Description

- Updated modal's backdrop background color variable to token.
- Added documentation
- Added `.d-bgc-backdrop` utility class

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/AQpx44uhRuY5TYtYVD/giphy.gif)
