### PR TITLE
fix(select): add dark mode to list for windows

### DIFF
--- a/lib/build/less/components/selects.less
+++ b/lib/build/less/components/selects.less
@@ -21,9 +21,13 @@
   //  --------------------------------------------------------------------------
   --select-color-border: var(--dt-inputs-color-border-default);
   --select-notch-position-right: var(--dt-space-400);
+  --select-color-background: var(--dt-inputs-color-background-default);
+  --select-color-foreground: var(--dt-inputs-color-foreground-default);
 
   position: relative;
   width: stretch;
+  color: var(--select-color-foreground);
+  background-color: var(--select-color-background);
 
   //  --  Arrows
   &::after {

--- a/lib/build/less/components/selects.less
+++ b/lib/build/less/components/selects.less
@@ -21,8 +21,6 @@
   //  --------------------------------------------------------------------------
   --select-color-border: var(--dt-inputs-color-border-default);
   --select-notch-position-right: var(--dt-space-400);
-  --select-color-background: var(--dt-inputs-color-background-default);
-  --select-color-foreground: var(--dt-inputs-color-foreground-default);
 
   position: relative;
   width: stretch;
@@ -58,8 +56,8 @@
 
   // select options can be styled on windows
   & option {
-    color: var(--select-color-foreground);
-    background-color: var(--select-color-background);
+    color: var(--dt-color-foreground-secondary);
+    background-color: var(--dt-color-surface-secondary);
   }
 
   //  --  FOCUS STATE

--- a/lib/build/less/components/selects.less
+++ b/lib/build/less/components/selects.less
@@ -26,8 +26,7 @@
 
   position: relative;
   width: stretch;
-  color: var(--select-color-foreground);
-  background-color: var(--select-color-background);
+
 
   //  --  Arrows
   &::after {
@@ -56,6 +55,12 @@
 
   // Use shared style properties of d-input (<input>, <textarea>)
   .d-input();
+
+  // select options can be styled on windows
+  & option {
+    color: var(--select-color-foreground);
+    background-color: var(--select-color-background);
+  }
 
   //  --  FOCUS STATE
   &:focus {

--- a/lib/build/less/components/selects.less
+++ b/lib/build/less/components/selects.less
@@ -25,7 +25,6 @@
   position: relative;
   width: stretch;
 
-
   //  --  Arrows
   &::after {
     --select-arrow-size: calc(var(--dt-size-300) * 3.5);


### PR DESCRIPTION
## Description

On mac select menu dialog always uses system defaults, however on windows it can be styled. Changing the select menu styling so it looks correct in dark mode on windows.

https://dialpad.atlassian.net/browse/DLT-1198

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/kAuU3dzYMqmOTKSUXk/giphy.gif)
