### PR TITLE
docs(keyboard-shortcut): add figma link

### DIFF
--- a/docs/.vuepress/theme/components/PageToc.vue
+++ b/docs/.vuepress/theme/components/PageToc.vue
@@ -1,6 +1,6 @@
 <template>
-  <aside class="lg:d-ps-relative lg:d-w100p d-ps-fixed d-pt24">
-    <h2 class="d-headline-eyebrow d-fw-semibold">
+  <aside class="lg:d-ps-relative lg:d-w100p d-ps-fixed d-pt32 d-pr12">
+    <h2 class="d-headline-eyebrow d-fw-semibold d-px12 d-pb4">
       On this page
     </h2>
     <toc
@@ -15,7 +15,7 @@ const options = {
   listClass: 'toc-list d-ls-reset',
   itemClass: 'toc-item lg:d-d-flex d-fw-wrap',
   linkTag: 'a',
-  linkClass: 'd-btn d-btn--sm d-btn--muted d-fw-normal d-w100p d-jc-flex-start d-ws-nowrap',
+  linkClass: 'd-btn d-btn--sm d-btn--muted d-fw-normal d-w100p d-jc-flex-start',
   linkActiveClass: 'active-item d-btn--active d-fw-medium',
   linkChildrenActiveClass: 'active-category',
 };

--- a/docs/components/keyboard-shortcut.md
+++ b/docs/components/keyboard-shortcut.md
@@ -5,11 +5,34 @@ status: ready
 thumb: true
 image: assets/images/components/keyboard-shortcut.png
 storybook: https://vue.dialpad.design/?path=/story/components-keyboard-shortcut--default
+figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Components?type=design&node-id=8922-20524&mode=design&t=4VsDQfzhbBwFVFl2-11
 ---
 
 <code-well-header>
   <dt-keyboard-shortcut shortcut="{cmd}+Ctrl+X"/>
 </code-well-header>
+
+## Variants
+
+### Base
+
+<code-well-header>
+  <dt-keyboard-shortcut shortcut="{cmd}+Ctrl+X"/>
+</code-well-header>
+
+```html
+  <dt-keyboard-shortcut shortcut="{cmd}+Ctrl+X"/>
+```
+
+### Inverted
+
+<code-well-header bgclass="d-bgc-contrast">
+  <dt-keyboard-shortcut inverted shortcut="{cmd}+Ctrl+X" />
+</code-well-header>
+
+```html
+  <dt-keyboard-shortcut inverted shortcut="{cmd}+Ctrl+X" />
+```
 
 ## Vue API
 

--- a/docs/components/validation-messages.md
+++ b/docs/components/validation-messages.md
@@ -26,7 +26,7 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   />
 </code-well-header>
 
-```vue
+```html
 <dt-validation-messages
   id="sample--02"
   :validationMessages='[{"message":"Positive validation message","type":"success"}]'
@@ -42,7 +42,7 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   />
 </code-well-header>
 
-```vue
+```html
 <dt-validation-messages
   id="sample--03"
   :validationMessages='[{"message":"Critical validation message","type":"error"}]'
@@ -58,7 +58,7 @@ figma_url: https://www.figma.com/file/2adf7JhZOncRyjYiy2joil/DT-Core%3A-Componen
   />
 </code-well-header>
 
-```vue
+```html
 <dt-validation-messages
   id="sample--04"
   :validationMessages='[{"message":"Critical validation message","type":"warning"}]'


### PR DESCRIPTION
## Description

[Keyboard Shortcut](https://dialpad.design/components/keyboard-shortcut.html) was missing Figma link. Also did some basic housekeeping and pixel-pushing.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).
![easy-keyboard-shortcuts06](https://github.com/dialpad/dialtone/assets/1165933/19b4bf7e-1e2e-4c08-a6be-707a02fa52ba)


