### PR TITLE
docs: theme system icon

### DIFF
--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -1,7 +1,9 @@
 <!-- eslint-disable max-len -->
 <template>
-  <nav
-    class="d-d-flex d-flow4"
+  <dt-stack
+    as="nav"
+    direction="row"
+    gap="300"
     role="navigation"
   >
     <router-link
@@ -13,9 +15,9 @@
     >
       {{ link.text }}
     </router-link>
-  </nav>
-  <div class="d-d-flex d-flow4">
-    <div class="d-d-flex d-flow4">
+  </dt-stack>
+  <dt-stack direction="row" gap="300">
+    <dt-stack direction="row" gap="300">
       <dt-tooltip
         message="Github repository"
         placement="bottom"
@@ -82,7 +84,6 @@
                 .01-.1V6.57a.7.7 0 0 0 0-.09l-.01-.03z"
               />
             </svg>
-
           </a>
         </template>
       </dt-tooltip>
@@ -94,6 +95,7 @@
         </template>
         <template #anchor>
           <dt-button
+            circle
             importance="clear"
             kind="muted"
             @click="toggleTheme"
@@ -107,11 +109,11 @@
           </dt-button>
         </template>
       </dt-tooltip>
-    </div>
+    </dt-stack>
     <dt-button
       importance="outlined"
       kind="muted"
-      class="d-ml16 d-w164 d-bgc-secondary-opaque d-bc-subtle h:d-bgc-moderate"
+      class="d-ml8 d-w164 d-bgc-secondary-opaque d-bc-subtle h:d-bgc-moderate"
       @click="$emit('search')"
     >
       <template #icon>
@@ -122,7 +124,7 @@
       </template>
       <span class="d-fc-placeholder">Search Dialtone</span>
     </dt-button>
-  </div>
+  </dt-stack>
 </template>
 
 <script setup>

--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -149,7 +149,7 @@ const currentThemeIconName = computed(() => {
     case 'light':
       return 'sun';
     default:
-      return 'sparkle';
+      return 'circle-half-filled';
   }
 });
 const isActiveLink = (text) => {

--- a/docs/.vuepress/theme/components/SidebarItem.vue
+++ b/docs/.vuepress/theme/components/SidebarItem.vue
@@ -4,7 +4,11 @@
       class="d-headline-eyebrow d-fw-semibold d-pl12 d-pt8 d-pb8 d-fc-secondary"
       v-text="item.text"
     />
-    <ul class="d-pl0 d-mb16 d-stack2">
+    <dt-stack
+      as="ul"
+      class="d-pl0"
+      gap="200"
+    >
       <li
         v-for="subItem in subItems"
         :key="subItem.text"
@@ -41,7 +45,7 @@
           </dt-badge>
         </div>
       </li>
-    </ul>
+    </dt-stack>
   </li>
 </template>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.16.0",
       "license": "MIT",
       "dependencies": {
-        "@dialpad/dialtone-icons": "^2.2.0",
+        "@dialpad/dialtone-icons": "^3.2.0",
         "docopt": "^0.6.2"
       },
       "bin": {
@@ -1509,11 +1509,11 @@
       "dev": true
     },
     "node_modules/@dialpad/dialtone-icons": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-2.2.0.tgz",
-      "integrity": "sha512-5tS0o/0vHtBbQT9RXsjw7jinRQlIZO9+gzgPzsVTFcHhNOXQtcrzFKMhZltCce+1H2j9heGsuO78M+Po9HAt/w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-3.2.0.tgz",
+      "integrity": "sha512-zzvdJXitzmt5bfO/XnHULhqUuvD4cm57UU2xCbDTuEsqOAyYE4Qxa6DPbjHIOfDl92Rdb0N9R8+R35O4YjcbxQ==",
       "peerDependencies": {
-        "vue": ">=2.6"
+        "vue": ">=3.2"
       }
     },
     "node_modules/@dialpad/dialtone-tokens": {
@@ -1548,15 +1548,6 @@
       },
       "peerDependencies": {
         "@dialpad/dialtone": "^7.30.0 || ^8.12.1",
-        "vue": ">=3.2"
-      }
-    },
-    "node_modules/@dialpad/dialtone-vue/node_modules/@dialpad/dialtone-icons": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-3.2.0.tgz",
-      "integrity": "sha512-zzvdJXitzmt5bfO/XnHULhqUuvD4cm57UU2xCbDTuEsqOAyYE4Qxa6DPbjHIOfDl92Rdb0N9R8+R35O4YjcbxQ==",
-      "dev": true,
-      "peerDependencies": {
         "vue": ">=3.2"
       }
     },
@@ -39899,9 +39890,9 @@
       "dev": true
     },
     "@dialpad/dialtone-icons": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-2.2.0.tgz",
-      "integrity": "sha512-5tS0o/0vHtBbQT9RXsjw7jinRQlIZO9+gzgPzsVTFcHhNOXQtcrzFKMhZltCce+1H2j9heGsuO78M+Po9HAt/w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-3.2.0.tgz",
+      "integrity": "sha512-zzvdJXitzmt5bfO/XnHULhqUuvD4cm57UU2xCbDTuEsqOAyYE4Qxa6DPbjHIOfDl92Rdb0N9R8+R35O4YjcbxQ==",
       "requires": {}
     },
     "@dialpad/dialtone-tokens": {
@@ -39930,15 +39921,6 @@
         "emoji-regex": "^10.2.1",
         "emoji-toolkit": "^6.6.0",
         "tippy.js": "^6.3.7"
-      },
-      "dependencies": {
-        "@dialpad/dialtone-icons": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/@dialpad/dialtone-icons/-/dialtone-icons-3.2.0.tgz",
-          "integrity": "sha512-zzvdJXitzmt5bfO/XnHULhqUuvD4cm57UU2xCbDTuEsqOAyYE4Qxa6DPbjHIOfDl92Rdb0N9R8+R35O4YjcbxQ==",
-          "dev": true,
-          "requires": {}
-        }
       }
     },
     "@dialpad/postcss-responsive-variations": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@dialpad/dialtone-icons": "^2.2.0",
+    "@dialpad/dialtone-icons": "^3.2.0",
     "docopt": "^0.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

1. Changed from `sparkles` to `circle-half-filled`.
2. Also converted nav items to `DtStack`.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

![image](https://github.com/dialpad/dialtone/assets/1165933/b2f0b9e0-f32d-48d6-9beb-b771b53f8241)
