### PR TITLE
docs: add tab component to show example, vue code and html code

### DIFF
--- a/docs/.vuepress/baseComponents/ExampleTabs.vue
+++ b/docs/.vuepress/baseComponents/ExampleTabs.vue
@@ -1,66 +1,62 @@
 <template>
-  <div>
-    <dt-tab-group class="example-tab-group">
-      <template #tabs>
-        <dt-tab
-          :id="1"
-          :panel-id="2"
-          selected
-        >
-          Example
-        </dt-tab>
-        <dt-tab
-          :id="3"
-          :panel-id="4"
-        >
-          Vue code
-        </dt-tab>
-        <dt-tab
-          :id="5"
-          :panel-id="6"
-        >
-          HTML code
-        </dt-tab>
-      </template>
-      <div>
-        <dt-tab-panel
-          :id="2"
-          :tab-id="1"
-        >
-          <!-- eslint-disable-next-line vue/no-undef-components -->
-          <code-well-header>
-            <slot name="example" />
-          </code-well-header>
-        </dt-tab-panel>
-        <dt-tab-panel
-          :id="4"
-          :tab-id="3"
-        >
-          <div class="language-html" data-ext="html">
-            <pre class="language-html" v-html="highlightedVue" />
-            <copy-button
-              class="code-copy-button"
-              :text="trimmedVueCode"
-              aria-label="Copy Vue code"
-            />
-          </div>
-        </dt-tab-panel>
-        <dt-tab-panel
-          :id="6"
-          :tab-id="5"
-        >
-          <div class="language-html" data-ext="html">
-            <pre class="language-html" v-html="highlightedHtml" />
-            <copy-button
-              class="code-copy-button"
-              :text="trimmedHtmlCode"
-              aria-label="Copy Html code"
-            />
-          </div>
-        </dt-tab-panel>
+  <dt-tab-group class="example-tab-group">
+    <template #tabs>
+      <dt-tab
+        id="1"
+        panel-id="2"
+        selected
+      >
+        Example
+      </dt-tab>
+      <dt-tab
+        id="3"
+        panel-id="4"
+      >
+        Vue code
+      </dt-tab>
+      <dt-tab
+        id="5"
+        panel-id="6"
+      >
+        HTML code
+      </dt-tab>
+    </template>
+    <dt-tab-panel
+      id="2"
+      tab-id="1"
+    >
+      <!-- eslint-disable-next-line vue/no-undef-components -->
+      <code-well-header>
+        <slot name="example" />
+      </code-well-header>
+    </dt-tab-panel>
+    <dt-tab-panel
+      id="4"
+      tab-id="3"
+    >
+      <div class="language-html" data-ext="html">
+        <pre class="language-html" v-html="highlightedVue" />
+        <copy-button
+          class="code-copy-button"
+          :text="trimmedVueCode"
+          aria-label="Copy Vue code"
+        />
       </div>
-    </dt-tab-group>
-  </div>
+    </dt-tab-panel>
+    <dt-tab-panel
+      id="6"
+      tab-id="5"
+    >
+      <div class="language-html" data-ext="html">
+        <pre class="language-html" v-html="highlightedHtml" />
+        <copy-button
+          class="code-copy-button"
+          :text="trimmedHtmlCode"
+          aria-label="Copy Html code"
+        />
+      </div>
+    </dt-tab-panel>
+  </dt-tab-group>
 </template>
 
 <script setup>

--- a/docs/.vuepress/baseComponents/ExampleTabs.vue
+++ b/docs/.vuepress/baseComponents/ExampleTabs.vue
@@ -3,6 +3,7 @@
     <template #tabs>
       <dt-tab
         id="vueTab"
+        label="vueCode"
         panel-id="vuePanel"
         selected
       >
@@ -10,6 +11,7 @@
       </dt-tab>
       <dt-tab
         id="htmlTab"
+        label="htmlCode"
         panel-id="htmlPanel"
       >
         HTML code
@@ -55,6 +57,7 @@
 <script setup>
 import Prism from 'prismjs';
 import CopyButton from './CopyButton.vue';
+
 const props = defineProps({
   htmlCode: {
     type: String,
@@ -64,14 +67,11 @@ const props = defineProps({
     type: String,
     required: true,
   },
-  showHtmlWarning: {
-    type: Boolean,
-  },
+  showHtmlWarning: Boolean,
 });
-const trimmedHtmlCode = props.htmlCode.replace(/^\n/gm, '');
-const trimmedVueCode = props.vueCode.replace(/^\n/gm, '');
-const highlightedHtml = Prism.highlight(trimmedHtmlCode, Prism.languages.html, 'html');
-const highlightedVue = Prism.highlight(trimmedVueCode, Prism.languages.html, 'html');
+
+const highlightedHtml = Prism.highlight(props.htmlCode.trim(), Prism.languages.html, 'html');
+const highlightedVue = Prism.highlight(props.vueCode.trim(), Prism.languages.html, 'html');
 </script>
 
 <style scoped lang="less">

--- a/docs/.vuepress/baseComponents/ExampleTabs.vue
+++ b/docs/.vuepress/baseComponents/ExampleTabs.vue
@@ -47,6 +47,14 @@
       id="6"
       tab-id="5"
     >
+      <dt-banner
+        v-if="showHtmlWarning"
+        class="d-ps-static"
+        kind="warning"
+        hide-close
+      >
+        This component needs Javascript to work as the example
+      </dt-banner>
       <div class="language-html" data-ext="html">
         <pre class="language-html" v-html="highlightedHtml" />
         <copy-button
@@ -70,6 +78,9 @@ const props = defineProps({
   vueCode: {
     type: String,
     required: true,
+  },
+  showHtmlWarning: {
+    type: Boolean,
   },
 });
 const trimmedHtmlCode = props.htmlCode.replace(/^\n/gm, '');

--- a/docs/.vuepress/baseComponents/ExampleTabs.vue
+++ b/docs/.vuepress/baseComponents/ExampleTabs.vue
@@ -2,37 +2,22 @@
   <dt-tab-group class="example-tab-group">
     <template #tabs>
       <dt-tab
-        id="1"
-        panel-id="2"
+        id="vueTab"
+        panel-id="vuePanel"
         selected
-      >
-        Example
-      </dt-tab>
-      <dt-tab
-        id="3"
-        panel-id="4"
       >
         Vue code
       </dt-tab>
       <dt-tab
-        id="5"
-        panel-id="6"
+        id="htmlTab"
+        panel-id="htmlPanel"
       >
         HTML code
       </dt-tab>
     </template>
     <dt-tab-panel
-      id="2"
-      tab-id="1"
-    >
-      <!-- eslint-disable-next-line vue/no-undef-components -->
-      <code-well-header>
-        <slot name="example" />
-      </code-well-header>
-    </dt-tab-panel>
-    <dt-tab-panel
-      id="4"
-      tab-id="3"
+      id="vuePanel"
+      tab-id="vueTab"
     >
       <div class="language-html" data-ext="html">
         <pre class="language-html" v-html="highlightedVue" />
@@ -44,8 +29,8 @@
       </div>
     </dt-tab-panel>
     <dt-tab-panel
-      id="6"
-      tab-id="5"
+      id="htmlPanel"
+      tab-id="htmlTab"
     >
       <dt-banner
         v-if="showHtmlWarning"
@@ -91,6 +76,7 @@ const highlightedVue = Prism.highlight(trimmedVueCode, Prism.languages.html, 'ht
 
 <style scoped lang="less">
 .example-tab-group {
+  margin-top: var(--dt-space-500);
   .language-html {
     margin-top: 0;
     position: relative;

--- a/docs/.vuepress/baseComponents/ExampleTabs.vue
+++ b/docs/.vuepress/baseComponents/ExampleTabs.vue
@@ -1,0 +1,97 @@
+<template>
+  <div>
+    <dt-tab-group class="example-tab-group">
+      <template #tabs>
+        <dt-tab
+          :id="1"
+          :panel-id="2"
+          selected
+        >
+          Example
+        </dt-tab>
+        <dt-tab
+          :id="3"
+          :panel-id="4"
+        >
+          Vue code
+        </dt-tab>
+        <dt-tab
+          :id="5"
+          :panel-id="6"
+        >
+          HTML code
+        </dt-tab>
+      </template>
+      <div>
+        <dt-tab-panel
+          :id="2"
+          :tab-id="1"
+        >
+          <!-- eslint-disable-next-line vue/no-undef-components -->
+          <code-well-header>
+            <slot name="example" />
+          </code-well-header>
+        </dt-tab-panel>
+        <dt-tab-panel
+          :id="4"
+          :tab-id="3"
+        >
+          <div class="language-html" data-ext="html">
+            <pre class="language-html" v-html="highlightedVue" />
+            <copy-button
+              class="code-copy-button"
+              :text="trimmedVueCode"
+              aria-label="Copy Vue code"
+            />
+          </div>
+        </dt-tab-panel>
+        <dt-tab-panel
+          :id="6"
+          :tab-id="5"
+        >
+          <div class="language-html" data-ext="html">
+            <pre class="language-html" v-html="highlightedHtml" />
+            <copy-button
+              class="code-copy-button"
+              :text="trimmedHtmlCode"
+              aria-label="Copy Html code"
+            />
+          </div>
+        </dt-tab-panel>
+      </div>
+    </dt-tab-group>
+  </div>
+</template>
+
+<script setup>
+import Prism from 'prismjs';
+import CopyButton from './CopyButton.vue';
+const props = defineProps({
+  htmlCode: {
+    type: String,
+    required: true,
+  },
+  vueCode: {
+    type: String,
+    required: true,
+  },
+});
+const trimmedHtmlCode = props.htmlCode.replace(/^\n/gm, '');
+const trimmedVueCode = props.vueCode.replace(/^\n/gm, '');
+const highlightedHtml = Prism.highlight(trimmedHtmlCode, Prism.languages.html, 'html');
+const highlightedVue = Prism.highlight(trimmedVueCode, Prism.languages.html, 'html');
+</script>
+
+<style scoped lang="less">
+.example-tab-group {
+  .language-html {
+    margin-top: 0;
+    position: relative;
+    .code-copy-button {
+      position: absolute;
+      top: var(--dt-space-450);
+      right: var(--dt-space-450);
+    }
+  }
+}
+</style>

--- a/docs/.vuepress/client.js
+++ b/docs/.vuepress/client.js
@@ -17,6 +17,7 @@ import WeatherCodesTable from './baseComponents/WeatherCodesTable.vue';
 import IconSizesTable from './baseComponents/IconSizesTable.vue';
 import ComponentAccessibleTable from './baseComponents/ComponentAccessibleTable.vue';
 import ComponentCombinator from './baseComponents/ComponentCombinator.vue';
+import ExampleTabs from './baseComponents/ExampleTabs.vue';
 
 // Common icons
 import IconInfo from '@svgIcons/IconInfo.vue';
@@ -47,6 +48,7 @@ export default defineClientConfig({
     app.component('IconSizesTable', IconSizesTable);
     app.component('ComponentAccessibleTable', ComponentAccessibleTable);
     app.component('ComponentCombinator', ComponentCombinator);
+    app.component('ExampleTabs', ExampleTabs);
 
     // Common icons
     app.component('IconInfo', IconInfo);

--- a/docs/.vuepress/theme/assets/less/dialtone-syntax.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-syntax.less
@@ -20,7 +20,7 @@ div[class*="language-"] {
 	}
 
 	&[class*="html"] {
-		margin-top: var(--dt-space-400-negative) !important;
+		margin-top: var(--dt-space-400-negative);
 		border-radius: 0 0 var(--dt-size-400) var(--dt-size-400) !important;
 	}
 }

--- a/docs/components/avatar.md
+++ b/docs/components/avatar.md
@@ -69,19 +69,24 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 
 ### Icon
 
-<code-well-header>
+<example-tabs
+htmlCode='
+    <div class="d-avatar d-avatar--{$size}">
+        <div class="d-avatar__canvas">
+            <span class="d-avatar__icon">
+            <svg>...</svg>
+            </span>
+        </div>
+    </div>'
+vueCode='
+    <dt-avatar
+        icon-name="person"
+    />
+'>
+<template #example>
     <dt-avatar icon-name="user" icon-size="300" />
-</code-well-header>
-
-```html
-<div class="d-avatar d-avatar--{$size}">
-    <div class="d-avatar__canvas">
-        <span class="d-avatar__icon">
-          <svg>...</svg>
-        </span>
-    </div>
-</div>
-```
+</template>
+</example-tabs>
 
 ### Initials
 

--- a/docs/components/avatar.md
+++ b/docs/components/avatar.md
@@ -69,6 +69,10 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 
 ### Icon
 
+<code-well-header>
+    <dt-avatar icon-name="user" icon-size="300" />
+</code-well-header>
+
 <example-tabs
 htmlCode='
     <div class="d-avatar d-avatar--{$size}">
@@ -82,10 +86,8 @@ vueCode='
     <dt-avatar
         icon-name="person"
     />
-'>
-<template #example>
-    <dt-avatar icon-name="user" icon-size="300" />
-</template>
+'
+showHtmlWarning>
 </example-tabs>
 
 ### Initials

--- a/docs/components/avatar.md
+++ b/docs/components/avatar.md
@@ -75,17 +75,17 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
 
 <example-tabs
 htmlCode='
-    <div class="d-avatar d-avatar--{$size}">
-        <div class="d-avatar__canvas">
-            <span class="d-avatar__icon">
-            <svg>...</svg>
-            </span>
-        </div>
-    </div>'
+<div class="d-avatar d-avatar--{$size}">
+    <div class="d-avatar__canvas">
+        <span class="d-avatar__icon">
+        <svg>...</svg>
+        </span>
+    </div>
+</div>'
 vueCode='
-    <dt-avatar
-        icon-name="person"
-    />
+<dt-avatar
+    icon-name="person"
+/>
 '
 showHtmlWarning>
 </example-tabs>

--- a/docs/components/avatar.md
+++ b/docs/components/avatar.md
@@ -73,22 +73,15 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
     <dt-avatar icon-name="user" icon-size="300" />
 </code-well-header>
 
-<example-tabs
-htmlCode='
+```html
 <div class="d-avatar d-avatar--{$size}">
     <div class="d-avatar__canvas">
         <span class="d-avatar__icon">
-        <svg>...</svg>
+            <svg>...</svg>
         </span>
     </div>
-</div>'
-vueCode='
-<dt-avatar
-    icon-name="person"
-/>
-'
-showHtmlWarning>
-</example-tabs>
+</div>
+```
 
 ### Initials
 


### PR DESCRIPTION
## Description
Jira ticket: https://dialpad.atlassian.net/browse/DLT-692
- Adds a reusable component to show in different tabs the component example, the vue code and the html code.
- Adds button to copy the code

Note: I needed to remove an `!important` from the `dialtone-syntax.less` file. I think because of selectors specificity nothing should break.

In the second commit I am using the new component for the Avatar (icon variant), for test purposes. You can check it out here: https://dialpad.design/deploy-previews/pr-968/components/avatar.html#icon

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![avatar-example](https://github.com/dialpad/dialtone/assets/24460973/1d046ce8-a871-496d-ad37-cca09238cd38)


