### PR TITLE
refactor(banner, notice, toast): use notice as base

### DIFF
--- a/docs/.vuepress/exampleComponents/ExampleNotice.vue
+++ b/docs/.vuepress/exampleComponents/ExampleNotice.vue
@@ -1,80 +1,26 @@
 <template>
-  <div class="d-stack12 d-w60p">
-    <aside
-      class="d-notice"
-      :class="[
-        noticeClass,
-        { 'd-notice--important': important },
-      ]"
-      :role="role"
-      aria-hidden="false"
+  <dt-notice
+    :important="important"
+    :kind="kind"
+    :title="title"
+  >
+    Message body with
+    <dt-link
+      :class="linkClass"
     >
-      <div class="d-notice__icon">
-        <dt-icon
-          v-show="kind === 'base'"
-          name="bell"
-          size="400"
-        />
-        <dt-icon
-          v-show="kind === 'error'"
-          name="alert-circle"
-          size="400"
-        />
-        <dt-icon
-          v-show="kind === 'info'"
-          name="info"
-          size="400"
-        />
-        <dt-icon
-          v-show="kind === 'success'"
-          name="check-circle"
-          size="400"
-        />
-        <dt-icon
-          v-show="kind === 'warning'"
-          name="alert-triangle"
-          size="400"
-        />
-      </div>
-      <div class="d-notice__content">
-        <h2 class="d-notice__title">
-          <span class="d-tt-capitalize">{{ kind }}</span> title (optional)
-        </h2>
-        <p class="d-notice__message">
-          Message body with
-          <a
-            href="#"
-            class="d-link"
-            :class="shouldBeInverted ? 'd-link--inverted' : 'd-link--muted'"
-          >
-            a link.
-          </a>
-        </p>
-      </div>
-      <div class="d-notice__actions">
-        <button
-          type="button"
-          class="d-btn d-btn--sm d-btn--outlined"
-          :class="shouldBeInverted ? 'd-btn--inverted' : 'd-btn--muted'"
-        >
-          Action
-        </button>
-        <button
-          type="button"
-          class="d-btn d-btn--sm d-btn--circle"
-          :class="shouldBeInverted ? 'd-btn--inverted' : 'd-btn--muted'"
-          aria-label="Close"
-        >
-          <span class="d-btn__icon">
-            <dt-icon
-              name="close"
-              size="200"
-            />
-          </span>
-        </button>
-      </div>
-    </aside>
-  </div>
+      a link
+    </dt-link>
+    <template #action>
+      <dt-button
+        size="sm"
+        importance="outlined"
+        :kind="important ? 'inverted' : 'muted'"
+        :class="{ 'd-bc-neutral-black': important && kind === 'warning' }"
+      >
+        Action
+      </dt-button>
+    </template>
+  </dt-notice>
 </template>
 
 <script>
@@ -91,24 +37,17 @@ export default {
       required: true,
     },
 
-    role: {
+    title: {
       type: String,
-      default: 'status',
+      default: '',
     },
   },
 
   computed: {
-    noticeClass () {
-      return 'd-notice--' + this.kind;
-    },
-
-    shouldBeInverted () {
-      return this.important && !['warning'].includes(this.kind);
+    linkClass () {
+      if (this.kind === 'warning' && this.important) return 'd-fc-neutral-black';
+      return this.important ? 'd-fc-primary-inverted' : 'd-fc-primary';
     },
   },
 };
 </script>
-
-<style scoped>
-
-</style>

--- a/docs/.vuepress/exampleComponents/ExampleToast.vue
+++ b/docs/.vuepress/exampleComponents/ExampleToast.vue
@@ -29,11 +29,8 @@
 </template>
 
 <script>
-import { DtButton } from '@dialpad/dialtone-vue';
-
 export default {
   name: 'ExampleToast',
-  components: { DtButton },
   props: {
     title: {
       type: String,

--- a/docs/.vuepress/exampleComponents/ExampleToast.vue
+++ b/docs/.vuepress/exampleComponents/ExampleToast.vue
@@ -1,200 +1,67 @@
 <template>
-  <div
-    class="dialtone-example"
-    data-example="yes"
-    data-code="yes"
-  >
-    <div class="dialtone-example__example">
-      <div
-        class="
-          lg:d-fd-column lg:d-ai-stretch lg:d-stack8 lg:d-flow0
-          d-d-flex d-ai-flex-end d-p16 d-bgc-secondary
-          d-ba d-bc-transparent d-flow16 d-mb8 d-bar4
-        "
-      >
-        <div class="d-fl-grow1">
-          <div>
-            <div class="d-label d-fs-14">
-              <label for="style-select">Style</label>
-            </div>
-            <div class="d-select d-select--sm">
-              <select
-                id="style-select"
-                v-model="kind"
-                class="d-select__input"
-              >
-                <option
-                  id="style-select-base"
-                  name="style-select"
-                  value="base"
-                  selected
-                >
-                  Base
-                </option>
-                <option
-                  id="style-select-error"
-                  name="style-select"
-                  value="error"
-                >
-                  Error
-                </option>
-                <option
-                  id="style-select-info"
-                  name="style-select"
-                  value="info"
-                >
-                  Informational
-                </option>
-                <option
-                  id="style-select-success"
-                  name="style-select"
-                  value="success"
-                >
-                  Success
-                </option>
-                <option
-                  id="style-select-warning"
-                  name="style-select"
-                  value="warning"
-                >
-                  Warning
-                </option>
-              </select>
-            </div>
-          </div>
-        </div>
-        <label>
-          <div class="d-checkbox-group">
-            <div class="d-checkbox__input">
-              <input
-                v-model="important"
-                type="checkbox"
-                class="d-checkbox"
-              >
-            </div>
-            <span class="d-checkbox__copy d-checkbox__label d-mb4">
-              Important?
-            </span>
-          </div>
-        </label>
-        <button
-          class="d-btn d-btn--outlined d-btn--sm"
-          @click="toggleExample"
-        >
-          Toggle example
-        </button>
-      </div>
-    </div>
-  </div>
   <aside class="d-toast-wrapper">
-    <div
-      class="d-toast"
-      :class="[toastClass, { 'd-toast--important': important }]"
-      role="status"
-      :aria-hidden="!showToast"
+    <dt-toast
+      :title="title"
+      :show="show"
+      :important="important"
+      :kind="kind"
+      :close-button-props="{ ariaLabel: 'Close button' }"
+      @close="$emit('close')"
     >
-      <div class="d-toast__dialog">
-        <div class="d-notice__icon">
-          <dt-icon
-            v-show="kind === 'base'"
-            name="bell"
-            size="400"
-          />
-          <dt-icon
-            v-show="kind === 'error'"
-            name="alert-circle"
-            size="400"
-          />
-          <dt-icon
-            v-show="kind === 'info'"
-            name="info"
-            size="400"
-          />
-          <dt-icon
-            v-show="kind === 'success'"
-            name="check-circle"
-            size="400"
-          />
-          <dt-icon
-            v-show="kind === 'warning'"
-            name="alert-triangle"
-            size="400"
-          />
-        </div>
-        <div class="d-notice__content">
-          <h2 class="d-notice__title">
-            Title
-          </h2>
-          <p class="d-notice__message">
-            Message body with
-            <a
-              href="#"
-              class="d-link"
-              :class="shouldBeInverted ? 'd-link--inverted' : 'd-link--muted'"
-            >
-              a link.
-            </a>
-          </p>
-        </div>
-        <div class="d-notice__actions">
-          <button
-            type="button"
-            class="d-btn d-btn--sm d-btn--outlined"
-            :class="shouldBeInverted ? 'd-btn--inverted' : 'd-btn--muted'"
-          >
-            Action
-          </button>
-          <button
-            type="button"
-            class="d-btn d-btn--sm d-btn--circle"
-            :class="shouldBeInverted ? 'd-btn--inverted' : 'd-btn--muted'"
-            aria-label="Close"
-            @click="toggleExample"
-          >
-            <span class="d-btn__icon">
-              <dt-icon
-                name="close"
-                size="200"
-              />
-            </span>
-          </button>
-        </div>
-      </div>
-    </div>
+      Message body with
+      <dt-link
+        :class="linkClass"
+      >
+        a link
+      </dt-link>
+      <template #action>
+        <dt-button
+          size="sm"
+          importance="outlined"
+          :kind="important ? 'inverted' : 'muted'"
+          :class="{ 'd-bc-neutral-black': important && kind === 'warning' }"
+        >
+          Action
+        </dt-button>
+      </template>
+    </dt-toast>
   </aside>
 </template>
 
 <script>
+import { DtButton } from '@dialpad/dialtone-vue';
+
 export default {
   name: 'ExampleToast',
-  data () {
-    return {
-      kind: 'base',
-      showToast: false,
-      important: false,
-    };
+  components: { DtButton },
+  props: {
+    title: {
+      type: String,
+      default: '',
+    },
+
+    show: {
+      type: Boolean,
+      default: false,
+    },
+
+    important: {
+      type: Boolean,
+      default: false,
+    },
+
+    kind: {
+      type: String,
+      default: 'base',
+    },
   },
 
+  emits: ['close'],
   computed: {
-    toastClass () {
-      return 'd-toast--' + this.kind;
-    },
-
-    shouldBeInverted () {
-      return this.important && !['warning'].includes(this.kind);
-    },
-  },
-
-  methods: {
-    toggleExample () {
-      this.showToast = !this.showToast;
+    linkClass () {
+      if (this.kind === 'warning' && this.important) return 'd-fc-neutral-black';
+      return this.important ? 'd-fc-primary-inverted' : 'd-fc-primary';
     },
   },
 };
 </script>
-
-<style lang="less" scoped>
-  .d-toast-wrapper {
-    top: var(--dt-space-730);
-  }
-</style>

--- a/docs/components/banner.md
+++ b/docs/components/banner.md
@@ -50,27 +50,20 @@ Banners are a type of notice and so you can use the following [Notice](notice.md
 </dt-banner>
 
 ```html
-<aside class="d-banner" role="alert" aria-hidden="false">
+<aside class="d-banner d-banner--base" role="alert" aria-hidden="false">
   <div class="d-banner__dialog" role="alertdialog" aria-labelledy="info-alert-title" aria-describedby="info-alert-desc">
-    <div class="d-notice__icon">
-      <IconInfo />
-    </div>
+    <div class="d-notice__icon">...</div>
     <div class="d-notice__content">
-      <h2 class="d-notice__title" id="info-alert-title">Optional title</h2>
-      <p class="d-notice__message" id="info-alert-desc">Message body with <a href="#">a link.</a></p>
+      <h2 class="d-notice__title" id="info-alert-title">...</h2>
+      <p class="d-notice__message" id="info-alert-desc">...</p>
     </div>
-    <div class="d-notice__actions">
-      <button type="button" class="d-btn d-btn--sm d-btn--outlined d-btn--muted">Action</button>
-      <button type="button" class="d-btn d-btn--sm d-btn--circle d-btn--muted js-example-notice-close" aria-label="Close">
-        <span class="d-btn__icon"><IconClose /></span>
-      </button>
-    </div>
+    <div class="d-notice__actions">...</div>
 </aside>
 
-<aside class="d-banner d-banner--error" role="alert" aria-hidden="false">…</aside>
-<aside class="d-banner d-banner--info" role="alert" aria-hidden="false">…</aside>
-<aside class="d-banner d-banner--success" role="alert" aria-hidden="false">…</aside>
-<aside class="d-banner d-banner--warning" role="alert" aria-hidden="false">…</aside>
+<aside class="d-banner d-banner--error" role="alert" aria-hidden="false">...</aside>
+<aside class="d-banner d-banner--info" role="alert" aria-hidden="false">...</aside>
+<aside class="d-banner d-banner--success" role="alert" aria-hidden="false">...</aside>
+<aside class="d-banner d-banner--warning" role="alert" aria-hidden="false">...</aside>
 ```
 
 ## Vue API

--- a/docs/components/notice.md
+++ b/docs/components/notice.md
@@ -9,7 +9,7 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 ---
 
 <code-well-header bgclass="d-bgc-primary">
-  <example-notice kind="base" role="status" />
+  <example-notice kind="base" title="Base title (optional)" />
 </code-well-header>
 
 <!-- <component-combinator component-name="DtNotice" /> -->
@@ -25,34 +25,27 @@ A notice delivers informational and assistive messages that inform the user abou
 Used in most scenarios when the message should be noticeable but not dominate.
 
 <code-well-header bgclass="d-bgc-primary">
-  <example-notice kind="base" role="status" />
-  <example-notice kind="error" role="status" />
-  <example-notice kind="info" role="status" />
-  <example-notice kind="success" role="status" />
-  <example-notice kind="warning" role="status" />
+  <example-notice kind="base" title="Base title (optional)" />
+  <example-notice kind="error" title="Error title (optional)" />
+  <example-notice kind="info" title="Info title (optional)" />
+  <example-notice kind="success" title="Success title (optional)" />
+  <example-notice kind="warning" title="Warning title (optional)" />
 </code-well-header>
 
 ```html
 <aside class="d-notice d-notice--base" role="status" aria-hidden="false">
-  <div class="d-notice__icon">
-    <IconInfo />
-  </div>
+  <div class="d-notice__icon">...</div>
   <div class="d-notice__content">
-    <h2 class="d-notice__title">Optional title</h2>
-    <p class="d-notice__message">Message body with <a href="#" class="d-link d-link--muted">a link.</a></p>
+    <h2 class="d-notice__title">...</h2>
+    <p class="d-notice__message">...</p>
   </div>
-  <div class="d-notice__actions">
-    <button type="button" class="d-btn d-btn--sm d-btn--outlined d-btn--muted">Action</button>
-    <button type="button" class="d-btn d-btn--sm d-btn--circle d-btn--muted js-example-notice-close" aria-label="Close">
-      <span class="d-btn__icon"><IconClose /></span>
-    </button>
-  </div>
+  <div class="d-notice__actions">...</div>
 </aside>
 
-<aside class="d-notice d-notice--error" role="status" aria-hidden="false">…</aside>
-<aside class="d-notice d-notice--info" role="status" aria-hidden="false">…</aside>
-<aside class="d-notice d-notice--success" role="status" aria-hidden="false">…</aside>
-<aside class="d-notice d-notice--warning" role="status" aria-hidden="false">…</aside>
+<aside class="d-notice d-notice--error" role="status" aria-hidden="false">...</aside>
+<aside class="d-notice d-notice--info" role="status" aria-hidden="false">...</aside>
+<aside class="d-notice d-notice--success" role="status" aria-hidden="false">...</aside>
+<aside class="d-notice d-notice--warning" role="status" aria-hidden="false">...</aside>
 ```
 
 ### Important
@@ -60,28 +53,21 @@ Used in most scenarios when the message should be noticeable but not dominate.
 Used occasionally in scenarios when the message needs to dominate.
 
 <code-well-header>
-  <example-notice kind="base" role="status" important />
-  <example-notice kind="error" role="status" important />
-  <example-notice kind="info" role="status" important />
-  <example-notice kind="success" role="status" important />
-  <example-notice kind="warning" role="status" important />
+  <example-notice important kind="base" title="Base title (optional)" />
+  <example-notice important kind="error" title="Error title (optional)" />
+  <example-notice important kind="info" title="Info title (optional)" />
+  <example-notice important kind="success" title="Success title (optional)" />
+  <example-notice important kind="warning" title="Warning title (optional)" />
 </code-well-header>
 
 ```html
 <aside class="d-notice d-notice--base d-notice--important" role="alert" aria-hidden="false">
-  <div class="d-notice__icon">
-    <IconInfo />
-  </div>
+  <div class="d-notice__icon">...</div>
   <div class="d-notice__content">
-    <h2 class="d-notice__title">Optional title</h2>
-    <p class="d-notice__message">Message body with <a href="#" class="d-link d-link--inverted">a link.</a></p>
+    <h2 class="d-notice__title">...</h2>
+    <p class="d-notice__message">...</p>
   </div>
-  <div class="d-notice__actions">
-    <button type="button" class="d-btn d-btn--sm d-btn--outlined d-btn--inverted">Action</button>
-    <button type="button" class="d-btn d-btn--sm d-btn--circle d-btn--inverted js-example-notice-close" aria-label="Close">
-      <span class="d-btn__icon"><IconClose /></span>
-    </button>
-  </div>
+  <div class="d-notice__actions">...</div>
 </aside>
 
 <aside class="d-notice d-notice--error d-notice--important" role="alert" aria-hidden="false">…</aside>

--- a/docs/components/toast.md
+++ b/docs/components/toast.md
@@ -8,28 +8,60 @@ storybook: https://vue.dialpad.design/?path=/story/components-toast--default
 figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components-7?node-id=8919%3A21834&viewport=-496%2C632%2C0.48&t=xHutRjwo1o5zMTgT-11
 ---
 
+<code-well-header>
+  <div class="d-d-flex d-jc-center">
+    <example-toast show title="Title" class="d-ps-relative d-zi-base d-t0" />
+  </div>
+</code-well-header>
+
 <!-- <component-combinator component-name="DtToast" /> -->
 
 ## Variants and examples
 
-<example-toast />
+<code-well-header>
+    <div class="d-d-flex d-w100p d-flow8 d-ai-flex-end">
+        <div class="d-fl-grow1">
+            <dt-select-menu label="Style" :options="toastOptions" @change="changeKind" />
+        </div>
+        <dt-checkbox value="important" @input="toggleImportant">Important</dt-checkbox>
+        <dt-button @click="toggleToast">Toggle Example</dt-button>
+    </div>
+</code-well-header>
+
+<example-toast
+  class="d-zi-notification"
+  :show="showToast"
+  title="Title"
+  :important="important"
+  :kind="selectedKind"
+  @close="toggleToast"
+/>
 
 ```html
 <aside class="d-toast-wrapper">
-  <div class="d-toast" role="status" aria-hidden="true">
+  <div class="d-toast d-toast--base" role="status" aria-hidden="true">
     <div class="d-toast__dialog">
       <div class="d-notice__icon">...</div>
       <div class="d-notice__content">
         <h2 class="d-notice__title">...</h2>
         <p class="d-notice__message">...</p>
       </div>
-      <div class="d-notice__actions">
-        <button type="button" class="d-btn d-btn--sm d-btn--circle d-btn--muted" aria-label="Close">
-          <span class="d-btn__icon"><icon-close /></span>
-        </button>
-      </div>
+      <div class="d-notice__actions">...</div>
     </div>
   </div>
+</aside>
+
+<aside class="d-toast-wrapper">
+  <div class="d-toast d-toast--error" role="status" aria-hidden="true">...</div>
+</aside>
+<aside class="d-toast-wrapper">
+  <div class="d-toast d-toast--info" role="status" aria-hidden="true">...</div>
+</aside>
+<aside class="d-toast-wrapper">
+  <div class="d-toast d-toast--success" role="status" aria-hidden="true">...</div>
+</aside>
+<aside class="d-toast-wrapper">
+  <div class="d-toast d-toast--warning" role="status" aria-hidden="true">...</div>
 </aside>
 ```
 
@@ -61,5 +93,31 @@ means the toast will be read out after what's currently being has finished.
 <component-accessible-table component-name="toast" />
 
 <script setup>
-  import ExampleToast from '@exampleComponents/ExampleToast.vue';
+import ExampleToast from '@exampleComponents/ExampleToast.vue';
+import { ref } from 'vue';
+
+const toastOptions = [
+  { value: 'base', label: 'Base' },
+  { value: 'error', label: 'Error' },
+  { value: 'info', label: 'Info' },
+  { value: 'success', label: 'Success' },
+  { value: 'warning', label: 'Warning' },
+];
+const showToast = ref(false);
+const important = ref(false);
+const pinned = ref(false);
+const selectedKind = ref('base');
+
+function toggleToast () {
+  showToast.value = !showToast.value;
+}
+function toggleImportant () {
+  important.value = !important.value;
+}
+function togglePinned () {
+  pinned.value = !pinned.value;
+}
+function changeKind (kind) {
+  selectedKind.value = kind;
+}
 </script>

--- a/lib/build/less/components/banner.less
+++ b/lib/build/less/components/banner.less
@@ -13,11 +13,7 @@
 .d-banner {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
-    --banner-color-background: var(--dt-color-surface-secondary);
-    --banner-color-text: var(--dt-color-foreground-primary);
-    --notice-color-icon: var(--banner-color-text);
     --banner-color-border: var(--dt-color-border-subtle);
-    --banner-font-size: var(--dt-font-size-200);
     --banner-line-height: var(--dt-font-line-height-200);
     --banner-dialog-padding-y: var(--dt-space-400);
     --banner-dialog-padding-x: var(--dt-space-500);
@@ -27,22 +23,15 @@
     right: 0;
     left: 0;
     z-index: var(--zi-navigation-fixed);
-    display: flex;
-    box-sizing: border-box;
-    width: 100%;
-    min-height: var(--dt-size-650); // 48
-    color: var(--banner-color-text);
-    font-size: var(--banner-font-size);
+    max-width: 100%;
+    min-height: var(--dt-size-6height50); // 48
+    padding: 0;
     line-height: var(--banner-line-height);
-    background-color: var(--banner-color-background);
     border-bottom: 1px solid var(--banner-color-border);
     border-radius: 0;
     box-shadow: none;
 
-    // If you want to hide and reveal the banner
     &[aria-hidden='true'] {
-        --topbar-height: var(--dt-size-650);
-
         visibility: hidden;
         opacity: 0;
     }
@@ -52,15 +41,10 @@
         opacity: 1;
     }
 
-    //  If you want to put the banner above the topbar
-    &.d-banner--pinned {
+    &--pinned {
         z-index: calc(~'var(--zi-navigation-fixed) + 1');
         transform: translate3d(0, 0, 0);
     }
-}
-
-.d-banner--transform {
-    transform: translate3d(0, var(--topbar-height), 0);
 }
 
 //  ============================================================================
@@ -81,12 +65,6 @@
         gap: var(--dt-space-300);
         align-items: baseline;
     }
-
-    .d-notice__actions {
-      button {
-        color: var(--banner-color-text);
-      }
-    }
 }
 
 //  ============================================================================
@@ -95,56 +73,5 @@
 //  $$  DEFAULT IMPORTANT
 //  ----------------------------------------------------------------------------
 .d-banner.d-banner--important {
-    --banner-color-background: var(--dt-color-surface-strong);
-    --banner-color-text: var(--dt-color-foreground-primary-inverted);
-    --notice-color-icon: var(--banner-color-text);
     --banner-color-border: transparent;
-}
-
-//  $$  ERROR
-//  ----------------------------------------------------------------------------
-.d-banner--error {
-    --banner-color-background: var(--dt-color-surface-critical);
-
-    &.d-banner--important {
-        --banner-color-background: var(--dt-color-surface-critical-strong);
-        --banner-color-text: var(--dt-color-foreground-primary-inverted);
-    }
-}
-
-//  $$  INFO
-//  ----------------------------------------------------------------------------
-.d-banner--info {
-    --banner-color-background: var(--dt-color-surface-info);
-
-    &.d-banner--important {
-        --banner-color-background: var(--dt-color-surface-info-strong);
-        --banner-color-text: var(--dt-color-foreground-primary-inverted);
-    }
-}
-
-//  $$  SUCCESS
-//  ----------------------------------------------------------------------------
-.d-banner--success {
-    --banner-color-background: var(--dt-color-surface-success);
-
-    &.d-banner--important {
-        --banner-color-background: var(--dt-color-surface-success-strong);
-        --banner-color-text: var(--dt-color-foreground-primary-inverted);
-    }
-}
-
-//  $$  WARNING
-//  ----------------------------------------------------------------------------
-.d-banner--warning {
-    --banner-color-background: var(--dt-color-surface-warning);
-
-    &.d-banner--important {
-        --banner-color-background: var(--dt-color-surface-warning-strong);
-        --banner-color-text: var(--dt-color-foreground-primary);
-
-      .dialtone-theme-dark & {
-        --banner-color-text: var(--dt-color-foreground-primary-inverted);
-      }
-    }
 }

--- a/lib/build/less/components/banner.less
+++ b/lib/build/less/components/banner.less
@@ -24,7 +24,7 @@
     left: 0;
     z-index: var(--zi-navigation-fixed);
     max-width: 100%;
-    min-height: var(--dt-size-6height50); // 48
+    min-height: var(--dt-size-650); // 48
     padding: 0;
     line-height: var(--banner-line-height);
     border-bottom: 1px solid var(--banner-color-border);

--- a/lib/build/less/components/notice.less
+++ b/lib/build/less/components/notice.less
@@ -10,7 +10,9 @@
 //  $   BASE WRAPPER
 //  ----------------------------------------------------------------------------
 
-.d-notice {
+.d-notice,
+.d-banner,
+.d-toast {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
     --notice-color-background: var(--dt-color-surface-secondary);
@@ -37,12 +39,6 @@
     background-color: var(--notice-color-background);
     border-radius: var(--notice-border-radius);
     box-shadow: var(--notice-box-shadow);
-
-    .d-toast & {
-        max-width: var(--dt-size-975);
-        box-shadow: var(--dt-shadow-small);
-        pointer-events: all;
-    }
 }
 
 //  ============================================================================
@@ -64,6 +60,10 @@
     flex: 0 auto;
     gap: var(--dt-space-400);
     align-items: center;
+
+    button {
+        color: var(--notice-color-text);
+    }
 }
 
 //  $$  ICON
@@ -98,11 +98,13 @@
 //  ============================================================================
 //  $$  DEFAULT IMPORTANT
 //  ----------------------------------------------------------------------------
-.d-notice.d-notice--important {
+.d-notice.d-notice--important,
+.d-banner.d-banner--important,
+.d-toast.d-toast--important {
     --notice-color-background: var(--dt-color-surface-strong);
     --notice-color-text: var(--dt-color-foreground-primary-inverted);
+    --notice-color-icon: var(--notice-color-text);
     --notice-color-shadow: transparent;
-    --notice-color-icon: var(--dt-color-foreground-primary-inverted);
 }
 
 //  $$  ERROR
@@ -117,7 +119,6 @@
     &.d-banner--important,
     &.d-toast--important {
         --notice-color-background: var(--dt-color-surface-critical-strong);
-        --notice-color-text: var(--dt-color-foreground-primary-inverted);
     }
 }
 
@@ -164,7 +165,7 @@
     &.d-notice--important,
     &.d-banner--important,
     &.d-toast--important {
-        --notice-color-background: var(--dt-color-gold-200);
-        --notice-color-text: var(--dt-color-foreground-primary);
+        --notice-color-background: var(--dt-color-surface-warning-strong);
+        --notice-color-text: var(--dt-color-neutral-black);
     }
 }

--- a/lib/build/less/components/toast.less
+++ b/lib/build/less/components/toast.less
@@ -25,28 +25,15 @@
 .d-toast {
     //  Component CSS Vars
     //  ------------------------------------------------------------------------
-    --toast-color-background: var(--dt-color-surface-secondary);
-    --toast-color-text: var(--dt-color-foreground-primary);
-    --notice-color-icon: var(--toast-color-text);
-    --toast-color-shadow: hsla(var(--dt-color-black-900-hsl) ~' / ' 15%);
-    --toast-padding: var(--dt-space-500);
-    --toast-border-radius: var(--dt-size-400);
+    --toast-color-shadow: hsla(var(--dt-color-black-900-hsl) / 0.15);
     --toast-box-shadow: 0 0 0 var(--dt-size-100) var(--toast-color-shadow) inset, var(--dt-shadow-medium);
-    --toast-font-size: var(--dt-font-size-200);
-    --toast-line-height: var(--dt-font-line-height-300);
 
     z-index: var(--zi-notification);
-    box-sizing: border-box;
-    width: 100%;
-    max-width: var(--dt-size-1020); // 628
-    padding: var(--toast-padding);
-    color: var(--toast-color-text);
-    font-size: var(--toast-font-size);
-    line-height: var(--toast-line-height);
+    display: block;
+    max-width: var(--dt-size-975);
     word-break: normal;
-    background-color: var(--toast-color-background);
-    border-radius: var(--toast-border-radius);
     box-shadow: var(--toast-box-shadow);
+    pointer-events: all;
 
     //  If there's a link in a toast, break the url so it wraps
     > a {
@@ -73,67 +60,8 @@
     display: flex;
     align-items: center;
 
-    .d-notice__content {
-        margin-right: var(--dt-space-500); // 16
-    }
-
     .d-notice__actions {
         margin-left: var(--dt-space-600); // 32
-    }
-}
-
-//  ============================================================================
-//  $   STYLES
-//  ============================================================================
-//  $$  DEFAULT IMPORTANT
-//  ----------------------------------------------------------------------------
-.d-toast.d-toast--important {
-    --toast-color-background: var(--dt-color-surface-strong);
-    --toast-color-text: var(--dt-color-foreground-primary-inverted);
-    --notice-color-icon: var(--toast-color-text);
-  }
-
-//  $$  ERROR
-//  ----------------------------------------------------------------------------
-.d-toast--error {
-    --toast-color-background: var(--dt-color-surface-critical);
-
-    &.d-toast--important {
-      --toast-color-background: var(--dt-color-red-400);
-      --toast-color-text: var(--dt-color-foreground-primary-inverted);
-    }
-}
-
-//  $$  INFO
-//  ----------------------------------------------------------------------------
-.d-toast--info {
-    --toast-color-background: var(--dt-color-surface-info);
-
-    &.d-toast--important {
-        --toast-color-background: var(--dt-color-surface-info-strong);
-        --toast-color-text: var(--dt-color-foreground-primary-inverted);
-    }
-}
-
-//  $$  SUCCESS
-//  ----------------------------------------------------------------------------
-.d-toast--success {
-    --toast-color-background: var(--dt-color-surface-success);
-
-    &.d-toast--important {
-        --toast-color-background: var(--dt-color-surface-success-strong);
-        --toast-color-text: var(--dt-color-foreground-primary-inverted);
-    }
-}
-
-//  $$  WARNING
-//  ----------------------------------------------------------------------------
-.d-toast--warning {
-    --toast-color-background: var(--dt-color-surface-warning);
-
-    &.d-toast--important {
-        --toast-color-background: var(--dt-color-surface-warning-strong);
-        --toast-color-text: var(--dt-color-foreground-primary);
     }
 }
 

--- a/lib/build/less/dialtone.less
+++ b/lib/build/less/dialtone.less
@@ -13,7 +13,6 @@
 //  --  COMPONENTS
 @import 'components/avatar';
 @import 'components/badge';
-@import 'components/banner';
 @import 'components/breadcrumbs';
 @import 'components/button';
 @import 'components/card';
@@ -25,8 +24,9 @@
 @import 'components/link';
 @import 'components/list-group'; // Dialtone 5 shim
 @import 'components/modal';
-@import 'components/toast'; // Needs to come before Notice styles
 @import 'components/notice';
+@import 'components/toast';
+@import 'components/banner';
 @import 'components/popover';
 @import 'components/radio-checkbox';
 @import 'components/selects';


### PR DESCRIPTION
## Description

- Refactored Banner, Toast and Notice so most of the stylings come from Notice to avoid duplicating code.
This will potentially enhance maintainability as if you need to update one, just update in notice and all of them are updated.

- Updated documentation a bit and changed examples to use `dt-banner`, `dt-toast` and `dt-notice` respectively.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/VJ5pkHokJgV78qy70E/giphy.gif)
