### PR TITLE
fix(item-layout): alignment issues

### DIFF
--- a/lib/build/less/components/item-layout.less
+++ b/lib/build/less/components/item-layout.less
@@ -33,6 +33,7 @@
     display: flex;
     align-items: center;
     min-width: var(--size-600);
+    min-height: inherit;
   }
 
   &--right {


### PR DESCRIPTION
## Description

Added min-height to item-layout to prevent smaller items to be misaligned.

**Note:** Once approved, I'll pull this into version8 branch and release

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/3oEduOnl5IHM5NRodO/giphy.gif)
