### PR TITLE
docs(theme): updated theme color table

### DIFF
--- a/docs/.vuepress/views/ThemeColorTable.vue
+++ b/docs/.vuepress/views/ThemeColorTable.vue
@@ -34,7 +34,7 @@
           <div
             v-else-if="c.property === 'color'"
             class="d-fs-300 d-p6 d-ta-center d-fw-medium"
-            style="color: var(--{{ c.name }})"
+            :style="{ color: `var(--${c.name})` }"
           >
             Aa
           </div>

--- a/docs/.vuepress/views/ThemeColorTable.vue
+++ b/docs/.vuepress/views/ThemeColorTable.vue
@@ -9,7 +9,7 @@
           Section
         </th>
         <th scope="col">
-          Item
+          State
         </th>
         <th scope="col">
           Property
@@ -22,7 +22,7 @@
     <tbody v-for="c in theme" :key="c.name">
       <tr>
         <td>
-          <div v-if="c.item === 'Icon'" class="d-d-flex d-ai-center d-jc-center">
+          <div v-if="c.section === 'Sidebar Icon'" class="d-d-flex d-ai-center d-jc-center" title="Sample icon">
             <dt-icon name="info" :style="{ color: `var(--${c.name})` }" />
           </div>
           <div v-else-if="c.property === 'background-color'" class="d-d-flex d-ai-center d-jc-center">
@@ -49,14 +49,12 @@
           </div>
         </td>
         <th scope="row">
-          <div>
+          <div class="d-ws-nowrap">
             {{ c.section }}
           </div>
         </th>
         <td>
-          <div>
-            {{ c.item }}
-          </div>
+          {{ c.item }}
         </td>
         <td>
           <div class="d-ff-mono d-fc-purple-400 d-fw-normal d-fs-100">

--- a/docs/_data/colors.json
+++ b/docs/_data/colors.json
@@ -42,187 +42,187 @@
     {
       "name": "dt-theme-topbar-color-foreground",
       "section": "Topbar",
-      "item": "Text",
+      "item": "resting",
       "property": "color"
     },
     {
       "name": "dt-theme-topbar-color-background",
       "section": "Topbar",
-      "item": "Surface",
+      "item": "resting",
       "property": "background-color"
     },
     {
       "name": "dt-theme-topbar-field-color-foreground",
-      "section": "Topbar",
-      "item": "Text",
+      "section": "Topbar Field",
+      "item": "resting",
       "property": "color"
     },
     {
       "name": "dt-theme-topbar-field-color-foreground-hover",
-      "section": "Topbar",
-      "item": "Text",
+      "section": "Topbar Field",
+      "item": "hovering",
       "property": "color"
     },
     {
       "name": "dt-theme-topbar-field-color-background",
-      "section": "Topbar",
-      "item": "Surface",
+      "section": "Topbar Field",
+      "item": "resting",
       "property": "background-color"
     },
     {
       "name": "dt-theme-topbar-field-color-background-hover",
-      "section": "Topbar",
-      "item": "Surface",
+      "section": "Topbar Field",
+      "item": "hovering",
       "property": "background-color"
     },
     {
       "name": "dt-theme-topbar-field-color-border",
-      "section": "Topbar",
-      "item": "Border: default",
+      "section": "Topbar Field",
+      "item": "resting",
       "property": "border-color"
     },
     {
       "name": "dt-theme-topbar-field-color-border-hover",
-      "section": "Topbar",
-      "item": "Border: hovering",
+      "section": "Topbar Field",
+      "item": "hovering",
       "property": "border-color"
     },
     {
       "name": "dt-theme-topbar-field-color-border-active",
-      "section": "Topbar",
-      "item": "Border: pressed",
+      "section": "Topbar Field",
+      "item": "pressing",
       "property": "border-color"
     },
     {
       "name": "dt-theme-topbar-button-color-foreground",
-      "section": "Topbar",
-      "item": "Text",
+      "section": "Topbar Button",
+      "item": "resting",
       "property": "color"
     },
     {
       "name": "dt-theme-topbar-button-color-foreground-hover",
-      "section": "Topbar",
-      "item": "Text",
+      "section": "Topbar Button",
+      "item": "hovering",
       "property": "color"
     },
     {
       "name": "dt-theme-topbar-button-color-background",
-      "section": "Topbar",
-      "item": "Surface",
+      "section": "Topbar Button",
+      "item": "resting",
       "property": "background-color"
     },
     {
       "name": "dt-theme-topbar-button-color-background-hover",
-      "section": "Topbar",
-      "item": "Surface",
+      "section": "Topbar Button",
+      "item": "hovering",
       "property": "background-color"
     },
     {
       "name": "dt-theme-topbar-button-color-background-active",
-      "section": "Topbar",
-      "item": "Surface",
+      "section": "Topbar Button",
+      "item": "pressing",
       "property": "background-color"
     },
     {
       "name": "dt-theme-topbar-profile-color-foreground",
-      "section": "Topbar",
-      "item": "Text",
+      "section": "Topbar Profile",
+      "item": "resting",
       "property": "color"
     },
     {
       "name": "dt-theme-topbar-profile-color-foreground-inverted",
-      "section": "Topbar",
-      "item": "Text",
+      "section": "Topbar Profile",
+      "item": "inverted, default",
       "property": "color"
     },
     {
       "name": "dt-theme-topbar-profile-color-background",
-      "section": "Topbar",
-      "item": "Surface",
+      "section": "Topbar Profile",
+      "item": "resting",
       "property": "background-color"
     },
     {
       "name": "dt-theme-topbar-profile-color-background-inverted",
-      "section": "Topbar",
-      "item": "Surface",
+      "section": "Topbar Profile",
+      "item": "inverted, default",
       "property": "background-color"
     },
     {
       "name": "dt-theme-topbar-profile-color-background-hover",
-      "section": "Topbar",
-      "item": "Surface",
+      "section": "Topbar Profile",
+      "item": "hovering",
       "property": "background-color"
     },
     {
       "name": "dt-theme-topbar-profile-color-background-active",
-      "section": "Topbar",
-      "item": "Surface",
+      "section": "Topbar Profile",
+      "item": "pressing",
       "property": "background-color"
     },
     {
       "name": "dt-theme-sidebar-color-foreground",
       "section": "Sidebar",
-      "item": "Text",
-      "property": "color"
-    },
-    {
-      "name": "dt-theme-sidebar-color-foreground-unread",
-      "section": "Sidebar",
-      "item": "Text",
+      "item": "resting",
       "property": "color"
     },
     {
       "name": "dt-theme-sidebar-color-background",
       "section": "Sidebar",
-      "item": "Surface",
-      "property": "background-color"
-    },
-    {
-      "name": "dt-theme-sidebar-icon-color-foreground",
-      "section": "Sidebar",
-      "item": "Icon",
-      "property": "color"
-    },
-    {
-      "name": "dt-theme-sidebar-status-color-foreground",
-      "section": "Sidebar",
-      "item": "Text",
-      "property": "color"
-    },
-    {
-      "name": "dt-theme-sidebar-row-color-background",
-      "section": "Sidebar",
-      "item": "Row: default",
-      "property": "background-color"
-    },
-    {
-      "name": "dt-theme-sidebar-row-color-background-hover",
-      "section": "Sidebar",
-      "item": "Row: hovering",
-      "property": "background-color"
-    },
-    {
-      "name": "dt-theme-sidebar-row-color-background-active",
-      "section": "Sidebar",
-      "item": "Row: pressing",
-      "property": "background-color"
-    },
-    {
-      "name": "dt-theme-sidebar-selected-row-color-foreground",
-      "section": "Sidebar",
-      "item": "Row: selected",
-      "property": "color"
-    },
-    {
-      "name": "dt-theme-sidebar-selected-row-color-background",
-      "section": "Sidebar",
-      "item": "Row: selected",
+      "item": "resting",
       "property": "background-color"
     },
     {
       "name": "dt-theme-sidebar-section-color-foreground",
-      "section": "Sidebar",
-      "item": "Text",
+      "section": "Sidebar Section",
+      "item": "resting",
+      "property": "color"
+    },
+    {
+      "name": "dt-theme-sidebar-color-foreground-unread",
+      "section": "Sidebar Row",
+      "item": "unread",
+      "property": "color"
+    },
+    {
+      "name": "dt-theme-sidebar-selected-row-color-foreground",
+      "section": "Sidebar Row",
+      "item": "selected",
+      "property": "color"
+    },
+    {
+      "name": "dt-theme-sidebar-row-color-background",
+      "section": "Sidebar Row",
+      "item": "resting",
+      "property": "background-color"
+    },
+    {
+      "name": "dt-theme-sidebar-row-color-background-hover",
+      "section": "Sidebar Row",
+      "item": "hovering",
+      "property": "background-color"
+    },
+    {
+      "name": "dt-theme-sidebar-row-color-background-active",
+      "section": "Sidebar Row",
+      "item": "pressing",
+      "property": "background-color"
+    },
+    {
+      "name": "dt-theme-sidebar-selected-row-color-background",
+      "section": "Sidebar Row",
+      "item": "selected",
+      "property": "background-color"
+    },
+    {
+      "name": "dt-theme-sidebar-icon-color-foreground",
+      "section": "Sidebar Icon",
+      "item": "resting",
+      "property": "color"
+    },
+    {
+      "name": "dt-theme-sidebar-status-color-foreground",
+      "section": "Sidebar Status",
+      "item": "resting",
       "property": "color"
     },
     {
@@ -245,14 +245,14 @@
     },
     {
       "name": "dt-theme-mention-color-foreground",
-      "section": "Mention",
-      "item": "Mention badge",
+      "section": "Mention Badge",
+      "item": "resting",
       "property": "color"
     },
     {
       "name": "dt-theme-mention-color-background",
-      "section": "Mention",
-      "item": "Mention badge",
+      "section": "Mention Badge",
+      "item": "resting",
       "property": "background-color"
      }
   ],


### PR DESCRIPTION
## Description

Organized Themes section of https://dialpad.design/design/colors/#theme to be easier to parse since their Design Tokens were refactored recently in `dialtone-tokens.

* Section column renamed to be more specific
* Added "State" column
* Reordered

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

![image](https://github.com/dialpad/dialtone/assets/1165933/9f9ace61-aebf-4d11-8808-a5629da69823)
