### PR TITLE
build: dialtone vue styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@ To add Dialtone into your project, you can install it via NPM:
 npm install @dialpad/dialtone
 ```
 
-Once installed, add the following line in your Less file:
+Once installed, add the following line in your CSS/LESS file:
 ```
-@import "node_modules/@dialpad/dialtone/lib/build/less/dialtone.less";
-```
-If you only need access to Dialtone's variables and customizations to build a file and don't need the whole library exported, use this line instead in your Less file:
-```
-@import (reference) "node_modules/@dialpad/dialtone/lib/build/less/dialtone.less";
+@import "node_modules/@dialpad/dialtone/lib/dist/css/dialtone.css";
 ```
 
 ## Building Dialtone locally
@@ -35,4 +31,4 @@ Requesting a feature or reporting a bug? Please do so at the below links:
 - [Report Bug](https://dialpad.atlassian.net/secure/CreateIssue.jspa?issuetype=10878&pid=12428)
 
 
-Please also feel free to contact us via the [#dialtone slack channel](https://dialpad.slack.com/messages/dialtone/) with any questions
+Please also feel free to contact us via the [#dialtone Slack channel](https://dialpad.slack.com/messages/dialtone/) with any questions

--- a/docs/.vuepress/theme/client.js
+++ b/docs/.vuepress/theme/client.js
@@ -6,7 +6,6 @@ import NotFound from './layouts/NotFound.vue';
 import './assets/css/dialtone.css';
 import './assets/less/dialtone-docs.less';
 import './assets/less/dialtone-syntax.less';
-import '@/../node_modules/@dialpad/dialtone-vue/dist/style.css';
 import { onBeforeMount, provide, ref } from 'vue';
 
 export default defineClientConfig({

--- a/docs/about/whats-new/posts/2023-8-14.md
+++ b/docs/about/whats-new/posts/2023-8-14.md
@@ -1,0 +1,34 @@
+---
+heading: Dialtone Vue CSS bundled in Dialtone
+author: Tico Ortega
+posted: '2023-8-14'
+---
+<!-- Note the date must be in this format YYYY-M-D and wrapped in single quotes -->
+
+<BlogPost :author="$frontmatter.author" :posted="parse($frontmatter.posted, 'y-M-d', new Date())" :heading="$frontmatter.heading">
+
+Hey everyone, I'd like communicate some recent updates to Dialtone's infrastructure.
+There is one small breaking change that consumers of Dialtone Vue will need to make after this update.
+
+The Dialtone developers will make this update in Dialpad, but if you maintain an app separate from Dialpad you'll have to make this update yourself.
+
+## Breaking change
+
+Dialtone Vue's CSS file is now bundled into Dialtone's CSS file, so you no longer need to import Dialtone Vue's CSS file into your code, please remove any of the following lines:
+
+```js
+import '@dialpad/dialtone-vue/css';
+```
+
+or within another css file:
+
+```css
+@import 'node_modules/@dialpad/dialtone-vue/dist/style.css';
+```
+
+</BlogPost>
+
+<script setup>
+import BlogPost from '@baseComponents/BlogPost.vue';
+import { parse } from 'date-fns';
+</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
         "gulp-svgmin": "^4.1.0",
         "husky": "^8.0.3",
         "jest": "^29.5.0",
+        "less": "^4.2.0",
         "lesshint": "^6.3.7",
         "lint-staged": "^13.2.3",
         "markdownlint": "^0.29.0",
@@ -19879,9 +19880,9 @@
       }
     },
     "node_modules/less": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.1.3.tgz",
-      "integrity": "sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.2.0.tgz",
+      "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
       "dev": true,
       "dependencies": {
         "copy-anything": "^2.0.1",
@@ -53503,9 +53504,9 @@
       }
     },
     "less": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.1.3.tgz",
-      "integrity": "sha512-w16Xk/Ta9Hhyei0Gpz9m7VS8F28nieJaL/VyShID7cYvP6IL5oHeL6p4TXSDJqZE/lNv0oJ2pGVjJsRkfwm5FA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.2.0.tgz",
+      "integrity": "sha512-P3b3HJDBtSzsXUl0im2L7gTO5Ubg8mEN6G8qoTS77iXxXX4Hvu4Qj540PZDvQ8V6DmX6iXo98k7Md0Cm1PrLaA==",
       "dev": true,
       "requires": {
         "copy-anything": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "gulp-svgmin": "^4.1.0",
     "husky": "^8.0.3",
     "jest": "^29.5.0",
+    "less": "^4.2.0",
     "lesshint": "^6.3.7",
     "lint-staged": "^13.2.3",
     "markdownlint": "^0.29.0",


### PR DESCRIPTION
## Description

Added dialtone-vue style.css into dialtone.css so clients don't need to import two different stylesheets. This also helps to avoid conflicts as dialtone-vue styles should always override dialtone's.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/hVTouq08miyVo1a21m/giphy.gif)
