### PR TITLE
fix(input-group): prevent label from spanning entire row

### DIFF
--- a/docs/components/checkbox-group.md
+++ b/docs/components/checkbox-group.md
@@ -10,7 +10,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
 <code-well-header>
   <dt-checkbox-group
     name="fruits-checkbox-group"
-    class="d-input-group__fieldset"
     legend="Fruits"
     :selectedValues="[]"
   >
@@ -23,7 +22,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
 ```html
 <dt-checkbox-group
   name="fruits-checkbox-group"
-  class="d-input-group__fieldset"
   legend="Fruits"
   :selectedValues="[]"
 >
@@ -40,7 +38,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
 <code-well-header>
   <dt-checkbox-group
     name="fruits-checkbox-group"
-    class="d-input-group__fieldset"
     legend="Fruits"
     :selectedValues="[]"
   >
@@ -53,7 +50,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
 ```html
 <dt-checkbox-group
   name="fruits-checkbox-group"
-  class="d-input-group__fieldset"
   legend="Fruits"
   :selectedValues="[]"
 >
@@ -71,7 +67,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
       <dt-checkbox-group
         name="checkbox-group-with-success-message"
         legend="Fruits"
-        class="d-input-group__fieldset"
         :messages='[{"message":"Success validation message","type":"success"}]'
       >
         <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
@@ -83,7 +78,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
       <dt-checkbox-group
         name="checkbox-group-with-warning-message"
         legend="Fruits"
-        class="d-input-group__fieldset"
         :messages='[{"message":"Warning validation message","type":"warning"}]'
       >
         <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
@@ -95,7 +89,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
       <dt-checkbox-group
       name="checkbox-group-with-error-message"
       legend="Fruits"
-      class="d-input-group__fieldset"
       :messages='[{"message":"Error validation message","type":"error"}]'
       >
         <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>

--- a/docs/components/checkbox-group.md
+++ b/docs/components/checkbox-group.md
@@ -10,6 +10,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
 <code-well-header>
   <dt-checkbox-group
     name="fruits-checkbox-group"
+    class="d-input-group__fieldset"
     legend="Fruits"
     :selectedValues="[]"
   >
@@ -22,6 +23,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
 ```html
 <dt-checkbox-group
   name="fruits-checkbox-group"
+  class="d-input-group__fieldset"
   legend="Fruits"
   :selectedValues="[]"
 >
@@ -38,6 +40,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
 <code-well-header>
   <dt-checkbox-group
     name="fruits-checkbox-group"
+    class="d-input-group__fieldset"
     legend="Fruits"
     :selectedValues="[]"
   >
@@ -50,6 +53,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
 ```html
 <dt-checkbox-group
   name="fruits-checkbox-group"
+  class="d-input-group__fieldset"
   legend="Fruits"
   :selectedValues="[]"
 >
@@ -67,6 +71,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
       <dt-checkbox-group
         name="checkbox-group-with-success-message"
         legend="Fruits"
+        class="d-input-group__fieldset"
         :messages='[{"message":"Success validation message","type":"success"}]'
       >
         <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
@@ -78,6 +83,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
       <dt-checkbox-group
         name="checkbox-group-with-warning-message"
         legend="Fruits"
+        class="d-input-group__fieldset"
         :messages='[{"message":"Warning validation message","type":"warning"}]'
       >
         <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>
@@ -89,6 +95,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-checkbox-group--de
       <dt-checkbox-group
       name="checkbox-group-with-error-message"
       legend="Fruits"
+      class="d-input-group__fieldset"
       :messages='[{"message":"Error validation message","type":"error"}]'
       >
         <dt-checkbox value="apple"><span>Apple</span></dt-checkbox>

--- a/docs/components/checkbox.md
+++ b/docs/components/checkbox.md
@@ -31,11 +31,13 @@ Checkboxes are an easily understandable way to indicate that users can select on
 - Binary selections that convey opposite states, such as check=“on” and unchecked=“off”, paired with a label that conveys the choice.
 - When users need to see all the available options at a glance.
 </template>
+
 <template #dont>
 
 - If a user can only select one option from a list; consider using [Radio](radio.md) or [Select](select-menu.md).
 - If there are too many options to reasonably display in its context.
 </template>
+
 </dialtone-usage>
 
 ### Best practices
@@ -56,7 +58,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 ### Base Styles
 
 <code-well-header>
-  <fieldset class="d-stack8">
+  <fieldset class="d-input-group__fieldset d-stack8">
     <div class="d-checkbox-group">
       <div class="d-checkbox__input">
         <input class="d-checkbox" type="checkbox" name="Dialtone-CheckExample1" id="Dialtone-CheckExample1" />
@@ -109,7 +111,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 </code-well-header>
 
 ```html
-<fieldset class="d-stack8">
+<fieldset class="d-input-group__fieldset d-stack8">
   <div class="d-checkbox-group">
     <div class="d-checkbox__input">
       <input class="d-checkbox" type="checkbox" name="Dialtone-CheckExample1" id="Dialtone-CheckExample1" />
@@ -164,7 +166,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 ### Indeterminate
 
 <code-well-header>
-  <fieldset class="d-stack8">
+  <fieldset class="d-input-group__fieldset d-stack8">
     <div class="d-checkbox-group">
       <div class="d-checkbox__input">
         <input class="d-checkbox d-checkbox--indeterminate" type="checkbox" name="Checkbox-IndeterminateExample1" id="Checkbox-IndeterminateExample1" />
@@ -185,7 +187,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 </code-well-header>
 
 ```html
-<fieldset class="d-stack8">
+<fieldset class="d-input-group__fieldset d-stack8">
   <div class="d-checkbox-group">
     <div class="d-checkbox__input">
       <input class="d-checkbox d-checkbox--indeterminate" type="checkbox" name="Checkbox-IndeterminateExample1" id="Checkbox-IndeterminateExample1" />
@@ -208,7 +210,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 ### Stacked Group
 
 <code-well-header>
-  <fieldset class="d-stack8">
+  <fieldset class="d-input-group__fieldset d-stack8">
     <legend class="d-label">Call Blocking & Spam Protection</legend>
     <div class="d-checkbox-group">
       <div class="d-checkbox__input">
@@ -238,7 +240,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 </code-well-header>
 
 ```html
-<fieldset class="d-stack8">
+<fieldset class="d-input-group__fieldset d-stack8">
   <legend class="d-label">Call Blocking & Spam Protection</legend>
   <div class="d-checkbox-group">
     <div class="d-checkbox__input">
@@ -270,7 +272,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 ### With Description Text
 
 <code-well-header>
-  <fieldset class="d-stack8">
+  <fieldset class="d-input-group__fieldset d-stack8">
     <legend class="d-label">Call Blocking & Spam Protection</legend>
     <div class="d-checkbox-group">
       <div class="d-checkbox__input">
@@ -306,7 +308,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 </code-well-header>
 
 ```html
-<fieldset class="d-stack8">
+<fieldset class="d-input-group__fieldset d-stack8">
   <legend class="d-label">Call Blocking & Spam Protection</legend>
   <div class="d-checkbox-group">
     <div class="d-checkbox__input">
@@ -344,7 +346,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 ### With validation states
 
 <code-well-header>
-  <fieldset class="d-stack8">
+  <fieldset class="d-input-group__fieldset d-stack8">
     <legend class="d-label">Call Blocking & Spam Protection</legend>
     <div class="d-checkbox-group">
       <div class="d-checkbox__input">
@@ -380,7 +382,7 @@ Checkboxes are an easily understandable way to indicate that users can select on
 </code-well-header>
 
 ```html
-<fieldset class="d-stack8">
+<fieldset class="d-input-group__fieldset d-stack8">
   <legend class="d-label">Call Blocking & Spam Protection</legend>
   <div class="d-checkbox-group">
     <div class="d-checkbox__input">

--- a/docs/components/radio-group.md
+++ b/docs/components/radio-group.md
@@ -10,7 +10,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-radio-group--defau
 <code-well-header>
   <dt-radio-group
     value=""
-    class="d-input-group__fieldset"
     name="fruits-radio-group-00"
     legend="Fruits"
   >
@@ -28,7 +27,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-radio-group--defau
   <dt-radio-group
     value=""
     name="fruits-radio-group-01"
-    class="d-input-group__fieldset"
     legend="Fruits"
   >
     <dt-radio value="apple"><span >Apple</span></dt-radio>
@@ -41,7 +39,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-radio-group--defau
 <dt-radio-group
     value=""
     name="fruits-radio-group-01"
-    class="d-input-group__fieldset"
     legend="Fruits"
   >
     <dt-radio value="apple"><span >Apple</span></dt-radio>
@@ -58,7 +55,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-radio-group--defau
       <dt-radio-group
         name="radio-group-with-success-message"
         legend="With Success Message"
-        class="d-input-group__fieldset"
         :messages='[{"message":"Success validation message","type":"success"}]'
       >
         <dt-radio value="apple"><span >Apple</span></dt-radio>
@@ -70,7 +66,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-radio-group--defau
       <dt-radio-group
         name="radio-group-with-warning-message"
         legend="With Warning Message"
-        class="d-input-group__fieldset"
         :messages='[{"message":"Warning validation message","type":"warning"}]'
       >
         <dt-radio value="apple"><span >Apple</span></dt-radio>
@@ -82,7 +77,6 @@ storybook: https://vue.dialpad.design/?path=/story/components-radio-group--defau
       <dt-radio-group
         name="radio-group-with-error-message"
         legend="With Error Message"
-        class="d-input-group__fieldset"
         :messages='[{"message":"Error validation message","type":"error"}]'
       >
         <dt-radio value="apple"><span >Apple</span></dt-radio>

--- a/docs/components/radio-group.md
+++ b/docs/components/radio-group.md
@@ -10,6 +10,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-radio-group--defau
 <code-well-header>
   <dt-radio-group
     value=""
+    class="d-input-group__fieldset"
     name="fruits-radio-group-00"
     legend="Fruits"
   >
@@ -27,6 +28,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-radio-group--defau
   <dt-radio-group
     value=""
     name="fruits-radio-group-01"
+    class="d-input-group__fieldset"
     legend="Fruits"
   >
     <dt-radio value="apple"><span >Apple</span></dt-radio>
@@ -39,6 +41,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-radio-group--defau
 <dt-radio-group
     value=""
     name="fruits-radio-group-01"
+    class="d-input-group__fieldset"
     legend="Fruits"
   >
     <dt-radio value="apple"><span >Apple</span></dt-radio>
@@ -55,6 +58,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-radio-group--defau
       <dt-radio-group
         name="radio-group-with-success-message"
         legend="With Success Message"
+        class="d-input-group__fieldset"
         :messages='[{"message":"Success validation message","type":"success"}]'
       >
         <dt-radio value="apple"><span >Apple</span></dt-radio>
@@ -66,6 +70,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-radio-group--defau
       <dt-radio-group
         name="radio-group-with-warning-message"
         legend="With Warning Message"
+        class="d-input-group__fieldset"
         :messages='[{"message":"Warning validation message","type":"warning"}]'
       >
         <dt-radio value="apple"><span >Apple</span></dt-radio>
@@ -77,6 +82,7 @@ storybook: https://vue.dialpad.design/?path=/story/components-radio-group--defau
       <dt-radio-group
         name="radio-group-with-error-message"
         legend="With Error Message"
+        class="d-input-group__fieldset"
         :messages='[{"message":"Error validation message","type":"error"}]'
       >
         <dt-radio value="apple"><span >Apple</span></dt-radio>

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -32,6 +32,7 @@ Radio buttons are a common way to allow users to make a single selection from a 
 - If the number of available options can fit onto a mobile screen.
 - In place of [Select](select-menu.md) element if there are few enough options (e.g. =7) and the design can support it.
 </template>
+
 <template #dont>
 
 - Consider [Checkbox](checkbox.md) if users may have the option to select more than one.
@@ -39,6 +40,7 @@ Radio buttons are a common way to allow users to make a single selection from a 
 - If users should be able to select zero of the options; radio elements are not “uncheckable.” A [Checkbox](checkbox.md) may be warranted.
 - If there are too many options to display on a single view; consider a [Select](select-menu.md) instead.
 </template>
+
 </dialtone-usage>
 
 ### Best practices
@@ -53,7 +55,7 @@ Radio buttons are a common way to allow users to make a single selection from a 
 ### Base Styles
 
 <code-well-header>
-  <fieldset class="d-stack8">
+  <fieldset class="d-input-group__fieldset d-stack8">
     <div class="d-radio-group">
       <div class="d-radio__input">
         <input class="d-radio" type="radio" name="Dialtone-RadioGroup1" id="Dialtone-RadioExample1" />
@@ -98,7 +100,7 @@ Radio buttons are a common way to allow users to make a single selection from a 
 </code-well-header>
 
 ```html
-<fieldset class="d-stack8">
+<fieldset class="d-input-group__fieldset d-stack8">
   <div class="d-radio-group">
     <div class="d-radio__input">
       <input class="d-radio" type="radio" name="Dialtone-RadioGroup1" id="Dialtone-RadioExample1" />
@@ -145,7 +147,7 @@ Radio buttons are a common way to allow users to make a single selection from a 
 ### Stacked Group
 
 <code-well-header>
-  <fieldset class="d-stack8">
+  <fieldset class="d-input-group__fieldset d-stack8">
     <legend class="d-label">Advanced missed call routing</legend>
     <div class="d-radio-group">
       <div class="d-radio__input">
@@ -175,7 +177,7 @@ Radio buttons are a common way to allow users to make a single selection from a 
 </code-well-header>
 
 ```html
-<fieldset class="d-stack8">
+<fieldset class="d-input-group__fieldset d-stack8">
   <legend class="d-label">Advanced missed call routing</legend>
   <div class="d-radio-group">
     <div class="d-radio__input">
@@ -207,7 +209,7 @@ Radio buttons are a common way to allow users to make a single selection from a 
 ### With Description Text
 
 <code-well-header>
-  <fieldset class="d-stack8">
+  <fieldset class="d-input-group__fieldset d-stack8">
     <legend class="d-label">Advanced missed call routing</legend>
     <div class="d-radio-group">
       <div class="d-radio__input">
@@ -240,7 +242,7 @@ Radio buttons are a common way to allow users to make a single selection from a 
 </code-well-header>
 
 ```html
-<fieldset class="d-stack8">
+<fieldset class="d-input-group__fieldset d-stack8">
   <legend class="d-label">Advanced missed call routing</legend>
   <div class="d-radio-group">
     <div class="d-radio__input">
@@ -275,7 +277,7 @@ Radio buttons are a common way to allow users to make a single selection from a 
 ### With validation states
 
 <code-well-header>
-  <fieldset class="d-stack8">
+  <fieldset class="d-input-group__fieldset d-stack8">
     <legend class="d-label">Advanced missed call routing</legend>
     <div class="d-radio-group">
       <div class="d-radio__input">
@@ -308,7 +310,7 @@ Radio buttons are a common way to allow users to make a single selection from a 
 </code-well-header>
 
 ```html
-<fieldset class="d-stack8">
+<fieldset class="d-input-group__fieldset d-stack8">
   <legend class="d-label">Advanced missed call routing</legend>
   <div class="d-radio-group">
     <div class="d-radio__input">

--- a/lib/build/less/components/radio-checkbox.less
+++ b/lib/build/less/components/radio-checkbox.less
@@ -89,7 +89,7 @@
 //  ----------------------------------------------------------------------------
 .d-checkbox-group,
 .d-radio-group {
-    display: flex;
+    display: inline-flex;
     gap: var(--dt-space-400); // 8
 
     //  --  Wrapper Disabled State
@@ -135,9 +135,9 @@
 .d-checkbox__label,
 .d-radio__label {
     display: inline-flex;
+    flex: 1 auto;
     flex-direction: column;
-    flex-grow: 0;
-    flex-shrink: 1;
+    align-items: flex-start;
     color: var(--dt-color-foreground-primary);
     font-weight: var(--dt-font-weight-normal);
     font-size: var(--dt-font-size-200);

--- a/lib/build/less/components/radio-checkbox.less
+++ b/lib/build/less/components/radio-checkbox.less
@@ -103,6 +103,12 @@
     }
 }
 
+.d-input-group__fieldset {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
 
 //  ============================================================================
 //  $   INPUT BLOCKS
@@ -129,8 +135,9 @@
 .d-checkbox__label,
 .d-radio__label {
     display: inline-flex;
-    flex: 1 auto;
     flex-direction: column;
+    flex-grow: 0;
+    flex-shrink: 1;
     color: var(--dt-color-foreground-primary);
     font-weight: var(--dt-font-weight-normal);
     font-size: var(--dt-font-size-200);

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@dialpad/conventional-changelog-angular": "^1.1.1",
         "@dialpad/dialtone-combinator": "^0.3.1",
         "@dialpad/dialtone-tokens": "^1.23.1",
-        "@dialpad/dialtone-vue": "^3.88.1",
+        "@dialpad/dialtone-vue": "^3.90.0",
         "@dialpad/postcss-responsive-variations": "^1.1.5",
         "@dialpad/semantic-release-changelog-json": "^1.0.0",
         "@docsearch/js": "^3.5.1",
@@ -1523,15 +1523,16 @@
       "dev": true
     },
     "node_modules/@dialpad/dialtone-vue": {
-      "version": "3.88.1",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.88.1.tgz",
-      "integrity": "sha512-ceoXjWOmAMuSmPiG7JbNRzo6oYWxWhIAYNBJnsTWYqEY2Wpf19hTagHuoHBZN8NqNiHteQsNVw3lKuocrS2POQ==",
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.90.0.tgz",
+      "integrity": "sha512-t4cR2qd8ActN21dwO2zEdLoUDQV8uvaqbBix+7b/PFrgHLuh6iI851759enr63vP/HJYXj1xTKAoLE4NhFCRtQ==",
       "dev": true,
       "dependencies": {
         "@dialpad/dialtone-icons": "^3.3.0",
         "@tiptap/extension-code-block": "^2.0.3",
         "@tiptap/extension-document": "^2.0.3",
         "@tiptap/extension-hard-break": "^2.0.3",
+        "@tiptap/extension-mention": "^2.1.11",
         "@tiptap/extension-paragraph": "^2.0.3",
         "@tiptap/extension-placeholder": "^2.0.3",
         "@tiptap/extension-text": "^2.0.3",
@@ -5330,6 +5331,21 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.0.0"
+      }
+    },
+    "node_modules/@tiptap/extension-mention": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-2.1.12.tgz",
+      "integrity": "sha512-Nc8wFlyPp+/48IpOFPk2O3hYsF465wizcM3aihMvZM96Ahic7dvv9yVptyOfoOwgpExl2FIn1QPjRDXF60VAUg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.0.0",
+        "@tiptap/pm": "^2.0.0",
+        "@tiptap/suggestion": "^2.0.0"
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
@@ -39902,15 +39918,16 @@
       "dev": true
     },
     "@dialpad/dialtone-vue": {
-      "version": "3.88.1",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.88.1.tgz",
-      "integrity": "sha512-ceoXjWOmAMuSmPiG7JbNRzo6oYWxWhIAYNBJnsTWYqEY2Wpf19hTagHuoHBZN8NqNiHteQsNVw3lKuocrS2POQ==",
+      "version": "3.90.0",
+      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.90.0.tgz",
+      "integrity": "sha512-t4cR2qd8ActN21dwO2zEdLoUDQV8uvaqbBix+7b/PFrgHLuh6iI851759enr63vP/HJYXj1xTKAoLE4NhFCRtQ==",
       "dev": true,
       "requires": {
         "@dialpad/dialtone-icons": "^3.3.0",
         "@tiptap/extension-code-block": "^2.0.3",
         "@tiptap/extension-document": "^2.0.3",
         "@tiptap/extension-hard-break": "^2.0.3",
+        "@tiptap/extension-mention": "^2.1.11",
         "@tiptap/extension-paragraph": "^2.0.3",
         "@tiptap/extension-placeholder": "^2.0.3",
         "@tiptap/extension-text": "^2.0.3",
@@ -42576,6 +42593,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.0.4.tgz",
       "integrity": "sha512-4j8BZa6diuoRytWoIc7j25EYWWut5TZDLbb+OVURdkHnsF8B8zeNTo55W40CdwSaSyTtXtxbTIldV80ShQarGQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "@tiptap/extension-mention": {
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-2.1.12.tgz",
+      "integrity": "sha512-Nc8wFlyPp+/48IpOFPk2O3hYsF465wizcM3aihMvZM96Ahic7dvv9yVptyOfoOwgpExl2FIn1QPjRDXF60VAUg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "@dialpad/conventional-changelog-angular": "^1.1.1",
     "@dialpad/dialtone-combinator": "^0.3.1",
     "@dialpad/dialtone-tokens": "^1.23.1",
-    "@dialpad/dialtone-vue": "^3.88.1",
+    "@dialpad/dialtone-vue": "^3.90.0",
     "@dialpad/postcss-responsive-variations": "^1.1.5",
     "@dialpad/semantic-release-changelog-json": "^1.0.0",
     "@docsearch/js": "^3.5.1",


### PR DESCRIPTION
## Description

Fix requested for related product issue: https://dialpad.atlassian.net/browse/DP-82301

The radio button / checkbox labels were spanning the entire width of the container they were in making it possible to toggle a radio button by clicking wayyyy to the right of it in empty space.

Added new class to put on the fieldset that will correct these issues. Will need to make a change in dialtone vue to apply this class as well.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/KfTgl5LzZ4PzIZk0ot/giphy-downsized-large.gif)
