### PR TITLE
docs: update dialtone usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@ Once installed, add the following line in your CSS/LESS file:
 @import "node_modules/@dialpad/dialtone/lib/dist/css/dialtone.css";
 ```
 
+And dialtone's theme class to the `<body>`
+
+**Light mode**
+```html
+<body class="dialtone-theme-light">...</body>
+```
+
+**Dark mode**
+```html
+<body class="dialtone-theme-dark">...</body>
+```
+
+It is important to add either of those classes in order to make dialtone work, as CSS variables
+definition change according to the selected mode (light, dark). 
+
+If the class is not added, the CSS variables aren't going to be defined.
+
 ## Building Dialtone locally
 
 To build Dialtone locally, visit our [installation instructions](https://dialpad.design/guides/getting-started/#build-dialtone-locally).

--- a/README.md
+++ b/README.md
@@ -2,35 +2,37 @@
 
 This is the home for Dialtone, Dialpad's design system. It includes the resources needed to create consistent, predictable interfaces that conform to Dialpad’s design principles, language, styles, and best practices.
 
-## Install Dialtone via NPM
+## Install Dialtone
 
-To add Dialtone into your project, you can install it via NPM:
-
+### Install it via NPM:
 ```
 npm install @dialpad/dialtone
 ```
 
-Once installed, add the following line in your CSS/LESS file:
+### Import dialtone:
+- CSS/LESS:
+```less
+@import "node_modules/@dialpad/dialtone/lib/dist/css/dialtone.min.css";
 ```
-@import "node_modules/@dialpad/dialtone/lib/dist/css/dialtone.css";
+- Javascript:
+```js
+import '@dialpad/dialtone/lib/dist/css/dialtone.min.css';
 ```
 
-And dialtone's theme class to the `<body>`
+### Add dialtone's theme class to the `<body>`
 
-**Light mode**
+- Light mode
 ```html
 <body class="dialtone-theme-light">...</body>
 ```
 
-**Dark mode**
+- Dark mode
 ```html
 <body class="dialtone-theme-dark">...</body>
 ```
 
-It is important to add either of those classes in order to make dialtone work, as CSS variables
-definition change according to the selected mode (light, dark). 
-
-If the class is not added, the CSS variables aren't going to be defined.
+This will define the Dialtone CSS variables for your desired theme. 
+It is required to do this for Dialtone to function.
 
 ## Building Dialtone locally
 


### PR DESCRIPTION
## Description

Updated dialtone usage documentation regarding the need of adding `dialtone-theme-light` or `dialtone-theme-dark` to the <body> in order for dialtone's CSS variables to work properly.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/Sk4KZ7guZRojzEGfD4/giphy.gif)
