### PR TITLE
fix(icon): prevent shrinking while on flex

### DIFF
--- a/lib/build/less/components/icon.less
+++ b/lib/build/less/components/icon.less
@@ -24,6 +24,7 @@
   --icon-size-800: calc(var(--icon-base-scale) * 6);
   --icon-size: var(--icon-size-500);
 
+  flex: none;
   width: var(--icon-size);
   height: var(--icon-size);
   fill: currentColor;


### PR DESCRIPTION
## Description

Added `flex: none` to prevent the icon from shrinking while on components like `<dt-stack>` or any custom CSS using `display: flex`.

## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/nbvgo0dl441Mv6JGcG/giphy.gif)
