### PR TITLE
fix: remove z-index on root-layout

### DIFF
--- a/docs/.vuepress/theme/assets/less/dialtone-docs.less
+++ b/docs/.vuepress/theme/assets/less/dialtone-docs.less
@@ -599,7 +599,6 @@ a.header-anchor {
   }
 
   &--content {
-    z-index: var(--zi-base1);
     align-items: flex-start;
     max-width: 40%;
 
@@ -611,7 +610,6 @@ a.header-anchor {
   }
 
   &--image {
-    z-index: var(--zi-base1);
 
     @media (max-width: 640px) {
       display: none;

--- a/lib/build/less/components/root-layout.less
+++ b/lib/build/less/components/root-layout.less
@@ -41,7 +41,6 @@
     &--sticky {
       position: sticky;
       top: 0;
-      z-index: var(--zi-navigation);
     }
   }
 


### PR DESCRIPTION
## Description
Issue on the doc site with hero images overlapping the topbar. Removed the z-index from these images, since it really served no purpose in the first place, and then also removed z-index from the sticky root layout class. It is best to avoid use of z-index if necessary, and here it does not seem necessary. The natural dom flow should work fine in the root layout case. If a product deems it necessary to have z-index on nav elements, they are able to add it at the product level via class props.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/XdE3y9BsX0ObDN3Wu4/giphy.gif)
