### PR TITLE
docs(algolia-search): apply DT Design Language

### DIFF
--- a/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -24,6 +24,7 @@
 //  ============================================================================
 //      [1]     Universally set border-box
 //  ----------------------------------------------------------------------------
+
 * {
   &,
   &::before,
@@ -38,11 +39,214 @@ html {
 }
 
 //  ============================================================================
-//  $   SEARCH BUTTON
-//      Override search button with dialtone styles
+//  $   SEARCH (Algolia)
+//      Override
 //  ----------------------------------------------------------------------------
-a.router-link-active {
-  font-weight: var(--dt-font-weight-semi-bold);
+html body {
+
+  --docsearch-primary-color: var(--dt-color-brand-purple);
+  --docsearch-text-color: var(--dt-color-foreground-primary);
+  --docsearch-spacing: var(--dt-space-550);
+  // --docsearch-icon-stroke-width
+  --docsearch-highlight-color: var(--docsearch-primary-color);
+  --docsearch-muted-color: var(--dt-color-foreground-tertiary);
+  --docsearch-container-background: var(--dt-color-surface-backdrop);
+  // --docsearch-logo-color
+  --docsearch-modal-width: var(--dt-size-1000);
+  --docsearch-modal-height: var(--dt-size-1000);
+  --docsearch-modal-background: var(--dt-color-surface-secondary);
+  --docsearch-modal-shadow: var(--dt-shadow-large);
+  --docsearch-searchbox-height: 40px;
+  // --docsearch-searchbox-background
+  --docsearch-searchbox-focus-background: var(--dt-inputs-color-background-default);
+  --docsearch-searchbox-shadow: inset 0 0 0 var(--dt-size-border-150) var(--dt-inputs-color-border-default);
+  --docsearch-hit-height: var(--dt-size-650);
+  --docsearch-hit-color: var(--dt-color-foreground-tertiary);
+  --docsearch-hit-active-color: var(--dt-color-neutral-white);
+  --docsearch-hit-background: var(--dt-color-surface-primary);
+  --docsearch-hit-shadow: inset 0 0 0 1px var(--dt-color-border-subtle);
+  --docsearch-key-gradient: linear-gradient(-225deg,var(--dt-color-surface-primary),var(--dt-color-surface-secondary));
+  --docsearch-key-shadow: inset 0 0 0 1px var(--dt-color-border-default);
+  --docsearch-footer-height: var(--dt-size-650);
+  --docsearch-footer-background: var(--dt-color-surface-primary);
+  --docsearch-footer-shadow: 0 -1px 0 0 var(--dt-color-border-subtle),0 -1px 3px 0 rgba(0,0,0,.2);
+
+  .DocSearch-Modal {
+    border-radius: var(--dt-size-radius-500);
+    background-clip: padding-box;
+    border: var(--dt-size-100) solid var(--dt-color-border-subtle);
+    border-radius: var(--dt-size-500);
+    box-shadow: var(--dt-shadow-large);
+    margin-top: 15vh;
+  }
+
+  .DocSearch-SearchBar {
+    padding-bottom: var(--dt-space-550);
+    border-bottom: 1px solid var(--dt-color-border-subtle);
+  }
+
+  .DocSearch-Form {
+    padding-left: var(--dt-space-450);
+    padding-right: var(--dt-space-450);
+    border-radius: var(--dt-size-radius-400);
+  }
+
+  .DocSearch-MagnifierLabel,
+  .DocSearch-Reset {
+    color: var(--dt-color-foreground-muted)
+  }
+
+  .DocSearch-Input {
+    font-size: var(--dt-font-size-300);
+    &:focus-visible {
+      box-shadow: none;
+    }
+    &::placeholder {
+      color: var(--dt-inputs-color-foreground-placeholder);
+    }
+  }
+
+  .DocSearch-LoadingIndicator svg,
+  .DocSearch-MagnifierLabel svg,
+  .DocSearch-Search-Icon {
+    width: var(--dt-icon-size-300) !important;
+    height: var(--dt-icon-size-300) !important;
+  }
+
+  .DocSearch-Reset:hover {
+    color: var(--dt-color-foreground-primary)
+  }
+
+  .DocSearch-Cancel {
+    // no overrides
+  }
+
+  .DocSearch-Dropdown {
+    // no overrides
+  }
+
+  .DocSearch-Dropdown-Container {
+    // no overrides
+  }
+
+  .DocSearch-Hits {
+    // no overrides
+  }
+
+  .DocSearch-Hit-source {
+    padding: var(--dt-space-400) var(--dt-space-300) 0;
+    font-size: var(--dt-font-size-200);
+    font-weight: var(--dt-font-weight-bold);
+    color: var(--dt-color-foreground-primary);
+  }
+
+  .DocSearch-Title {
+    font-size: var(--dt-font-size-300);
+    color: var(--dt-color-foreground-secondary);
+    strong {
+      color: var(--dt-color-foreground-primary);
+    }
+  }
+
+  .DocSearch-Hit-Container {
+    padding-right: 0;
+  }
+
+  .DocSearch-Hit {
+    padding-bottom: var(--dt-space-400);
+  }
+
+  .DocSearch-Hits mark {
+    background: var(--dt-color-surface-warning);
+    color: var(--dt-color-foreground-primary);
+    padding: var(--dt-space-200);
+  }
+
+  .DocSearch-Hit a {
+    border-radius: var(--dt-size-radius-300);
+    padding-left: var(--dt-space-450);
+    padding-right: var(--dt-space-450);
+  }
+
+  .DocSearch-Hit-action svg,
+  .DocSearch-Hit-icon svg {
+    width: var(--dt-icon-size-200);
+    height: var(--dt-icon-size-200);
+  }
+
+  .DocSearch-Hit-content-wrapper {
+    margin: 0 var(--dt-space-200);
+    line-height: var(--dt-font-line-height-200);
+    font-weight: var(--dt-font-weight-normal);
+  }
+
+  .DocSearch-Hit-action {
+    // no overrides
+  }
+
+  .DocSearch-Hit[aria-selected=true] mark {
+    color: var(--dt-color-foreground-primary) !important;
+    text-decoration: none;
+  }
+
+  .DocSearch-Hit-title {
+    font-size: var(--dt-font-size-200);
+  }
+
+  .DocSearch-Hit-path {
+    font-size: var(--dt-font-size-100);
+    color: var(--dt-color-foreground-muted);
+  }
+
+  .DocSearch-HitsFooter {
+    // no overrides
+  }
+
+  .DocSearch-Footer {
+    border-radius: 0 0 var(--dt-size-radius-500) var(--dt-size-radius-500);
+  }
+
+  .DocSearch-Logo {
+    // no overrides
+  }
+
+  .DocSearch-Logo svg {
+    filter: saturate(0) contrast(.25);
+  }
+
+  .DocSearch-Commands {
+    // no overrides
+  }
+
+  .DocSearch-Commands-Key {
+    border-radius: var(--dt-size-radius-300);
+  }
+
+  .DocSearch-Label {
+    font-size: var(--dt-font-size-100);
+  }
+
+  .DocSearch-Help {
+    color: var(--dt-color-foreground-secondary);
+  }
+
+  .DocSearch-NoResults {
+    font-size: var(--dt-font-size-200);
+    padding: var(--dt-space-600) 0;
+  }
+
+  .DocSearch-Help {
+    margin-top: var(--dt-space-400);
+    font-size: var(--dt-font-size-100);
+  }
+
+  .DocSearch-Prefill {
+    color: var(--dt-color-link-primary);
+  }
+
+  .DocSearch-NoResults-Prefill-List li {
+    list-style-type: none;
+  }
 }
 
 //  ============================================================================
@@ -73,7 +277,6 @@ a.router-link-active {
     }
   }
 }
-
 
 //  ============================================================================
 //  $   LAYOUT

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -111,8 +111,7 @@
     <dt-button
       importance="outlined"
       kind="muted"
-      class="d-ml16"
-      width="154px"
+      class="d-ml16 d-w164 d-bgc-secondary-opaque d-bc-subtle f:d-bc-default"
       @click="$emit('search')"
     >
       <template #icon>

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -111,7 +111,7 @@
     <dt-button
       importance="outlined"
       kind="muted"
-      class="d-ml16 d-w164 d-bgc-secondary-opaque d-bc-subtle f:d-bc-default"
+      class="d-ml16 d-w164 d-bgc-secondary-opaque d-bc-subtle h:d-bgc-moderate"
       @click="$emit('search')"
     >
       <template #icon>
@@ -120,7 +120,7 @@
           size="200"
         />
       </template>
-      <span class="d-fc-disabled">Search Dialtone</span>
+      <span class="d-fc-placeholder">Search Dialtone</span>
     </dt-button>
   </div>
 </template>


### PR DESCRIPTION
## Description

Search modal was wildly out-of-sync, and doesn't play well with dark theme. 

1. Reassigned Algolia's CSS variables to reference DT CSS Variables
2. Added CSS overrides to align to DT Design Language.

![image](https://github.com/dialpad/dialtone/assets/1165933/86479449-6964-4662-b68c-8633cf3b1c95)

## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).