### PR TITLE
fix(root-layout): make sidebar scrollable

### DIFF
--- a/lib/build/less/components/root-layout.less
+++ b/lib/build/less/components/root-layout.less
@@ -48,6 +48,8 @@
   &__sidebar {
     grid-area: sidebar;
     height: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
     box-shadow: none;
   }
 
@@ -67,37 +69,58 @@
 }
 
 @media (max-width: 480px) {
+
+  // Having a fixed height in mobile mode doesn't really make any sense,
+  // so we'll set it back to auto if the media query triggered.
+  .d-root-layout--fixed.d-root-layout__responsive--sm {
+    height: auto;
+  }
+
   .d-root-layout__responsive--sm {
     grid-template-areas:
     'header'
     'sidebar'
     'body'
     'footer';
-    grid-template-rows: min-content min-content 1fr min-content;
+    grid-template-rows: min-content auto 1fr min-content;
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 640px) {
+
+  // Having a fixed height in mobile mode doesn't really make any sense,
+  // so we'll set it back to auto if the media query triggered.
+  .d-root-layout--fixed.d-root-layout__responsive--md {
+    height: auto;
+  }
+
   .d-root-layout__responsive--md {
     grid-template-areas:
     'header'
     'sidebar'
     'body'
     'footer';
-    grid-template-rows: min-content min-content 1fr min-content;
+    grid-template-rows: min-content auto 1fr min-content;
     grid-template-columns: 1fr;
   }
 }
 
 @media (max-width: 980px) {
+
+  // Having a fixed height in mobile mode doesn't really make any sense,
+  // so we'll set it back to auto if the media query triggered.
+  .d-root-layout--fixed.d-root-layout__responsive--lg {
+    height: auto;
+  }
+
   .d-root-layout__responsive--lg {
     grid-template-areas:
     'header'
     'sidebar'
     'body'
     'footer';
-    grid-template-rows: min-content min-content 1fr min-content;
+    grid-template-rows: min-content auto 1fr min-content;
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Description
Prior to this change if the sidebar had content within it greater than the height of the viewport it would cause the entire page to scroll. Added auto overflow to the sidebar. 

Also removed fixed height when we are in single column "mobile" mode. Doesn't really ever make sense for this mode to have a fixed height.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/FkbiCK3JUhnDlo68W3/giphy.gif)
