### PR TITLE
fix(item-layout): set width to 100%

### DIFF
--- a/lib/build/less/components/item-layout.less
+++ b/lib/build/less/components/item-layout.less
@@ -15,6 +15,7 @@
 .dt-item-layout {
   display: flex;
   align-items: center;
+  width: 100%;
   min-height: calc(var(--dt-size-550) + var(--dt-size-300));
   padding: var(--dt-space-300) var(--dt-space-400);
   font-size: var(--dt-font-size-200);

--- a/lib/build/less/components/item-layout.less
+++ b/lib/build/less/components/item-layout.less
@@ -22,7 +22,7 @@
 
   &--content {
     flex-grow: 1;
-    max-width: 100%;
+    min-width: var(--dt-size-0);
   }
 
   &--subtitle {

--- a/lib/build/less/components/item-layout.less
+++ b/lib/build/less/components/item-layout.less
@@ -15,7 +15,6 @@
 .dt-item-layout {
   display: flex;
   align-items: center;
-  width: 100%;
   min-height: calc(var(--dt-size-550) + var(--dt-size-300));
   padding: var(--dt-space-300) var(--dt-space-400);
   font-size: var(--dt-font-size-200);

--- a/lib/build/less/components/item-layout.less
+++ b/lib/build/less/components/item-layout.less
@@ -22,6 +22,7 @@
 
   &--content {
     flex-grow: 1;
+    width: 100%;
   }
 
   &--subtitle {

--- a/lib/build/less/components/item-layout.less
+++ b/lib/build/less/components/item-layout.less
@@ -22,7 +22,7 @@
 
   &--content {
     flex-grow: 1;
-    width: 100%;
+    max-width: 100%;
   }
 
   &--subtitle {


### PR DESCRIPTION
## Description
It was possible for item-layout to overflow it's container. This should lock it to the width of it's container.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/SRkctO9741bELZdoNg/giphy.gif)
