### PR TITLE
docs: fix sidebar overlap

### DIFF
--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -5,7 +5,7 @@
   <ul
     v-if="sidebarItems.length"
     class="
-    dialtone-sidebar__list d-t64 d-b0 d-ps-fixed
+    dialtone-sidebar__list d-t64 d-b0
     d-p24 d-px16 d-pb96
     d-h100vh d-of-y-auto"
   >


### PR DESCRIPTION
## Description
This was only happening on the docsite because of the `d-ps-fixed` set on the sidebar list. The sidebar was not taking up space within the sidebar causing the main content to overlap. However it also appears the "responsive breakpoint" props are not working as expected. Doesn't matter for the docsite since we don't use them there, but I will continue looking into this.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/W561jj5bXQvqGRMXoR/giphy.gif)
