### PR TITLE
fix(utility): fix box shadow indexing

### DIFF
--- a/postcss/dialtone-generators.js
+++ b/postcss/dialtone-generators.js
@@ -769,7 +769,8 @@ function boxShadows (declaration, mode = 'light') {
       const value = Array(times)
         .fill(undefined)
         .map((val, i) => {
-          return `var(${shadowVar}-${i}-x) var(${shadowVar}-${i}-y) var(${shadowVar}-${i}-blur) var(${shadowVar}-${i}-spread) var(${shadowVar}-${i}-color)`;
+          const shadowNumber = i + 1;
+          return `var(${shadowVar}-${shadowNumber}-x) var(${shadowVar}-${shadowNumber}-y) var(${shadowVar}-${shadowNumber}-blur) var(${shadowVar}-${shadowNumber}-spread) var(${shadowVar}-${shadowNumber}-color)`;
         }).join(', ');
 
       if (mode === 'light') {


### PR DESCRIPTION
## Description

Since sd-tranforms migration shadow tokens were indexed from 1 instead of 0. Updated the composition token generated here to match that.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/2UoF2nmLNgZYzMl82S/giphy.gif)
