### PR TITLE
fix: bgc color generation

### DIFF
--- a/postcss/dialtone-generators.js
+++ b/postcss/dialtone-generators.js
@@ -105,10 +105,11 @@ const generatedRules = {
  * @param { Declaration } declaration
  */
 function colorUtilities (Rule, clonedSource, declaration) {
-  const dialtoneColors = extractColors();
+  const dialtoneColors = extractColors(false);
   dialtoneColors.light.forEach(({ colorName: color }) => {
     const hslaColor = `hsla(var(${color}-h) var(${color}-s) var(${color}-l)`;
     const colorNoPrefix = removePrefixFromColor(color);
+    console.log(colorNoPrefix);
     generatedRules.fontColor.push(new Rule({
       source: clonedSource,
       selector: appendHoverFocusSelectors(`.d-fc-${colorNoPrefix}.d-fc-${colorNoPrefix}`),

--- a/postcss/dialtone-generators.js
+++ b/postcss/dialtone-generators.js
@@ -109,7 +109,6 @@ function colorUtilities (Rule, clonedSource, declaration) {
   dialtoneColors.light.forEach(({ colorName: color }) => {
     const hslaColor = `hsla(var(${color}-h) var(${color}-s) var(${color}-l)`;
     const colorNoPrefix = removePrefixFromColor(color);
-    console.log(colorNoPrefix);
     generatedRules.fontColor.push(new Rule({
       source: clonedSource,
       selector: appendHoverFocusSelectors(`.d-fc-${colorNoPrefix}.d-fc-${colorNoPrefix}`),

--- a/postcss/helpers.js
+++ b/postcss/helpers.js
@@ -23,18 +23,18 @@ module.exports = {
   *
   * @returns {Object}
   */
-  extractColors () {
+  extractColors (includeThemeColors = true) {
     const lightColors = Object.entries(dialtoneTokensLight)
-      .filter(([key]) => colorsRegex.test(key) || themeColorsRegex.test(key))
+      .filter(([key]) => colorsRegex.test(key) || (themeColorsRegex.test(key) && includeThemeColors))
       .reduce(processColors, []);
     const darkColors = Object.entries(dialtoneTokensDark)
-      .filter(([key]) => colorsRegex.test(key) || themeColorsRegex.test(key))
+      .filter(([key]) => colorsRegex.test(key) || (themeColorsRegex.test(key) && includeThemeColors))
       .reduce(processColors, []);
     return { light: lightColors, dark: darkColors };
   },
 
   removePrefixFromColor (colorName) {
-    return colorName.replace('dt-theme-', '').replace('dt-color-', '');
+    return colorName.replace('--dt-theme-', '').replace('--dt-color-', '');
   },
 
   /**


### PR DESCRIPTION
## Description
Couple issues here, we were not removing the preceding `--` in removePrefixFromColor and we were generating utility classes for all the new theme colors which we don't want, we only want variables.