### PR TITLE
feat: add theme tokens to output

### DIFF
--- a/lib/build/less/components/avatar.less
+++ b/lib/build/less/components/avatar.less
@@ -26,7 +26,7 @@
   --avatar-size-text: var(--dt-font-size-200);
   --avatar-presence-position-right: var(--dt-space-200-negative);
   --avatar-presence-position-bottom: var(--dt-space-200-negative);
-  --avatar-count-color-shadow: var(--theme-sidebar-color-background);
+  --avatar-count-color-shadow: var(--dt-theme-sidebar-color-background);
 
   position: relative;
   display: flex;
@@ -113,7 +113,7 @@
 
     .dt-leftbar-row--selected &,
     .dt-leftbar-row__primary:hover & {
-      --avatar-count-color-shadow: var(--theme-sidebar-row-color-background-hover);
+      --avatar-count-color-shadow: var(--dt-theme-sidebar-row-color-background-hover);
     }
   }
 

--- a/lib/build/less/components/presence.less
+++ b/lib/build/less/components/presence.less
@@ -7,12 +7,12 @@
 //  visit https://dialpad.design/components/presence
 
 .d-presence {
-  --presence-color-border-base: var(--theme-sidebar-color-background);
+  --presence-color-border-base: var(--dt-theme-sidebar-color-background);
   --presence-color-border-offline: var(--dt-color-black-600);
-  --presence-color-background-active: var(--theme-presence-color-background-available);
-  --presence-color-background-busy: var(--theme-presence-color-background-busy-unavailable);
-  --presence-color-background-away: var(--theme-presence-color-background-busy);
-  --presence-color-background-offline: var(--theme-sidebar-color-background);
+  --presence-color-background-active: var(--dt-theme-presence-color-background-available);
+  --presence-color-background-busy: var(--dt-theme-presence-color-background-busy-unavailable);
+  --presence-color-background-away: var(--dt-theme-presence-color-background-busy);
+  --presence-color-background-offline: var(--dt-theme-sidebar-color-background);
   --presence-border-size: var(--dt-size-200);
   --presence-size: var(--dt-size-400);
 
@@ -24,11 +24,11 @@
   border-radius: var(--dt-size-radius-circle);
 
   .dt-leftbar-row--selected & {
-    --presence-color-border-base: var(--theme-sidebar-selected-row-color-background);
+    --presence-color-border-base: var(--dt-theme-sidebar-selected-row-color-background);
   }
 
   .dt-leftbar-row__primary:hover & {
-    --presence-color-border-base: var(--theme-sidebar-row-color-background-hover);
+    --presence-color-border-base: var(--dt-theme-sidebar-row-color-background-hover);
   }
 
   &__inner {

--- a/lib/build/less/themes/default.less
+++ b/lib/build/less/themes/default.less
@@ -41,62 +41,7 @@
     base--font-family:                                var(--dt-font-family-body);
     base--line-height:                                var(--dt-font-line-height-300);
     base--corner-radius:                              0.25em; // TODO: unused. deprecate or...?
-
-    theme-topbar-color:                               hsl(var(--theme-topbar-color-hsl));
-    theme-topbar-color-hsl:                           var(--dt-color-black-900-h) var(--dt-color-black-900-s) var(--dt-color-black-900-l); // Use with d-fco[##] Opacity utility
-    theme-topbar-color-background:                    var(--dt-color-surface-secondary);
-
-    theme-sidebar-color:                              var(--dt-color-foreground-primary);
-    theme-sidebar-color-hsl:                          var(--dt-color-black-900-h) var(--dt-color-black-900-s) var(--dt-color-black-900-l);
-    theme-sidebar-color-background:                   var(--dt-color-surface-secondary);
-
-    theme-sidebar-icon-color:                         var(--dt-color-foreground-secondary);
-    theme-sidebar-status-color:                       var(--dt-color-foreground-tertiary);
-
-    theme-sidebar-row-color-background:               transparent;
-    theme-sidebar-row-color-background-hover:         hsla(var(--dt-color-black-900-hsl) / 0.1);
-    theme-sidebar-row-color-background-active:        var(--dt-color-black-300);
-
-    theme-sidebar-selected-row-color:                 var(--dt-color-foreground-primary);
-    theme-sidebar-selected-row-color-hsl:             var(--dt-color-black-900-h) var(--dt-color-black-900-s) var(--dt-color-black-900-l); // Use with d-fco[##] Opacity utility
-    theme-sidebar-selected-row-color-background:      var(--dt-color-surface-moderate-opaque);
-
-    theme-presence-color-background-available:        var(--dt-color-green-400);
-    theme-presence-color-background-busy-unavailable: var(--dt-color-red-300);
-    theme-presence-color-background-busy:             var(--dt-color-gold-300);
-
-    theme-mention-color-background:                   var(--dt-color-purple-400);
-    theme-mention-color-foreground:                   var(--dt-color-neutral-white);
 }
-
-//  ============================================================================
-//  $   THEME CLASSES
-//  ============================================================================
-
-.d-theme-topbar-fc {
-    --fco: 75%;
-
-    color: hsla(var(--theme-topbar-color-hsl) / var(--fco)) !important;
-
-    &:hover {
-        --fco: 100%;
-    }
-}
-.d-theme-topbar-bgc { background-color: var(--theme-topbar-color-background) !important; }
-.d-theme-sidebar-fc { color: var(--theme-sidebar-color) !important; }
-.d-theme-sidebar-status-fc { color: var(--theme-sidebar-status-color) !important; }
-.d-theme-sidebar-icon-fc { color: var(--theme-sidebar-icon-color) !important; }
-.d-theme-sidebar-bgc { background-color: var(--theme-sidebar-color-background) !important; }
-.d-theme-sidebar-row-bgc:hover { background-color: var(--theme-sidebar-row-color-background-hover) !important; }
-.d-theme-sidebar-row-bgc:active { background-color: var(--theme-sidebar-row-color-background-active) !important; }
-.d-theme-sidebar-row-selected-fc { color: var(--theme-sidebar-selected-row-color) !important; }
-.d-theme-sidebar-row-selected-bgc { background-color: var(--theme-sidebar-selected-row-color-background) !important; }
-.d-theme-presence-available { background-color: var(--theme-presence-color-background-available) !important; }
-.d-theme-presence-busy-unavailable { background-color: var(--theme-presence-color-background-busy-unavailable) !important; }
-.d-theme-presence-busy { background-color: var(--theme-presence-color-background-busy) !important; }
-.d-theme-mention { background-color: var(--theme-mention-color-background) !important; }
-.d-theme-mention-fc { color: var(--theme-mention-color-foreground) !important; }
-
 
 //  ============================================================================
 //  $   OUTPUT VARIABLES

--- a/postcss/dialtone-generators.js
+++ b/postcss/dialtone-generators.js
@@ -22,6 +22,7 @@ const {
   appendHoverFocusSelectors,
   extractShadows,
   extractTypographies,
+  removePrefixFromColor,
 } = require('./helpers');
 const tinycolor = require('tinycolor2');
 const bodyCSSVariables = [];
@@ -106,10 +107,11 @@ const generatedRules = {
 function colorUtilities (Rule, clonedSource, declaration) {
   const dialtoneColors = extractColors();
   dialtoneColors.light.forEach(({ colorName: color }) => {
-    const hslaColor = `hsla(var(--dt-color-${color}-h) var(--dt-color-${color}-s) var(--dt-color-${color}-l)`;
+    const hslaColor = `hsla(var(${color}-h) var(${color}-s) var(${color}-l)`;
+    const colorNoPrefix = removePrefixFromColor(color);
     generatedRules.fontColor.push(new Rule({
       source: clonedSource,
-      selector: appendHoverFocusSelectors(`.d-fc-${color}.d-fc-${color}`),
+      selector: appendHoverFocusSelectors(`.d-fc-${colorNoPrefix}.d-fc-${colorNoPrefix}`),
       nodes: [
         declaration.clone({ prop: '--fco', value: '100%' }),
         declaration.clone({ prop: 'color', value: `${hslaColor} / var(--fco)) !important` }),
@@ -117,7 +119,7 @@ function colorUtilities (Rule, clonedSource, declaration) {
     }));
     generatedRules.borderColor.push(new Rule({
       source: clonedSource,
-      selector: appendHoverFocusSelectors(`.d-bc-${color}.d-bc-${color}`),
+      selector: appendHoverFocusSelectors(`.d-bc-${colorNoPrefix}.d-bc-${colorNoPrefix}`),
       nodes: [
         declaration.clone({ prop: '--bco', value: '100%' }),
         declaration.clone({ prop: 'border-color', value: `${hslaColor} / var(--bco)) !important` }),
@@ -125,7 +127,7 @@ function colorUtilities (Rule, clonedSource, declaration) {
     }));
     generatedRules.backgroundColor.push(new Rule({
       source: clonedSource,
-      selector: appendHoverFocusSelectors(`.d-bgc-${color}.d-bgc-${color}`),
+      selector: appendHoverFocusSelectors(`.d-bgc-${colorNoPrefix}.d-bgc-${colorNoPrefix}`),
       nodes: [
         declaration.clone({ prop: '--bgo', value: '100%' }),
         declaration.clone({ prop: 'background-color', value: `${hslaColor} / var(--bgo)) !important` }),
@@ -133,7 +135,7 @@ function colorUtilities (Rule, clonedSource, declaration) {
     }));
     generatedRules.dividerColor.push(new Rule({
       source: clonedSource,
-      selector: `.d-divide-${color}.d-divide-${color} > * + *`,
+      selector: `.d-divide-${colorNoPrefix}.d-divide-${colorNoPrefix} > * + *`,
       nodes: [
         declaration.clone({ prop: '--dco', value: '100%' }),
         declaration.clone({ prop: 'border-color', value: `${hslaColor} / var(--dco)) !important` }),
@@ -141,7 +143,7 @@ function colorUtilities (Rule, clonedSource, declaration) {
     }));
     generatedRules.backgroundGradientFromColor.push(new Rule({
       source: clonedSource,
-      selector: appendHoverFocusSelectors(`.d-bgg-from-${color}.d-bgg-from-${color}`),
+      selector: appendHoverFocusSelectors(`.d-bgg-from-${colorNoPrefix}.d-bgg-from-${colorNoPrefix}`),
       nodes: [
         declaration.clone({ prop: '--bgg-from-opacity', value: '100%' }),
         declaration.clone({ prop: '--bgg-from', value: `${hslaColor} / var(--bgg-from-opacity))` }),
@@ -150,7 +152,7 @@ function colorUtilities (Rule, clonedSource, declaration) {
     }));
     generatedRules.backgroundGradientToColor.push(new Rule({
       source: clonedSource,
-      selector: appendHoverFocusSelectors(`.d-bgg-to-${color}.d-bgg-to-${color}`),
+      selector: appendHoverFocusSelectors(`.d-bgg-to-${colorNoPrefix}.d-bgg-to-${colorNoPrefix}`),
       nodes: [
         declaration.clone({ prop: '--bgg-to-opacity', value: '100%' }),
         declaration.clone({ prop: '--bgg-to', value: `${hslaColor} / var(--bgg-to-opacity)) !important` }),
@@ -688,26 +690,24 @@ function colorVariables (declaration) {
   dialtoneColors.light.forEach(({ colorName, hexValue }) => {
     const color = tinycolor(hexValue);
     const { h: hue, s: saturation, l: lightness } = color.toHsl();
-    const colorVar = `--dt-color-${colorName}`;
     lightCSSVariables.push([
-      declaration.clone({ prop: `${colorVar}-h`, value: `${hue}` }),
-      declaration.clone({ prop: `${colorVar}-s`, value: `${saturation * 100}%` }),
-      declaration.clone({ prop: `${colorVar}-l`, value: `${lightness * 100}%` }),
-      declaration.clone({ prop: `${colorVar}-hsl`, value: `var(${colorVar}-h) var(${colorVar}-s) var(${colorVar}-l)` }),
-      declaration.clone({ prop: `${colorVar}-hsla`, value: `hsla(var(${colorVar}-h) var(${colorVar}-s) var(${colorVar}-l) / var(--alpha, 100%))` }),
+      declaration.clone({ prop: `${colorName}-h`, value: `${hue}` }),
+      declaration.clone({ prop: `${colorName}-s`, value: `${saturation * 100}%` }),
+      declaration.clone({ prop: `${colorName}-l`, value: `${lightness * 100}%` }),
+      declaration.clone({ prop: `${colorName}-hsl`, value: `var(${colorName}-h) var(${colorName}-s) var(${colorName}-l)` }),
+      declaration.clone({ prop: `${colorName}-hsla`, value: `hsla(var(${colorName}-h) var(${colorName}-s) var(${colorName}-l) / var(--alpha, 100%))` }),
     ]);
   });
   lightCSSVariables.push({ prop: 'color-scheme', value: 'light' });
   dialtoneColors.dark.forEach(({ colorName, hexValue }) => {
     const color = tinycolor(hexValue);
     const { h: hue, s: saturation, l: lightness } = color.toHsl();
-    const colorVar = `--dt-color-${colorName}`;
     darkCSSVariables.push([
-      declaration.clone({ prop: `${colorVar}-h`, value: `${hue}` }),
-      declaration.clone({ prop: `${colorVar}-s`, value: `${saturation * 100}%` }),
-      declaration.clone({ prop: `${colorVar}-l`, value: `${lightness * 100}%` }),
-      declaration.clone({ prop: `${colorVar}-hsl`, value: `var(${colorVar}-h) var(${colorVar}-s) var(${colorVar}-l)` }),
-      declaration.clone({ prop: `${colorVar}-hsla`, value: `hsla(var(${colorVar}-h) var(${colorVar}-s) var(${colorVar}-l) / var(--alpha, 100%))` }),
+      declaration.clone({ prop: `${colorName}-h`, value: `${hue}` }),
+      declaration.clone({ prop: `${colorName}-s`, value: `${saturation * 100}%` }),
+      declaration.clone({ prop: `${colorName}-l`, value: `${lightness * 100}%` }),
+      declaration.clone({ prop: `${colorName}-hsl`, value: `var(${colorName}-h) var(${colorName}-s) var(${colorName}-l)` }),
+      declaration.clone({ prop: `${colorName}-hsla`, value: `hsla(var(${colorName}-h) var(${colorName}-s) var(${colorName}-l) / var(--alpha, 100%))` }),
     ]);
   });
   darkCSSVariables.push({ prop: 'color-scheme', value: 'dark' });

--- a/postcss/helpers.js
+++ b/postcss/helpers.js
@@ -10,7 +10,7 @@ const pascalToKebabCase = (string) => {
 };
 
 const processColors = (result, color) => {
-  const colorName = pascalToKebabCase(color[0]);
+  const colorName = `--${pascalToKebabCase(color[0])}`;
   const hexValue = color[1];
   result.push({ colorName, hexValue });
   return result;

--- a/postcss/helpers.js
+++ b/postcss/helpers.js
@@ -3,18 +3,17 @@ const dialtoneTokensLight = require('../node_modules/@dialpad/dialtone-tokens/di
 const dialtoneTokensDark = require('../node_modules/@dialpad/dialtone-tokens/dist/tokens-dark.json');
 
 const colorsRegex = new RegExp(`dtColor(Neutral)?(${REGEX_OPTIONS.COLORS})([0-9]{3})?`);
+const themeColorsRegex = /(dtTheme).*(Color).*/;
+
+const pascalToKebabCase = (string) => {
+  return string.split(/(?=[A-Z]|[0-9]{3,}?)/).join('-').toLowerCase();
+};
+
 const processColors = (result, color) => {
-  const colorName = color[0]
-    .replace(colorsRegex, (_, m1, m2, m3) => {
-      return [m1, m2, m3].filter(el => !!el).join('-');
-    })
-    .toLowerCase();
+  const colorName = pascalToKebabCase(color[0]);
   const hexValue = color[1];
   result.push({ colorName, hexValue });
   return result;
-};
-const pascalToKebabCase = (string) => {
-  return string.split(/(?=[A-Z])/).join('-').toLowerCase();
 };
 
 module.exports = {
@@ -26,12 +25,16 @@ module.exports = {
   */
   extractColors () {
     const lightColors = Object.entries(dialtoneTokensLight)
-      .filter(([key]) => colorsRegex.test(key))
+      .filter(([key]) => colorsRegex.test(key) || themeColorsRegex.test(key))
       .reduce(processColors, []);
     const darkColors = Object.entries(dialtoneTokensDark)
-      .filter(([key]) => colorsRegex.test(key))
+      .filter(([key]) => colorsRegex.test(key) || themeColorsRegex.test(key))
       .reduce(processColors, []);
     return { light: lightColors, dark: darkColors };
+  },
+
+  removePrefixFromColor (colorName) {
+    return colorName.replace('dt-theme-', '').replace('dt-color-', '');
   },
 
   /**


### PR DESCRIPTION
## Description

Removes the old theme vars and replaces them with dialtone-tokens including hsl variants. Also removed theme utility classes.

I believe this will only be a breaking change on UV since they are the only ones who use theme vars.. But I will check other repos as well.

Will not merge this until dialtone vue is updated as well.

Will update documentation in separate PR.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/M53BgsOZnVkadIYKFM/giphy.gif)
