### PR TITLE
docs: added more info to button group docs

### DIFF
--- a/docs/components/button-group.md
+++ b/docs/components/button-group.md
@@ -1,6 +1,6 @@
 ---
 title: Button group
-description: Button groups are used to group buttons that have a relationship or similar actions.
+description: Used for grouping buttons that share a relationship or perform similar actions.
 thumb: true
 image: assets/images/components/button-group.png
 storybook: https://vue.dialpad.design/?path=/story/components-button-group--default
@@ -22,8 +22,11 @@ storybook: https://vue.dialpad.design/?path=/story/components-button-group--defa
 
 ## Variants
 
+The alignment and the order of buttons within it can be customized to suit the specific use case.
+
 ### Start
 
+When aligned to `start`, the `primary` button is on the **left** side of the group.
 <code-well-header class="d-d-block">
   <dt-button-group alignment="start" class="d-gg8">
     <dt-button importance="primary">Confirm</dt-button>
@@ -40,22 +43,24 @@ storybook: https://vue.dialpad.design/?path=/story/components-button-group--defa
 
 ### End
 
+When aligned to `end`, the `primary` button is on the **right** side of the group.
 <code-well-header class="d-d-block">
   <dt-button-group alignment="end" class="d-gg8">
-    <dt-button importance="primary">Confirm</dt-button>
     <dt-button importance="outlined">Cancel</dt-button>
+    <dt-button importance="primary">Confirm</dt-button>
   </dt-button-group>
 </code-well-header>
 
 ```html
 <dt-button-group alignment="end" class="d-gg8">
-  <dt-button importance="primary">Confirm</dt-button>
   <dt-button importance="outlined">Cancel</dt-button>
+  <dt-button importance="primary">Confirm</dt-button>
 </dt-button-group>
 ```
 
 ### Space-between
 
+When set to `space-between`, the elements are evenly distributed within the row, creating a directional flow where the `primary` button is either on the **left** (regressive) or on the **right** (progressive).
 <code-well-header class="d-d-block">
   <dt-button-group alignment="space-between" class="d-gg8">
     <dt-button importance="primary">Confirm</dt-button>


### PR DESCRIPTION
## Description
Related to ticket: [DLT-1362](https://dialpad.atlassian.net/browse/DLT-1362)
Updated docs for `button-group` component with information on how to order buttons depending on the alignment.

## Pull Request Checklist

 - [x] Ask the contributors if a similar effort is already in process or has been solved.
 - [x] Review the [contribution guidelines](https://github.com/dialpad/dialtone/blob/staging/.github/CONTRIBUTING.md).
 - [x] Use `staging` as your pull request's base branch. (All PRs using `production` as its base branch will be declined).
 - [x] Ensure all `gulp` scripts successfully compile.
 - [x] Update, remove, or extend all affected documentation.
 - [x] Ensure no private Dialpad links or info are in the code or pull request description (Dialtone is a public repo!).

## Obligatory GIF (super important!)
![](https://media.giphy.com/media/26n7bg2Qet94PU8lq/giphy-downsized.gif)


[DLT-1362]: https://dialpad.atlassian.net/browse/DLT-1362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ