### PR TITLE
feat(stack): add defaults for align prop

### DIFF
--- a/docs/_data/stack.json
+++ b/docs/_data/stack.json
@@ -129,16 +129,6 @@
       "class": "d-stack--gap-600",
       "applies": ".d-stack",
       "description": "Styles stack with gap 600 between elements."
-    },
-    {
-      "class": "d-stack--ai--center",
-      "applies": ".d-stack",
-      "description": "Aligns the items to the center."
-    },
-    {
-      "class": "d-stack--ai--flex-start",
-      "applies": ".d-stack",
-      "description": "Aligns the items to the start."
     }
   ]
 }

--- a/docs/_data/stack.json
+++ b/docs/_data/stack.json
@@ -129,6 +129,16 @@
       "class": "d-stack--gap-600",
       "applies": ".d-stack",
       "description": "Styles stack with gap 600 between elements."
+    },
+    {
+      "class": "d-stack--ai--center",
+      "applies": ".d-stack",
+      "description": "Aligns the items to the center."
+    },
+    {
+      "class": "d-stack--ai--flex-start",
+      "applies": ".d-stack",
+      "description": "Aligns the items to the start."
     }
   ]
 }

--- a/lib/build/less/components/stack.less
+++ b/lib/build/less/components/stack.less
@@ -18,14 +18,12 @@
   &--column {
     --stack-direction: column;
 
-    align-items: normal;
     justify-content: flex-start;
   }
 
   &--column-reverse {
     --stack-direction: column-reverse;
 
-    align-items: normal;
     justify-content: flex-start;
   }
 
@@ -51,7 +49,6 @@
   display: flex;
   flex-direction: var(--stack-direction);
   gap: var(--stack-gap);
-  align-items: normal;
   justify-content: flex-start;
 }
 
@@ -63,7 +60,6 @@
 .d-stack--column-reverse {
   --stack-direction: column-reverse;
 
-  align-items: normal;
   justify-content: flex-start;
 }
 

--- a/lib/build/less/components/stack.less
+++ b/lib/build/less/components/stack.less
@@ -17,34 +17,42 @@
 .direction-options() {
   &--column {
     --stack-direction: column;
-    --align-items: flex-start;
+
+    align-items: normal;
+    justify-content: flex-start;
   }
 
   &--column-reverse {
     --stack-direction: column-reverse;
-    --align-items: flex-start;
+
+    align-items: normal;
+    justify-content: flex-start;
   }
 
   &--row {
     --stack-direction: row;
-    --align-items: center;
+
+    align-items: center;
+    justify-content: normal;
   }
 
   &--row-reverse {
     --stack-direction: row-reverse;
-    --align-items: center;
+
+    align-items: center;
+    justify-content: normal;
   }
 }
 
 .d-stack {
   --stack-gap: 0;
   --stack-direction: column;
-  --align-items: flex-start;
 
   display: flex;
   flex-direction: var(--stack-direction);
   gap: var(--stack-gap);
-  align-items: var(--align-items);
+  align-items: normal;
+  justify-content: flex-start;
 }
 
 //  ============================================================================
@@ -54,7 +62,9 @@
 //  ----------------------------------------------------------------------------
 .d-stack--column-reverse {
   --stack-direction: column-reverse;
-  --align-items: flex-start;
+
+  align-items: normal;
+  justify-content: flex-start;
 }
 
 //  ----------------------------------------------------------------------------
@@ -62,7 +72,9 @@
 //  ----------------------------------------------------------------------------
 .d-stack--row {
   --stack-direction: row;
-  --align-items: center;
+
+  align-items: center;
+  justify-content: normal;
 }
 
 //  ----------------------------------------------------------------------------
@@ -70,7 +82,9 @@
 //  ----------------------------------------------------------------------------
 .d-stack--row-reverse {
   --stack-direction: row-reverse;
-  --align-items: center;
+
+  align-items: center;
+  justify-content: normal;
 }
 
 //  ============================================================================

--- a/lib/build/less/components/stack.less
+++ b/lib/build/less/components/stack.less
@@ -17,18 +17,22 @@
 .direction-options() {
   &--column {
     --stack-direction: column;
+    --align-items: flex-start;
   }
 
   &--column-reverse {
     --stack-direction: column-reverse;
+    --align-items: flex-start;
   }
 
   &--row {
     --stack-direction: row;
+    --align-items: center;
   }
 
   &--row-reverse {
     --stack-direction: row-reverse;
+    --align-items: center;
   }
 }
 
@@ -50,6 +54,7 @@
 //  ----------------------------------------------------------------------------
 .d-stack--column-reverse {
   --stack-direction: column-reverse;
+  --align-items: flex-start;
 }
 
 //  ----------------------------------------------------------------------------
@@ -57,6 +62,7 @@
 //  ----------------------------------------------------------------------------
 .d-stack--row {
   --stack-direction: row;
+  --align-items: center;
 }
 
 //  ----------------------------------------------------------------------------
@@ -64,17 +70,7 @@
 //  ----------------------------------------------------------------------------
 .d-stack--row-reverse {
   --stack-direction: row-reverse;
-}
-
-//  ----------------------------------------------------------------------------
-//  $$  ALIGN-ITEMS
-//  ----------------------------------------------------------------------------
-.d-stack--ai-center {
   --align-items: center;
-}
-
-.d-stack--ai-flex-start {
-  --align-items: flex-start;
 }
 
 //  ============================================================================

--- a/lib/build/less/components/stack.less
+++ b/lib/build/less/components/stack.less
@@ -35,10 +35,12 @@
 .d-stack {
   --stack-gap: 0;
   --stack-direction: column;
+  --align-items: flex-start;
 
   display: flex;
   flex-direction: var(--stack-direction);
   gap: var(--stack-gap);
+  align-items: var(--align-items);
 }
 
 //  ============================================================================
@@ -62,6 +64,17 @@
 //  ----------------------------------------------------------------------------
 .d-stack--row-reverse {
   --stack-direction: row-reverse;
+}
+
+//  ----------------------------------------------------------------------------
+//  $$  ALIGN-ITEMS
+//  ----------------------------------------------------------------------------
+.d-stack--ai-center {
+  --align-items: center;
+}
+
+.d-stack--ai-flex-start {
+  --align-items: flex-start;
 }
 
 //  ============================================================================


### PR DESCRIPTION
## Description
https://dialpad.atlassian.net/browse/DLT-1265
Adds defaults for aligning items in the Stack component.
Documentation will be updated in the `dialtone-vue` repository.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](path/to/gif)
