### PR TITLE
feat: update dialtone tokens and tokens page

### DIFF
--- a/docs/_data/site-nav.json
+++ b/docs/_data/site-nav.json
@@ -35,12 +35,20 @@
           "link": "/tokens/typography.html"
         },
         {
+          "text": "Shadow",
+          "link": "/tokens/shadow.html"
+        },
+        {
           "text": "Sizing",
           "link": "/tokens/sizing.html"
         },
         {
           "text": "Spacing",
           "link": "/tokens/spacing.html"
+        },
+        {
+          "text": "Component",
+          "link": "/tokens/component.html"
         }
       ]
     }

--- a/docs/tokens/component.md
+++ b/docs/tokens/component.md
@@ -1,0 +1,5 @@
+---
+title: Component Tokens
+---
+
+<token-table category="component" />

--- a/docs/tokens/shadow.md
+++ b/docs/tokens/shadow.md
@@ -1,0 +1,5 @@
+---
+title: Shadow Tokens
+---
+
+<token-table category="shadow" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@commitlint/config-conventional": "^17.6.6",
         "@dialpad/conventional-changelog-angular": "^1.1.1",
         "@dialpad/dialtone-combinator": "^0.3.1",
-        "@dialpad/dialtone-tokens": "^1.22.0",
+        "@dialpad/dialtone-tokens": "^1.23.1",
         "@dialpad/dialtone-vue": "3.82.2",
         "@dialpad/postcss-responsive-variations": "^1.1.5",
         "@dialpad/semantic-release-changelog-json": "^1.0.0",
@@ -1518,9 +1518,9 @@
       }
     },
     "node_modules/@dialpad/dialtone-tokens": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-tokens/-/dialtone-tokens-1.22.0.tgz",
-      "integrity": "sha512-bOEmqbIKO/8mdT3MXgTw5ivftmwLOHpaVn9pPSSZJ4MmwahSk+jJD1sBTdGFx84YtlT2MPHLofWEu+th9GI6yw==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-tokens/-/dialtone-tokens-1.23.1.tgz",
+      "integrity": "sha512-WSLYrxSyA06TOL0owcf+N4S3St8ODm1AFlNk07Z6qsArXdrX+6VKgEhcKnkODiUsjVelNQrGfeZcEqdY4clDSw==",
       "dev": true
     },
     "node_modules/@dialpad/dialtone-vue": {
@@ -39910,9 +39910,9 @@
       "requires": {}
     },
     "@dialpad/dialtone-tokens": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-tokens/-/dialtone-tokens-1.22.0.tgz",
-      "integrity": "sha512-bOEmqbIKO/8mdT3MXgTw5ivftmwLOHpaVn9pPSSZJ4MmwahSk+jJD1sBTdGFx84YtlT2MPHLofWEu+th9GI6yw==",
+      "version": "1.23.1",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-tokens/-/dialtone-tokens-1.23.1.tgz",
+      "integrity": "sha512-WSLYrxSyA06TOL0owcf+N4S3St8ODm1AFlNk07Z6qsArXdrX+6VKgEhcKnkODiUsjVelNQrGfeZcEqdY4clDSw==",
       "dev": true
     },
     "@dialpad/dialtone-vue": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@commitlint/config-conventional": "^17.6.6",
     "@dialpad/conventional-changelog-angular": "^1.1.1",
     "@dialpad/dialtone-combinator": "^0.3.1",
-    "@dialpad/dialtone-tokens": "^1.22.0",
+    "@dialpad/dialtone-tokens": "^1.23.1",
     "@dialpad/dialtone-vue": "3.82.2",
     "@dialpad/postcss-responsive-variations": "^1.1.5",
     "@dialpad/semantic-release-changelog-json": "^1.0.0",


### PR DESCRIPTION
## Description
Updated dialtone tokens to the latest version using sd-transforms. Also updated the tokens page on dialpad.design to have "category groups" instead of just a single category name, and added additional categories that were not displaying on the tokens page at all before. Also added a theme toggle as previously it was only showing dark mode tokens in the documentation which didn't make any sense.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/W2b8JkhIwnVH7Sr1zl/giphy.gif)
