### PR TITLE
docs(modal): add banner variants

### DIFF
--- a/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -26,10 +26,13 @@
     @keydown.esc="closeModal"
   >
     <div
-      class="d-modal__banner"
-      :class="{ 'd-d-none': !showModalBanner }"
+      v-if="shouldShowModalBanner"
+      :class="[
+        'd-modal__banner',
+        bannerKindClass,
+      ]"
     >
-      This example banner sits at the top of the modal.
+      {{ bannerTitle || "This example banner sits at the top of the modal." }}
     </div>
     <div
       class="d-modal__dialog"
@@ -50,13 +53,27 @@
             {{ modalDescription.repeat(3) }}
           </template>
         </p>
-        <p class="d-mt16">
+        <p v-if="!bannerTitle" class="d-mt16">
           <a
             href="#"
             class="d-link"
             @click.prevent="openModalBanner"
           >Show me a modal banner</a>
         </p>
+        <dt-select-menu
+          v-if="bannerTitle"
+          label="Banner kind"
+          size="sm"
+          @change="changeBannerKind"
+        >
+          <option
+            v-for="option in bannerKinds"
+            :key="option"
+            :selected="option === selectedBannerKind"
+            :value="option"
+            v-text="option"
+          />
+        </dt-select-menu>
       </div>
       <footer class="d-modal__footer">
         <button
@@ -109,10 +126,24 @@ export default {
         return MODAL_KINDS.includes(_kind);
       },
     },
+
+    bannerKind: {
+      type: String,
+      default: 'warning',
+      validate (kind) {
+        return window.DIALTONE_CONSTANTS.NOTICE_KINDS.includes(kind);
+      },
+    },
+
+    bannerTitle: {
+      type: String,
+      default: '',
+    },
   },
 
   data () {
     return {
+      selectedBannerKind: this.bannerKind,
       showModal: false,
       showModalBanner: false,
       animateIn: false,
@@ -136,6 +167,18 @@ export default {
 
     isFixed () {
       return this.kind === 'fixed';
+    },
+
+    bannerKindClass () {
+      return window.DIALTONE_CONSTANTS.MODAL_BANNER_KINDS[this.selectedBannerKind];
+    },
+
+    shouldShowModalBanner () {
+      return this.showModalBanner || !!this.bannerTitle;
+    },
+
+    bannerKinds () {
+      return Object.keys(window.DIALTONE_CONSTANTS.MODAL_BANNER_KINDS);
     },
   },
 
@@ -168,6 +211,10 @@ export default {
       if (this.showModal) {
         this.focusTrappedTabPress(e, this.$refs.modal);
       }
+    },
+
+    changeBannerKind (kind) {
+      this.selectedBannerKind = kind;
     },
   },
 };

--- a/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -1,11 +1,29 @@
 <template>
-  <button
-    class="d-btn d-btn--primary d-btn--sm"
-    type="button"
-    @click="openModal"
-  >
-    Launch modal
-  </button>
+  <div class="d-d-flex d-ai-flex-end d-jc-space-between d-w100p">
+    <div class="d-w100p d-mr8">
+      <dt-select-menu
+        v-if="bannerTitle"
+        label="Kind of Banner"
+        size="sm"
+        @change="changeBannerKind"
+      >
+        <option
+          v-for="option in bannerKinds"
+          :key="option"
+          :selected="option === selectedBannerKind"
+          :value="option"
+          v-text="option"
+        />
+      </dt-select-menu>
+    </div>
+    <button
+      class="d-btn d-btn--primary d-btn--sm d-fl-none"
+      type="button"
+      @click="openModal"
+    >
+      Launch modal
+    </button>
+  </div>
   <aside
     id="modal-base"
     ref="modal"
@@ -60,20 +78,6 @@
             @click.prevent="openModalBanner"
           >Show me a modal banner</a>
         </p>
-        <dt-select-menu
-          v-if="bannerTitle"
-          label="Banner kind"
-          size="sm"
-          @change="changeBannerKind"
-        >
-          <option
-            v-for="option in bannerKinds"
-            :key="option"
-            :selected="option === selectedBannerKind"
-            :value="option"
-            v-text="option"
-          />
-        </dt-select-menu>
       </div>
       <footer class="d-modal__footer">
         <button

--- a/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -53,7 +53,7 @@
             {{ modalDescription.repeat(3) }}
           </template>
         </p>
-        <p v-if="!bannerTitle" class="d-mt16">
+        <p v-if="!hasBannerTitle" class="d-mt16">
           <a
             href="#"
             class="d-link"
@@ -172,8 +172,12 @@ export default {
       return window.DIALTONE_CONSTANTS.MODAL_BANNER_KINDS[this.selectedBannerKind];
     },
 
+    hasBannerTitle () {
+      return !!this.bannerTitle;
+    },
+
     shouldShowModalBanner () {
-      return this.showModalBanner || !!this.bannerTitle;
+      return this.showModalBanner || this.hasBannerTitle;
     },
 
     bannerKinds () {

--- a/docs/.vuepress/exampleComponents/ExampleModal.vue
+++ b/docs/.vuepress/exampleComponents/ExampleModal.vue
@@ -98,7 +98,10 @@
         @click="closeModal"
       >
         <span class="d-btn__icon">
-          <icon-close />
+          <dt-icon
+            name="close"
+            size="300"
+          />
         </span>
       </button>
     </div>
@@ -106,15 +109,11 @@
 </template>
 
 <script>
-import IconClose from '@svgIcons/IconClose.vue';
 import Modal from '@mixins/modal.js';
 const MODAL_KINDS = ['full-screen', 'danger', 'fixed', 'base'];
 
 export default {
   name: 'ExampleModal',
-  components: {
-    IconClose,
-  },
 
   mixins: [Modal],
 

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -171,6 +171,27 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
 </aside>
 ```
 
+### Different banner kinds
+
+<code-well-header>
+  <example-modal kind="default" bannerKind="success" bannerTitle="This banner can have different kinds." />
+</code-well-header>
+
+```html
+<aside class="d-modal d-modal--full" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
+  <div class="d-modal__banner d-modal__banner--success">...</div>
+  <div class="d-modal__dialog" role="document">
+    <h2 class="d-modal__header" id="modal-title">…</h2>
+    <p class="d-modal__content" id="modal-description">…</p>
+    <footer class="d-modal__footer">
+      <button class="d-btn" type="button">…</button>
+      <button class="d-btn d-btn--primary" type="button">…</button>
+    </footer>
+    <button href="#" class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close"><IconClose \></button>
+  </div>
+</aside>
+```
+
 ## Vue API
 
 <component-vue-api component-name="modal" />

--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -171,14 +171,16 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
 </aside>
 ```
 
-### Different banner kinds
+### Has Banner
+
+When there is a need of more context information regarding the content of the Modal
 
 <code-well-header>
   <example-modal kind="default" bannerKind="success" bannerTitle="This banner can have different kinds." />
 </code-well-header>
 
 ```html
-<aside class="d-modal d-modal--full" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
+<aside class="d-modal" id="modal-base" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-describedby="modal-description" aria-hidden="true">
   <div class="d-modal__banner d-modal__banner--success">...</div>
   <div class="d-modal__dialog" role="document">
     <h2 class="d-modal__header" id="modal-title">…</h2>
@@ -187,7 +189,7 @@ Although highly versatile, this doesn't mean modal dialogs are fit for all purpo
       <button class="d-btn" type="button">…</button>
       <button class="d-btn d-btn--primary" type="button">…</button>
     </footer>
-    <button href="#" class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close"><IconClose \></button>
+    <button href="#" class="d-modal__close d-btn d-btn--circle d-btn--lg" aria-label="Close"><IconClose /></button>
   </div>
 </aside>
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@dialpad/conventional-changelog-angular": "^1.1.1",
         "@dialpad/dialtone-combinator": "^0.3.1",
         "@dialpad/dialtone-tokens": "^1.23.1",
-        "@dialpad/dialtone-vue": "^3.86.0",
+        "@dialpad/dialtone-vue": "3.86.3",
         "@dialpad/postcss-responsive-variations": "^1.1.5",
         "@dialpad/semantic-release-changelog-json": "^1.0.0",
         "@docsearch/js": "^3.5.1",
@@ -1523,9 +1523,9 @@
       "dev": true
     },
     "node_modules/@dialpad/dialtone-vue": {
-      "version": "3.86.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.86.0.tgz",
-      "integrity": "sha512-C+b32oBc1sX0wV8laBcPwmD/F48qYHJ7b9pJPzOb1HYNtL9DKp+OiQkvLvA8SkvErZdk8wJcjO5J9RkNm0kBgw==",
+      "version": "3.86.3",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.86.3.tgz",
+      "integrity": "sha512-ijujM7j7H18kgZICqLl+HDDvuDkrC8n5rm4Zv3xbgrn2y5HrkfwsT6T2m9TctECDreGm+Yks+Uch9AIkDN46OQ==",
       "dev": true,
       "dependencies": {
         "@dialpad/dialtone-icons": "^3.2.0",
@@ -39902,9 +39902,9 @@
       "dev": true
     },
     "@dialpad/dialtone-vue": {
-      "version": "3.86.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.86.0.tgz",
-      "integrity": "sha512-C+b32oBc1sX0wV8laBcPwmD/F48qYHJ7b9pJPzOb1HYNtL9DKp+OiQkvLvA8SkvErZdk8wJcjO5J9RkNm0kBgw==",
+      "version": "3.86.3",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.86.3.tgz",
+      "integrity": "sha512-ijujM7j7H18kgZICqLl+HDDvuDkrC8n5rm4Zv3xbgrn2y5HrkfwsT6T2m9TctECDreGm+Yks+Uch9AIkDN46OQ==",
       "dev": true,
       "requires": {
         "@dialpad/dialtone-icons": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@dialpad/conventional-changelog-angular": "^1.1.1",
     "@dialpad/dialtone-combinator": "^0.3.1",
     "@dialpad/dialtone-tokens": "^1.23.1",
-    "@dialpad/dialtone-vue": "^3.86.0",
+    "@dialpad/dialtone-vue": "3.86.3",
     "@dialpad/postcss-responsive-variations": "^1.1.5",
     "@dialpad/semantic-release-changelog-json": "^1.0.0",
     "@docsearch/js": "^3.5.1",


### PR DESCRIPTION
## Description
https://dialpad.atlassian.net/browse/DLT-1025
Adds variants to the modal banner in the documentation.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)

![modal-with-banner](https://github.com/dialpad/dialtone/assets/24460973/06d820b4-de07-4f7d-b10d-29c68d066a42)
