### PR TITLE
fix(emoji-picker): category background

### DIFF
--- a/lib/build/less/components/emoji-picker.less
+++ b/lib/build/less/components/emoji-picker.less
@@ -136,7 +136,7 @@
     top: 0;
     width: 100%;
     padding-top: var(--dt-space-525);
-    background: var(--dt-color-surface-secondary);
+    background: var(--dt-color-surface-primary);
   }
 
   &__list {


### PR DESCRIPTION
## Description
Fixed token for category background in emoji picker component

Change:
`background: var(--dt-color-surface-secondary);` -> `background: var(--dt-color-surface-primary);`

Jira Ticket: [DLT-1210](https://dialpad.atlassian.net/browse/DLT-1210)

previous:
<img width="377" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/0b89421b-89c2-4254-bdd3-734d77d887ba">

now:
<img width="377" alt="image" src="https://github.com/dialpad/dialtone/assets/89984179/44b68e87-8395-4fea-bcdc-4c7ec0540cf9">



[DLT-1210]: https://dialpad.atlassian.net/browse/DLT-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ