### PR TITLE
docs: fix glitch when loading the tokens table

### DIFF
--- a/docs/.vuepress/baseComponents/TokenTable.vue
+++ b/docs/.vuepress/baseComponents/TokenTable.vue
@@ -84,6 +84,7 @@
 </template>
 
 <script>
+import * as tokensJson from '@dialpad/dialtone-tokens/dist/doc.json';
 import { getComposedTypographyTokens, getComposedShadowTokens } from '../common/token-utilities';
 import CopyButton from './CopyButton.vue';
 
@@ -139,17 +140,14 @@ export default {
     return {
       format: 'CSS',
       theme: 'light',
-      json: null,
       THEMES,
     };
   },
 
   computed: {
     tokensProcessed () {
-      if (!this.json) return [];
-
       const tokens = [];
-      Object.entries(this.json[this.theme])
+      Object.entries(tokensJson[this.theme])
         .filter(([key, value]) => CATEGORY_MAP[this.category].includes(key.split('/')[0]) && value['css/variables'])
         .forEach(([_, value]) => {
           const { name, value: tokenValue, description } = value[FORMAT_MAP[this.format]] || {};
@@ -169,12 +167,6 @@ export default {
         return { value: item, label: item };
       });
     },
-  },
-
-  beforeMount () {
-    import('@dialpad/dialtone-tokens/dist/doc.json').then((module) => {
-      this.json = module.default;
-    });
   },
 
   methods: {


### PR DESCRIPTION
## Description
Replaces the dynamic import of the json containing the tokens for a static import. Importing it dynamically was causing that in the first frame the table would look empty.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
| Before | Now |
|------|------|
| ![tokens-load](https://github.com/dialpad/dialtone/assets/24460973/607f7985-1f0b-4d51-801d-02e1584b0b86) | ![tokens-load-2](https://github.com/dialpad/dialtone/assets/24460973/6ab15330-da2a-4be6-b594-be1292e0a0ed) |
