### PR TITLE
chore(docs): leftbar spacing

### DIFF
--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -4,6 +4,8 @@
   </h2>
   <dt-stack
     v-if="sidebarItems.length"
+    as="ul"
+    gap="500"
     class="
     dialtone-sidebar__list d-t64 d-b0
     d-p24 d-px16 d-pb96

--- a/docs/.vuepress/theme/components/Sidebar.vue
+++ b/docs/.vuepress/theme/components/Sidebar.vue
@@ -2,7 +2,7 @@
   <h2 class="d-vi-visible-sr">
     Local navigation
   </h2>
-  <ul
+  <dt-stack
     v-if="sidebarItems.length"
     class="
     dialtone-sidebar__list d-t64 d-b0
@@ -14,7 +14,7 @@
       :key="item.link || item.text"
       :item="item"
     />
-  </ul>
+  </dt-stack>
 </template>
 
 <script setup>


### PR DESCRIPTION
## Description

Space out leftbar groups.

![image](https://github.com/dialpad/dialtone/assets/1165933/612d3b20-e95e-410d-b15b-8e77ba2fd8ad)

## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).


