### PR TITLE
chore: fix package-lock inconsistencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dialpad/dialtone",
-  "version": "8.19.1",
+  "version": "8.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dialpad/dialtone",
-      "version": "8.19.1",
+      "version": "8.20.0",
       "license": "MIT",
       "dependencies": {
         "@dialpad/dialtone-icons": "^3.3.0",
@@ -1524,15 +1524,9 @@
       "dev": true
     },
     "node_modules/@dialpad/dialtone-vue": {
-<<<<<<< HEAD
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.89.0.tgz",
-      "integrity": "sha512-OQe7DBN9FLsU9UyOzq1BLsMrOJQgfwvCgjgDRX9PDZVPRnDtxp2c0RJ2AMGRR1Eo+x8MB/zSmLPT+38QvbMkrw==",
-=======
       "version": "3.90.0",
       "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.90.0.tgz",
       "integrity": "sha512-t4cR2qd8ActN21dwO2zEdLoUDQV8uvaqbBix+7b/PFrgHLuh6iI851759enr63vP/HJYXj1xTKAoLE4NhFCRtQ==",
->>>>>>> staging
       "dev": true,
       "dependencies": {
         "@dialpad/dialtone-icons": "^3.3.0",
@@ -40091,15 +40085,9 @@
       "dev": true
     },
     "@dialpad/dialtone-vue": {
-<<<<<<< HEAD
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.89.0.tgz",
-      "integrity": "sha512-OQe7DBN9FLsU9UyOzq1BLsMrOJQgfwvCgjgDRX9PDZVPRnDtxp2c0RJ2AMGRR1Eo+x8MB/zSmLPT+38QvbMkrw==",
-=======
       "version": "3.90.0",
       "resolved": "https://registry.npmjs.org/@dialpad/dialtone-vue/-/dialtone-vue-3.90.0.tgz",
       "integrity": "sha512-t4cR2qd8ActN21dwO2zEdLoUDQV8uvaqbBix+7b/PFrgHLuh6iI851759enr63vP/HJYXj1xTKAoLE4NhFCRtQ==",
->>>>>>> staging
       "dev": true,
       "requires": {
         "@dialpad/dialtone-icons": "^3.3.0",


### PR DESCRIPTION
## Description
`package.json` and `package-lock.json` where out of sync in the staging branch.
The inconsistencies seems to have been introduced here: https://github.com/dialpad/dialtone/pull/964/files#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519L3

## Pull Request Checklist

 - [ ] Ask the contributors if a similar effort is already in process or has been solved.
 - [ ] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [ ] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [ ] Ensure all `gulp` scripts successfully compile.
 - [ ] Update, remove, or extend all affected documentation.
 - [ ] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](path/to/gif)
