### PR TITLE
docs: system theme setting

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -25,7 +25,6 @@ const themeConfig = {
   editLink: false,
   colorModeSwitch: false,
   contributors: false,
-  themeMode: 'dark',
 };
 
 const __dirname = getDirname(import.meta.url);

--- a/docs/.vuepress/theme/client.js
+++ b/docs/.vuepress/theme/client.js
@@ -1,4 +1,3 @@
-import { useThemeData } from '@vuepress/plugin-theme-data/client';
 import { defineClientConfig } from '@vuepress/client';
 import Layout from './layouts/Layout.vue';
 import NotFound from './layouts/NotFound.vue';
@@ -8,6 +7,7 @@ import './assets/css/dialtone.css';
 import './assets/less/dialtone-docs.less';
 import './assets/less/dialtone-syntax.less';
 import '@/../node_modules/@dialpad/dialtone-vue/dist/style.css';
+import { onBeforeMount, provide, ref } from 'vue';
 
 export default defineClientConfig({
   async enhance ({ app, router }) {
@@ -16,14 +16,29 @@ export default defineClientConfig({
       await registerDialtoneVue(app);
       await registerEmojiDialtoneVue(app);
       await registerDialtoneCombinator(app);
-      const defaultTheme = useThemeData().value.themeMode;
-      document.body.classList.add(`dialtone-theme-${defaultTheme}`);
     }
     router.options.scrollBehavior = (to, from, savedPosition) => {
       return to.hash
         ? { el: to.hash, behavior: 'smooth', top: 64 }
         : { top: 0 };
     };
+  },
+  setup () {
+    onBeforeMount(() => {
+      const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+      const preferredTheme = localStorage.getItem('preferredTheme') || 'system';
+
+      const currentTheme = ref(preferredTheme);
+
+      if (currentTheme.value !== 'system') {
+        document.body.className = `dialtone-theme-${currentTheme.value}`;
+      } else {
+        document.body.className = systemPrefersDark.matches ? 'dialtone-theme-dark' : 'dialtone-theme-light';
+      }
+
+      provide('currentTheme', currentTheme);
+      provide('systemPrefersDark', systemPrefersDark);
+    });
   },
   layouts: {
     Layout,

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -87,9 +87,11 @@
         </template>
       </dt-tooltip>
       <dt-tooltip
-        message="Toggle Dark Mode"
         placement="bottom"
       >
+        <template #default>
+          <span class="d-tt-capitalize">{{ `${currentTheme} theme` }}</span>
+        </template>
         <template #anchor>
           <dt-button
             importance="clear"
@@ -126,8 +128,7 @@
 
 <script setup>
 import { useRoute } from 'vue-router';
-import { computed } from 'vue';
-import { useThemeData } from '@vuepress/plugin-theme-data/client';
+import { inject, computed } from 'vue';
 
 defineProps({
   items: {
@@ -138,19 +139,35 @@ defineProps({
 defineEmits(['search']);
 
 const route = useRoute();
-const isCurrentThemeLight = computed(() => {
-  return useThemeData().value.themeMode === 'light';
-});
+const currentTheme = inject('currentTheme');
+const systemPrefersDark = inject('systemPrefersDark');
+const themes = ['system', 'light', 'dark'];
+
 const currentThemeIconName = computed(() => {
-  return isCurrentThemeLight.value ? 'sun' : 'moon';
+  switch (currentTheme.value) {
+    case 'dark':
+      return 'moon';
+    case 'light':
+      return 'sun';
+    default:
+      return 'sparkle';
+  }
 });
 const isActiveLink = (text) => {
   const linkBase = text.toLowerCase();
   return route.path.search(linkBase) !== -1;
 };
 const toggleTheme = () => {
-  useThemeData().value.themeMode = isCurrentThemeLight.value ? 'dark' : 'light';
-  document.body.classList.toggle('dialtone-theme-light');
-  document.body.classList.toggle('dialtone-theme-dark');
+  const currentIndex = themes.indexOf(currentTheme.value);
+  const nextIndex = (currentIndex + 1) % themes.length;
+  currentTheme.value = themes[nextIndex];
+
+  localStorage.setItem('preferredTheme', currentTheme.value);
+
+  if (currentTheme.value === 'system') {
+    document.body.className = systemPrefersDark.matches ? 'dialtone-theme-dark' : 'dialtone-theme-light';
+  } else {
+    document.body.className = `dialtone-theme-${currentTheme.value}`;
+  }
 };
 </script>


### PR DESCRIPTION
## Description

Added the possibility to change between system, dark and light themes. default is system and if the user changes the theme to dark/light it'd be saved on localstorage to preserve the choice.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/NMlmbDwu9eeg8/giphy.gif)
